### PR TITLE
handle idle expires in silent auth

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @authhero/demo
 
+## 0.9.28
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.86.0
+  - @authhero/kysely-adapter@9.4.0
+
 ## 0.9.27
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.9.27",
+  "version": "0.9.28",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
   "dependencies": {
-    "@authhero/kysely-adapter": "^9.3.0",
+    "@authhero/kysely-adapter": "^9.4.0",
     "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^0.18.3",
     "@peculiar/x509": "^1.12.3",
-    "authhero": "^0.85.0",
+    "authhero": "^0.86.0",
     "hono": "^4.6.15",
     "hono-openapi-middlewares": "^1.0.11",
     "kysely": "^0.27.4",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.86.0
+
+### Minor Changes
+
+- Hande idle_expires_at in silent auth
+
 ## 0.85.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/authentication-flows/silent.ts
+++ b/packages/authhero/src/authentication-flows/silent.ts
@@ -106,9 +106,17 @@ export async function silentAuth({
   // Update session
   await env.data.sessions.update(client.tenant.id, session.id, {
     used_at: new Date().toISOString(),
-    expires_at: new Date(
-      Date.now() + SILENT_AUTH_MAX_AGE_IN_SECONDS * 1000,
-    ).toISOString(),
+    last_interaction_at: new Date().toISOString(),
+    device: {
+      ...session.device,
+      last_ip: ctx.req.header("x-real-ip") || "",
+      last_user_agent: ctx.req.header("user-agent") || "",
+    },
+    idle_expires_at: session.idle_expires_at
+      ? new Date(
+          Date.now() + SILENT_AUTH_MAX_AGE_IN_SECONDS * 1000,
+        ).toISOString()
+      : undefined,
   });
 
   // Log successful authentication

--- a/packages/authhero/src/authentication-flows/silent.ts
+++ b/packages/authhero/src/authentication-flows/silent.ts
@@ -41,78 +41,92 @@ export async function silentAuth({
   response_type,
 }: SilentAuthParams) {
   const { env } = ctx;
-
   const redirectURL = new URL(redirect_uri);
+  const originUrl = `${redirectURL.protocol}//${redirectURL.host}`;
 
-  if (session?.expires_at && new Date(session.expires_at) > new Date()) {
-    ctx.set("user_id", session.user_id);
+  // Helper function to handle login required scenarios
+  async function handleLoginRequired(description: string = "Login required") {
+    const log = createLogMessage(ctx, {
+      type: LogTypes.FAILED_SILENT_AUTH,
+      description,
+    });
+    await ctx.env.data.logs.create(client.tenant.id, log);
 
-    // Update the cookie
-    const headers = new Headers();
-    const cookie = serializeAuthCookie(client.tenant.id, session.id);
-    headers.set("set-cookie", cookie);
-
-    const user = await env.data.users.get(client.tenant.id, session.user_id);
-
-    if (user) {
-      ctx.set("username", user.email);
-      ctx.set("connection", user.connection);
-
-      const tokenResponse = await createAuthTokens(ctx, {
-        client,
-        authParams: {
-          client_id: client.id,
-          audience,
-          code_challenge_method,
-          code_challenge,
-          scope,
+    return ctx.html(
+      renderAuthIframe(
+        originUrl,
+        JSON.stringify({
+          error: "login_required",
+          error_description: description,
           state,
-          nonce,
-          response_type,
-        },
-        user,
-        session_id: session.id,
-      });
-
-      await env.data.sessions.update(client.tenant.id, session.id, {
-        used_at: new Date().toISOString(),
-        expires_at: new Date(
-          Date.now() + SILENT_AUTH_MAX_AGE_IN_SECONDS * 1000,
-        ).toISOString(),
-      });
-
-      const log = createLogMessage(ctx, {
-        type: LogTypes.SUCCESS_SILENT_AUTH,
-        description: "Successful silent authentication",
-      });
-      await ctx.env.data.logs.create(client.tenant.id, log);
-
-      return ctx.html(
-        renderAuthIframe(
-          `${redirectURL.protocol}//${redirectURL.host}`,
-          JSON.stringify(tokenResponse),
-        ),
-        {
-          headers,
-        },
-      );
-    }
+        }),
+      ),
+    );
   }
 
+  // Check if session is valid
+  const isSessionExpired =
+    !session ||
+    (session?.expires_at && new Date(session.expires_at) < new Date()) ||
+    (session?.idle_expires_at &&
+      new Date(session.idle_expires_at) < new Date());
+
+  if (isSessionExpired) {
+    return handleLoginRequired();
+  }
+
+  ctx.set("user_id", session.user_id);
+
+  const user = await env.data.users.get(client.tenant.id, session.user_id);
+
+  if (!user) {
+    return handleLoginRequired("User not found");
+  }
+
+  ctx.set("username", user.email);
+  ctx.set("connection", user.connection);
+
+  // Create authentication tokens
+  const tokenResponse = await createAuthTokens(ctx, {
+    client,
+    authParams: {
+      client_id: client.id,
+      audience,
+      code_challenge_method,
+      code_challenge,
+      scope,
+      state,
+      nonce,
+      response_type,
+    },
+    user,
+    session_id: session.id,
+  });
+
+  // Update session
+  await env.data.sessions.update(client.tenant.id, session.id, {
+    used_at: new Date().toISOString(),
+    expires_at: new Date(
+      Date.now() + SILENT_AUTH_MAX_AGE_IN_SECONDS * 1000,
+    ).toISOString(),
+  });
+
+  // Log successful authentication
   const log = createLogMessage(ctx, {
-    type: LogTypes.FAILED_SILENT_AUTH,
-    description: "Login required",
+    type: LogTypes.SUCCESS_SILENT_AUTH,
+    description: "Successful silent authentication",
   });
   await ctx.env.data.logs.create(client.tenant.id, log);
 
-  return ctx.html(
-    renderAuthIframe(
-      `${redirectURL.protocol}//${redirectURL.host}`,
-      JSON.stringify({
-        error: "login_required",
-        error_description: "Login required",
-        state,
-      }),
-    ),
-  );
+  // Set response headers
+  const headers = new Headers();
+  // The following header is added to prevent Cloudflare from adding the beacon script to the file which might mess with Safari ITP
+  headers.set("Server-Timing", "cf-nel=0; no-cloudflare-insights=1");
+
+  const cookie = serializeAuthCookie(client.tenant.id, session.id);
+  headers.set("set-cookie", cookie);
+
+  return ctx.html(renderAuthIframe(originUrl, JSON.stringify(tokenResponse)), {
+    headers,
+  });
 }

--- a/packages/authhero/test/routes/auth-api/authorize.spec.ts
+++ b/packages/authhero/test/routes/auth-api/authorize.spec.ts
@@ -138,13 +138,13 @@ describe("authorize", () => {
       const { oauthApp, env } = await getTestServer();
       const oauthClient = testClient(oauthApp, env);
 
-      const expires_at = new Date(Date.now() + 1000).toISOString();
+      const idle_expires_at = new Date(Date.now() + 1000).toISOString();
 
       await env.data.sessions.create("tenantId", {
         id: "sessionId",
         user_id: "email|userId",
         clients: ["clientId"],
-        expires_at,
+        idle_expires_at,
         device: {
           last_ip: "",
           initial_ip: "",
@@ -185,7 +185,7 @@ describe("authorize", () => {
       // Fetch the session
       const session = await env.data.sessions.get("tenantId", "sessionId");
       expect(session?.used_at).toBeDefined();
-      expect(session?.expires_at).not.toBe(expires_at);
+      expect(session?.idle_expires_at).not.toBe(idle_expires_at);
     });
 
     it("should return a web_message response with login required for a expired session", async () => {

--- a/packages/kysely/CHANGELOG.md
+++ b/packages/kysely/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @authhero/kysely-adapter
 
+## 9.4.0
+
+### Minor Changes
+
+- Hande idle_expires_at in silent auth
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/kysely/migrate/migrations/2025-03-12T14:14:00_authorization_url_length.ts
+++ b/packages/kysely/migrate/migrations/2025-03-12T14:14:00_authorization_url_length.ts
@@ -1,0 +1,32 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/db";
+
+/**
+ * Up migration: Add a new custom domains table
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("logins")
+    .dropColumn("authorization_url")
+    .execute();
+
+  await db.schema
+    .alterTable("logins")
+    .addColumn("authorization_url", "varchar(2048)")
+    .execute();
+}
+
+/**
+ * Down migration: restore the domains table
+ */
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("logins")
+    .dropColumn("authorization_url")
+    .execute();
+
+  await db.schema
+    .alterTable("logins")
+    .addColumn("authorization_url", "varchar(1024)")
+    .execute();
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -72,6 +72,7 @@ import * as n72_session_primary_key from "./2025-02-12T13:15:00_session_primary_
 import * as n73_drop_sessions from "./2025-02-12T15:27:00_drop_sessions";
 import * as n74_custom_domains from "./2025-02-21T23:45:00_custom_domains";
 import * as n75_organizations from "./2025-03-10T11:20:00_organization";
+import * as n76_authorization_url_length from "./2025-03-12T14:14:00_authorization_url_length";
 
 // These need to be in alphabetic order
 export default {
@@ -149,4 +150,5 @@ export default {
   n73_drop_sessions,
   n74_custom_domains,
   n75_organizations,
+  n76_authorization_url_length,
 };

--- a/packages/kysely/package.json
+++ b/packages/kysely/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/markusahlstrand/authhero"
   },
-  "version": "9.3.0",
+  "version": "9.4.0",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Silent auth was expecting a expires at, but now we have both expires_at and idle_expires_at and they are both optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Released a new patch with updated version numbers and dependency upgrades.

- **Authentication Improvements**
  - Enhanced silent login flow with improved session validation and error reporting for a smoother user experience.

- **Database Enhancements**
  - Increased the capacity for authorization URLs to ensure more robust data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->