### PR TITLE
create variables to abstract issuer

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.7.9
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.47.0
+
 ## 0.7.8
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.7.8",
+  "version": "0.7.9",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^0.18.3",
     "@peculiar/x509": "^1.12.3",
-    "authhero": "^0.46.0",
+    "authhero": "^0.47.0",
     "hono": "^4.6.15",
     "hono-openapi-middlewares": "^1.0.11",
     "kysely": "^0.27.4",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.47.0
+
+### Minor Changes
+
+- create variables to separate issuer from domains
+
 ## 0.46.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/authentication-flows/authorization-code.ts
+++ b/packages/authhero/src/authentication-flows/authorization-code.ts
@@ -43,6 +43,8 @@ export async function authorizationCodeGrant(
     throw new HTTPException(403, { message: "Client not found" });
   }
 
+  console.log("client", client);
+
   const code = await ctx.env.data.codes.get(
     client.tenant.id,
     params.code,

--- a/packages/authhero/src/emails/index.ts
+++ b/packages/authhero/src/emails/index.ts
@@ -5,6 +5,7 @@ import { LogTypes, User } from "@authhero/adapter-interfaces";
 import { HTTPException } from "hono/http-exception";
 import { createLogMessage } from "../utils/create-log-message";
 import { waitUntil } from "../helpers/wait-until";
+import { getAuthUrl, getUniversalLoginUrl } from "../variables";
 
 export type SendEmailParams = {
   to: string;
@@ -55,7 +56,7 @@ export async function sendResetPassword(
   }
 
   // the auth0 link looks like this:  https://auth.sesamy.dev/u/reset-verify?ticket={ticket}#
-  const passwordResetUrl = `${ctx.env.ISSUER}u/reset-password?state=${state}&code=${code}`;
+  const passwordResetUrl = `${getUniversalLoginUrl(ctx.env)}reset-password?state=${state}&code=${code}`;
 
   const options = {
     vendorName: tenant.name,
@@ -65,7 +66,7 @@ export async function sendResetPassword(
   await sendEmail(ctx, {
     to,
     subject: `Reset your password`,
-    html: `Click here to reset your password: ${ctx.env.ISSUER}u/reset-password?state=${state}&code=${code}`,
+    html: `Click here to reset your password: ${getUniversalLoginUrl(ctx.env)}reset-password?state=${state}&code=${code}`,
     template: "auth-password-reset",
     data: {
       vendorName: tenant.name,
@@ -91,8 +92,6 @@ export async function sendCode(
   to: string,
   code: string,
 ) {
-  const { env } = ctx;
-
   const tenant = await ctx.env.data.tenants.get(ctx.var.tenant_id);
   if (!tenant) {
     throw new HTTPException(500, { message: "Tenant not found" });
@@ -107,14 +106,14 @@ export async function sendCode(
   await sendEmail(ctx, {
     to,
     subject: t("code_email_subject", options),
-    html: `Click here to validate your email: ${ctx.env.ISSUER}u/validate-email`,
+    html: `Click here to validate your email: ${getUniversalLoginUrl(ctx.env)}validate-email`,
     template: "auth-link",
     data: {
       code,
       vendorName: tenant.name,
       logo: tenant.logo || "",
       supportUrl: tenant.support_url || "",
-      magicLink: `${env.ISSUER}passwordless/verify_redirect?ticket=${code}`,
+      magicLink: `${getAuthUrl(ctx.env)}passwordless/verify_redirect?ticket=${code}`,
       buttonColor: tenant.primary_color || "",
       welcomeToYourAccount: t("welcome_to_your_account", options),
       linkEmailClickToLogin: t("link_email_click_to_login", options),
@@ -139,8 +138,6 @@ export async function sendLink(
   to: string,
   code: string,
 ) {
-  const { env } = ctx;
-
   const tenant = await ctx.env.data.tenants.get(ctx.var.tenant_id);
   if (!tenant) {
     throw new HTTPException(500, { message: "Tenant not found" });
@@ -155,14 +152,14 @@ export async function sendLink(
   await sendEmail(ctx, {
     to,
     subject: t("code_email_subject", options),
-    html: `Click here to validate your email: ${ctx.env.ISSUER}u/validate-email`,
+    html: `Click here to validate your email: ${getUniversalLoginUrl(ctx.env)}validate-email`,
     template: "auth-link",
     data: {
       code,
       vendorName: tenant.name,
       logo: tenant.logo || "",
       supportUrl: tenant.support_url || "",
-      magicLink: `${env.ISSUER}passwordless/verify_redirect?ticket=${code}`,
+      magicLink: `${getAuthUrl(ctx.env)}passwordless/verify_redirect?ticket=${code}`,
       buttonColor: tenant.primary_color || "",
       welcomeToYourAccount: t("welcome_to_your_account", options),
       linkEmailClickToLogin: t("link_email_click_to_login", options),
@@ -199,12 +196,12 @@ export async function sendValidateEmailAddress(
   await sendEmail(ctx, {
     to: user.email,
     subject: `Validate your email address`,
-    html: `Click here to validate your email: ${ctx.env.ISSUER}u/validate-email`,
+    html: `Click here to validate your email: ${getUniversalLoginUrl(ctx.env)}}validate-email`,
     template: "auth-verify-email",
     data: {
       vendorName: tenant.name,
       logo: tenant.logo || "",
-      emailValidationUrl: `${ctx.env.ISSUER}u/validate-email`,
+      emailValidationUrl: `${getUniversalLoginUrl(ctx.env)}validate-email`,
       supportUrl: tenant.support_url || "https://support.sesamy.com",
       buttonColor: tenant.primary_color || "#7d68f4",
       welcomeToYourAccount: t("welcome_to_your_account", options),

--- a/packages/authhero/src/emails/index.ts
+++ b/packages/authhero/src/emails/index.ts
@@ -196,7 +196,7 @@ export async function sendValidateEmailAddress(
   await sendEmail(ctx, {
     to: user.email,
     subject: `Validate your email address`,
-    html: `Click here to validate your email: ${getUniversalLoginUrl(ctx.env)}}validate-email`,
+    html: `Click here to validate your email: ${getUniversalLoginUrl(ctx.env)}validate-email`,
     template: "auth-verify-email",
     data: {
       vendorName: tenant.name,

--- a/packages/authhero/src/helpers/client.ts
+++ b/packages/authhero/src/helpers/client.ts
@@ -1,6 +1,7 @@
 import { HTTPException } from "hono/http-exception";
 import { Client, connectionSchema } from "@authhero/adapter-interfaces";
 import { Bindings } from "../types";
+import { getUniversalLoginUrl } from "../variables";
 
 export async function getClientWithDefaults(
   env: Bindings,
@@ -50,7 +51,7 @@ export async function getClientWithDefaults(
     web_origins: [
       ...(defaultClient?.web_origins || []),
       ...(client.web_origins || []),
-      `${env.ISSUER}u/login`,
+      `${getUniversalLoginUrl(env)}login`,
     ],
     allowed_logout_urls: [
       ...(defaultClient?.allowed_logout_urls || []),
@@ -60,7 +61,7 @@ export async function getClientWithDefaults(
     callbacks: [
       ...(defaultClient?.callbacks || []),
       ...(client.callbacks || []),
-      `${env.ISSUER}u/info`,
+      `${getUniversalLoginUrl(env)}info`,
     ],
     connections,
     domains: [...(client.domains || []), ...(defaultClient?.domains || [])],

--- a/packages/authhero/src/routes/auth-api/callback.ts
+++ b/packages/authhero/src/routes/auth-api/callback.ts
@@ -7,6 +7,7 @@ import { Bindings, Variables } from "../../types";
 import { connectionCallback } from "../../authentication-flows/connection";
 import { createLogMessage } from "../../utils/create-log-message";
 import { waitUntil } from "../../helpers/wait-until";
+import { getUniversalLoginUrl } from "../../variables";
 
 async function returnError(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
@@ -54,7 +55,7 @@ async function returnError(
   });
 
   return ctx.redirect(
-    `${ctx.env.ISSUER}u/enter-email?state=${loginSession.login_id}&error=${error}`,
+    `${getUniversalLoginUrl(ctx.env)}enter-email?state=${loginSession.login_id}&error=${error}`,
   );
 }
 

--- a/packages/authhero/src/routes/auth-api/passwordless.ts
+++ b/packages/authhero/src/routes/auth-api/passwordless.ts
@@ -14,6 +14,7 @@ import { isValidRedirectUrl } from "../../utils/is-valid-redirect-url";
 import { createAuthResponse } from "../../authentication-flows/common";
 import { getPrimaryUserByEmailAndProvider } from "../../helpers/users";
 import { getClientWithDefaults } from "../../helpers/client";
+import { getUniversalLoginUrl } from "../../variables";
 
 export const passwordlessRoutes = new OpenAPIHono<{
   Bindings: Bindings;
@@ -161,7 +162,7 @@ export const passwordlessRoutes = new OpenAPIHono<{
 
       if (loginSession.ip !== clientInfo.ip) {
         return ctx.redirect(
-          `${ctx.env.ISSUER}u/invalid-session?state=${loginSession.login_id}`,
+          `${getUniversalLoginUrl(ctx.env)}invalid-session?state=${loginSession.login_id}`,
         );
       }
 

--- a/packages/authhero/src/routes/auth-api/token.ts
+++ b/packages/authhero/src/routes/auth-api/token.ts
@@ -92,6 +92,8 @@ export const tokenRoutes = new OpenAPIHono<{
     async (ctx) => {
       const body = ctx.req.valid("form");
 
+      console.log("body", body);
+
       const basicAuth = parseBasicAuthHeader(ctx.req.header("Authorization"));
       const params = { ...body, ...basicAuth };
 

--- a/packages/authhero/src/strategies/apple.ts
+++ b/packages/authhero/src/strategies/apple.ts
@@ -5,6 +5,7 @@ import { nanoid } from "nanoid";
 import { Bindings, Variables } from "../types";
 import { parseJWT } from "oslo/jwt";
 import { idTokenSchema } from "../types/IdToken";
+import { getAuthUrl } from "../variables";
 
 function getAppleOptions(connection: Connection) {
   const { options } = connection;
@@ -42,7 +43,7 @@ export async function getRedirect(
     options.team_id!,
     options.kid!,
     keyArray,
-    `${ctx.env.ISSUER}callback`,
+    `${getAuthUrl(ctx.env)}callback`,
   );
 
   const code = nanoid();
@@ -75,7 +76,7 @@ export async function validateAuthorizationCodeAndGetUser(
     options.team_id!,
     options.kid!,
     keyArray,
-    `${ctx.env.ISSUER}callback`,
+    `${getAuthUrl(ctx.env)}callback`,
   );
 
   const tokens = await apple.validateAuthorizationCode(code);

--- a/packages/authhero/src/strategies/facebook.ts
+++ b/packages/authhero/src/strategies/facebook.ts
@@ -3,6 +3,7 @@ import { Context } from "hono";
 import { Connection } from "@authhero/adapter-interfaces";
 import { nanoid } from "nanoid";
 import { Bindings, Variables } from "../types";
+import { getAuthUrl } from "../variables";
 
 export async function getRedirect(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
@@ -17,7 +18,7 @@ export async function getRedirect(
   const facebook = new Facebook(
     options.client_id,
     options.client_secret,
-    `${ctx.env.ISSUER}callback`,
+    `${getAuthUrl(ctx.env)}callback`,
   );
 
   const code = nanoid();
@@ -47,7 +48,7 @@ export async function validateAuthorizationCodeAndGetUser(
   const facebook = new Facebook(
     options.client_id,
     options.client_secret,
-    `${ctx.env.ISSUER}callback`,
+    `${getAuthUrl(ctx.env)}callback`,
   );
 
   const tokens = await facebook.validateAuthorizationCode(code);

--- a/packages/authhero/src/strategies/google-oauth2.ts
+++ b/packages/authhero/src/strategies/google-oauth2.ts
@@ -5,6 +5,7 @@ import { nanoid } from "nanoid";
 import { Bindings, Variables } from "../types";
 import { parseJWT } from "oslo/jwt";
 import { idTokenSchema } from "../types/IdToken";
+import { getAuthUrl } from "../variables";
 
 export async function getRedirect(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
@@ -19,7 +20,7 @@ export async function getRedirect(
   const google = new Google(
     options.client_id,
     options.client_secret,
-    `${ctx.env.ISSUER}callback`,
+    `${getAuthUrl(ctx.env)}callback`,
   );
 
   const code = nanoid();
@@ -53,7 +54,7 @@ export async function validateAuthorizationCodeAndGetUser(
   const google = new Google(
     options.client_id,
     options.client_secret,
-    `${ctx.env.ISSUER}callback`,
+    `${getAuthUrl(ctx.env)}callback`,
   );
 
   const tokens = await google.validateAuthorizationCode(code, code_verifier);

--- a/packages/authhero/src/strategies/vipps.ts
+++ b/packages/authhero/src/strategies/vipps.ts
@@ -6,6 +6,7 @@ import { Bindings, Variables } from "../types";
 import { HTTPException } from "hono/http-exception";
 import { parseJWT } from "oslo/jwt";
 import { idTokenSchema } from "../types/IdToken";
+import { getAuthUrl } from "../variables";
 
 export async function getRedirect(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
@@ -20,7 +21,7 @@ export async function getRedirect(
   const client = new OAuth2Client(
     options.client_id,
     options.client_secret,
-    `${ctx.env.ISSUER}callback`,
+    `${getAuthUrl(ctx.env)}callback`,
   );
 
   const code = nanoid();
@@ -60,7 +61,7 @@ export async function validateAuthorizationCodeAndGetUser(
   const client = new OAuth2Client(
     options.client_id,
     options.client_secret,
-    `${ctx.env.ISSUER}callback`,
+    `${getAuthUrl(ctx.env)}callback`,
   );
 
   const tokens = await client.validateAuthorizationCode(

--- a/packages/authhero/src/types/Bindings.ts
+++ b/packages/authhero/src/types/Bindings.ts
@@ -1,7 +1,7 @@
 import { DataAdapters } from "@authhero/adapter-interfaces";
 import { OnExecuteCredentialsExchange } from "./Hooks";
 import { EmailService } from "./EmailService";
-import { Strategy } from "src/strategies";
+import { Strategy } from "../strategies";
 
 declare type Fetcher = {
   fetch: typeof fetch;

--- a/packages/authhero/src/types/Bindings.ts
+++ b/packages/authhero/src/types/Bindings.ts
@@ -13,6 +13,8 @@ export type Bindings = {
   JWKS_URL: string;
   JWKS_SERVICE: Fetcher;
   ISSUER: string;
+  UNIVERSAL_LOGIN_URL?: string;
+  OAUTH_API_URL?: string;
 
   data: DataAdapters;
 

--- a/packages/authhero/src/variables.ts
+++ b/packages/authhero/src/variables.ts
@@ -1,0 +1,13 @@
+import { Bindings } from "./types";
+
+export function getIssuer(env: Bindings) {
+  return env.ISSUER;
+}
+
+export function getUniversalLoginUrl(env: Bindings) {
+  return env.UNIVERSAL_LOGIN_URL || `${env.ISSUER}u/`;
+}
+
+export function getAuthUrl(env: Bindings) {
+  return env.OAUTH_API_URL || env.ISSUER;
+}


### PR DESCRIPTION
By default it's sufficient to set issuer, but if the api's are hosted on different urls it's not possible to separate them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for AuthHero v0.47.0

- **New Features**
  - Added support for configurable login and authentication URLs.
  - Introduced new environment variables for universal login and OAuth API URLs.

- **Improvements**
  - Enhanced URL generation for authentication flows.
  - Improved flexibility in handling authentication configurations.

- **Dependency Updates**
  - Updated package version to 0.47.0.
  - Updated dependencies across demo and core packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->