### PR TITLE
add default audience from tenant for refresh token

### DIFF
--- a/.changeset/hip-actors-remember.md
+++ b/.changeset/hip-actors-remember.md
@@ -1,0 +1,6 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+---
+
+Use default audience from tenant for refresh token

--- a/packages/adapter-interfaces/src/types/Token.ts
+++ b/packages/adapter-interfaces/src/types/Token.ts
@@ -8,7 +8,7 @@ export enum GrantType {
   Password = "password",
 }
 
-const tokenResponseSchema = z.object({
+export const tokenResponseSchema = z.object({
   access_token: z.string(),
   id_token: z.string().optional(),
   scope: z.string().optional(),

--- a/packages/authhero/src/routes/auth-api/token.ts
+++ b/packages/authhero/src/routes/auth-api/token.ts
@@ -1,4 +1,4 @@
-import { GrantType } from "@authhero/adapter-interfaces";
+import { GrantType, tokenResponseSchema } from "@authhero/adapter-interfaces";
 import { Bindings, Variables } from "../../types";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
@@ -75,13 +75,7 @@ export const tokenRoutes = new OpenAPIHono<{
         200: {
           content: {
             "application/json": {
-              schema: z.object({
-                access_token: z.string(),
-                id_token: z.string().optional(),
-                refresh_token: z.string().optional(),
-                token_type: z.string(),
-                expires_in: z.number(),
-              }),
+              schema: tokenResponseSchema,
             },
           },
           description: "Tokens",
@@ -91,8 +85,6 @@ export const tokenRoutes = new OpenAPIHono<{
     // @ts-ignore
     async (ctx) => {
       const body = ctx.req.valid("form");
-
-      console.log("body", body);
 
       const basicAuth = parseBasicAuthHeader(ctx.req.header("Authorization"));
       const params = { ...body, ...basicAuth };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled refresh tokens to automatically use the tenant’s default audience for smoother authentication flows.
  - Introduced a unified token response structure for consistent and reliable data handling.

- **Chores**
  - Updated internal dependencies to enhance overall system stability.

- **Refactor**
  - Streamlined token creation and session management processes, including refined user login tracking for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->