### PR TITLE
create users with matching email

### DIFF
--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.74.2
+
+### Patch Changes
+
+- Create the user if there's a matching email
+
 ## 0.74.1
 
 ### Patch Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "files": [
     "dist"
   ],

--- a/packages/authhero/test/hooks/account-linking.spec.ts
+++ b/packages/authhero/test/hooks/account-linking.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { testClient } from "hono/testing";
+import { getTestServer } from "../helpers/test-server";
+import { linkUsersHook } from "../../src/hooks/link-users";
+
+describe("account-linking-hook", () => {
+  it("should link an account to a matching existing verified account", async () => {
+    const { env } = await getTestServer();
+
+    // Add a test user. Creating the user will not trigger the hoos
+    await linkUsersHook(env.data)("tenantId", {
+      email: "foo@example.com",
+      email_verified: true,
+      name: "Test Google User",
+      nickname: "Test User",
+      picture: "https://example.com/test.png",
+      connection: "google-oauth2",
+      provider: "google-oauth2",
+      is_social: false,
+      user_id: "google-oauth2|userId",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      login_count: 0,
+    });
+
+    const originalUser = await env.data.users.get("tenantId", "email|userId");
+    expect(originalUser?.identities?.length).toBe(2);
+  });
+});


### PR DESCRIPTION
This should really be moved into a helper so the behaviour is consistent between different auth flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced passwordless login to verify existing emails before handling missing user errors.
  - Improved account linking, ensuring that verified accounts are consolidated seamlessly.

- **Documentation**
  - Updated release documentation and version metadata to reflect the new release (version 0.74.2).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->