### PR TITLE
Change enter-email page to identifier

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.10.5
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.114.0
+
 ## 0.10.4
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.10.4",
+  "version": "0.10.5",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.12.3",
-    "authhero": "^0.113.0",
+    "authhero": "^0.114.0",
     "hono": "^4.6.15",
     "hono-openapi-middlewares": "^1.0.11",
     "kysely": "^0.27.4",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.114.0
+
+### Minor Changes
+
+- Change enter-email page to identifier
+
 ## 0.113.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.113.0",
+  "version": "0.114.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/authentication-flows/universal.ts
+++ b/packages/authhero/src/authentication-flows/universal.ts
@@ -82,5 +82,5 @@ export async function universalAuth({
     return ctx.redirect(`/u/check-account?state=${loginSession.id}`);
   }
 
-  return ctx.redirect(`/u/enter-email?state=${loginSession.id}`);
+  return ctx.redirect(`/u/login/identifier?state=${loginSession.id}`);
 }

--- a/packages/authhero/src/components/CheckEmailPage.tsx
+++ b/packages/authhero/src/components/CheckEmailPage.tsx
@@ -41,7 +41,7 @@ const CheckEmailPage: FC<Props> = ({ vendorSettings, state, user }) => {
           </Form>
           <a
             className="block text-center text-primary hover:text-primaryHover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-900"
-            href={`/u/enter-email?state=${encodeURIComponent(state)}`}
+            href={`/u/login/identifier?state=${encodeURIComponent(state)}`}
           >
             {i18next.t("no_use_another")}
           </a>

--- a/packages/authhero/src/components/EnterPasswordPage.tsx
+++ b/packages/authhero/src/components/EnterPasswordPage.tsx
@@ -68,7 +68,7 @@ const EnterPasswordPage: FC<Props> = (params) => {
           </div>
           <form
             method="post"
-            action={`/u/enter-email?${loginLinkParams.toString()}`}
+            action={`/u/login/identifier?${loginLinkParams.toString()}`}
           >
             <input type="hidden" name="login_selection" value="code" />
             <input type="hidden" name="username" value={email} />

--- a/packages/authhero/src/components/GoBack.tsx
+++ b/packages/authhero/src/components/GoBack.tsx
@@ -8,7 +8,7 @@ export const GoBack = (props: Props) => {
   return (
     <a
       className="block text-primary hover:text-primaryHover text-center"
-      href={`/u/enter-email?state=${props.state}`}
+      href={`/u/login/identifier?state=${props.state}`}
     >
       {i18next.t("go_back")}
     </a>

--- a/packages/authhero/src/components/IdentifierPage.tsx
+++ b/packages/authhero/src/components/IdentifierPage.tsx
@@ -24,7 +24,7 @@ type Props = {
   impersonation?: boolean;
 };
 
-const EnterEmailPage: FC<Props> = ({
+const IdentifierPage: FC<Props> = ({
   error,
   vendorSettings,
   loginSession,
@@ -148,4 +148,4 @@ const EnterEmailPage: FC<Props> = ({
   );
 };
 
-export default EnterEmailPage;
+export default IdentifierPage;

--- a/packages/authhero/src/components/index.ts
+++ b/packages/authhero/src/components/index.ts
@@ -4,7 +4,7 @@ import Button from "./Button";
 import CheckEmailPage from "./CheckEmailPage";
 import EmailValidatedPage from "./EmailValidatedPage";
 import EnterCodePage from "./EnterCodePage";
-import EnterEmailPage from "./EnterEmailPage";
+import IdentifierPage from "./IdentifierPage";
 import EnterPasswordPage from "./EnterPasswordPage";
 import ErrorMessage from "./ErrorMessage";
 import Footer from "./Footer";
@@ -35,7 +35,7 @@ export {
   CheckEmailPage,
   EmailValidatedPage,
   EnterCodePage,
-  EnterEmailPage,
+  IdentifierPage,
   EnterPasswordPage,
   ErrorMessage,
   Footer,

--- a/packages/authhero/src/routes/auth-api/callback.ts
+++ b/packages/authhero/src/routes/auth-api/callback.ts
@@ -55,7 +55,7 @@ async function returnError(
   });
 
   return ctx.redirect(
-    `${getUniversalLoginUrl(ctx.env)}enter-email?state=${loginSession.id}&error=${error}`,
+    `${getUniversalLoginUrl(ctx.env)}login/identifier?state=${loginSession.id}&error=${error}`,
   );
 }
 

--- a/packages/authhero/src/routes/universal-login/check-account.tsx
+++ b/packages/authhero/src/routes/universal-login/check-account.tsx
@@ -47,7 +47,7 @@ export const checkAccountRoutes = new OpenAPIHono<{
         : null;
 
       if (!authSession) {
-        return ctx.redirect(`/u/enter-email?state=${state}`);
+        return ctx.redirect(`/u/login/identifier?state=${state}`);
       }
 
       const user = await env.data.users.get(
@@ -56,7 +56,7 @@ export const checkAccountRoutes = new OpenAPIHono<{
       );
 
       if (!user) {
-        return ctx.redirect(`/u/enter-email?state=${state}`);
+        return ctx.redirect(`/u/login/identifier?state=${state}`);
       }
 
       return ctx.html(
@@ -105,7 +105,7 @@ export const checkAccountRoutes = new OpenAPIHono<{
         : null;
 
       if (!authSession) {
-        return ctx.redirect(`/u/enter-email?state=${state}`);
+        return ctx.redirect(`/u/login/identifier?state=${state}`);
       }
 
       const user = await env.data.users.get(
@@ -114,7 +114,7 @@ export const checkAccountRoutes = new OpenAPIHono<{
       );
 
       if (!user) {
-        return ctx.redirect(`/u/enter-email?state=${state}`);
+        return ctx.redirect(`/u/login/identifier?state=${state}`);
       }
 
       return createAuthResponse(ctx, {

--- a/packages/authhero/src/routes/universal-login/identifier.tsx
+++ b/packages/authhero/src/routes/universal-login/identifier.tsx
@@ -1,7 +1,7 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { Bindings, Variables } from "../../types";
 import { initJSXRoute, usePasswordLogin } from "./common";
-import EnterEmailPage from "../../components/EnterEmailPage";
+import IdentifierPage from "../../components/IdentifierPage";
 import { getPrimaryUserByEmail } from "../../helpers/users";
 import { preUserSignupHook } from "../../hooks";
 import { createLogMessage } from "../../utils/create-log-message";
@@ -36,12 +36,12 @@ export function getSendParamFromAuth0ClientHeader(
   return isAppClient ? "code" : "link";
 }
 
-export const enterEmailRoutes = new OpenAPIHono<{
+export const identifierRoutes = new OpenAPIHono<{
   Bindings: Bindings;
   Variables: Variables;
 }>()
   // --------------------------------
-  // GET /u/enter-email
+  // GET /u/login/identifier
   // --------------------------------
   .openapi(
     createRoute({
@@ -71,7 +71,7 @@ export const enterEmailRoutes = new OpenAPIHono<{
       );
 
       return ctx.html(
-        <EnterEmailPage
+        <IdentifierPage
           vendorSettings={vendorSettings}
           loginSession={loginSession}
           client={client}
@@ -82,7 +82,7 @@ export const enterEmailRoutes = new OpenAPIHono<{
     },
   )
   // --------------------------------
-  // POST /u/enter-email
+  // POST /u/login/identifier
   // --------------------------------
   .openapi(
     createRoute({
@@ -152,7 +152,7 @@ export const enterEmailRoutes = new OpenAPIHono<{
           await ctx.env.data.logs.create(client.tenant.id, log);
 
           return ctx.html(
-            <EnterEmailPage
+            <IdentifierPage
               vendorSettings={vendorSettings}
               loginSession={loginSession}
               error={i18next.t("user_account_does_not_exist")}

--- a/packages/authhero/src/routes/universal-login/index.ts
+++ b/packages/authhero/src/routes/universal-login/index.ts
@@ -1,7 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { Context } from "hono";
 import { AuthHeroConfig, Bindings, Variables } from "../../types";
-import { enterEmailRoutes } from "./enter-email";
+import { identifierRoutes } from "./identifier";
 import { enterCodeRoutes } from "./enter-code";
 import { enterPasswordRoutes } from "./enter-password";
 import { signupRoutes } from "./signup";
@@ -39,7 +39,7 @@ export default function create(config: AuthHeroConfig) {
   const universalApp = app
     .route("/info", infoRoutes)
     .route("/check-account", checkAccountRoutes)
-    .route("/enter-email", enterEmailRoutes)
+    .route("/login/identifier", identifierRoutes)
     .route("/enter-code", enterCodeRoutes)
     .route("/enter-password", enterPasswordRoutes)
     .route("/invalid-session", invalidSessionRoutes)

--- a/packages/authhero/test/routes/auth-api/authorize.spec.ts
+++ b/packages/authhero/test/routes/auth-api/authorize.spec.ts
@@ -67,7 +67,7 @@ describe("authorize", () => {
     const redirectUri = new URL("https://example.com" + location);
 
     // Validate the redirect uri
-    expect(redirectUri.pathname).toEqual("/u/enter-email");
+    expect(redirectUri.pathname).toEqual("/u/login/identifier");
 
     // Fetch the login session
     const login = await env.data.loginSessions.get(

--- a/packages/authhero/test/routes/auth-api/callback.spec.ts
+++ b/packages/authhero/test/routes/auth-api/callback.spec.ts
@@ -55,7 +55,7 @@ describe("callback", () => {
       throw new Error("No location header");
     }
     const redirectUri = new URL(location);
-    expect(redirectUri.pathname).toEqual("/u/enter-email");
+    expect(redirectUri.pathname).toEqual("/u/login/identifier");
     expect(redirectUri.searchParams.get("error")).toEqual("error");
     expect(redirectUri.searchParams.get("state")).toEqual(loginSession.id);
   });

--- a/packages/authhero/test/routes/universal-login/check-account.spec.ts
+++ b/packages/authhero/test/routes/universal-login/check-account.spec.ts
@@ -38,7 +38,7 @@ describe("check account", () => {
     expect(enterEmailGetResponse.status).toBe(302);
 
     const loginLocation = enterEmailGetResponse.headers.get("location");
-    expect(loginLocation).toContain(`/u/enter-email?state=${state}`);
+    expect(loginLocation).toContain(`/u/login/identifier?state=${state}`);
   });
 
   it("should return a code if there is a session", async () => {

--- a/packages/authhero/test/routes/universal-login/code.spec.ts
+++ b/packages/authhero/test/routes/universal-login/code.spec.ts
@@ -33,15 +33,17 @@ describe("code", () => {
     // --------------------------------
     // enter email
     // --------------------------------
-    const enterEmailGetResponse = await universalClient["enter-email"].$get({
+    const enterEmailGetResponse = await universalClient.login.identifier.$get({
       query: { state },
     });
     expect(enterEmailGetResponse.status).toBe(200);
 
-    const enterEmailPostResponse = await universalClient["enter-email"].$post({
-      query: { state },
-      form: { username: "foo@example.com" },
-    });
+    const enterEmailPostResponse = await universalClient.login.identifier.$post(
+      {
+        query: { state },
+        form: { username: "foo@example.com" },
+      },
+    );
     expect(enterEmailPostResponse.status).toBe(302);
 
     // --------------------------------
@@ -143,15 +145,17 @@ describe("code", () => {
     // --------------------------------
     // enter email
     // --------------------------------
-    const enterEmailGetResponse = await universalClient["enter-email"].$get({
+    const enterEmailGetResponse = await universalClient.login.identifier.$get({
       query: { state },
     });
     expect(enterEmailGetResponse.status).toBe(200);
 
-    const enterEmailPostResponse = await universalClient["enter-email"].$post({
-      query: { state },
-      form: { username: "new-account@example.com" },
-    });
+    const enterEmailPostResponse = await universalClient.login.identifier.$post(
+      {
+        query: { state },
+        form: { username: "new-account@example.com" },
+      },
+    );
     expect(enterEmailPostResponse.status).toBe(302);
 
     // --------------------------------

--- a/packages/authhero/test/routes/universal-login/passwords.spec.ts
+++ b/packages/authhero/test/routes/universal-login/passwords.spec.ts
@@ -54,15 +54,17 @@ describe("passwords", () => {
     // --------------------------------
     // enter email
     // --------------------------------
-    const enterEmailGetResponse = await universalClient["enter-email"].$get({
+    const enterEmailGetResponse = await universalClient.login.identifier.$get({
       query: { state },
     });
     expect(enterEmailGetResponse.status).toBe(200);
 
-    const enterEmailPostResponse = await universalClient["enter-email"].$post({
-      query: { state },
-      form: { username: "foo2@example.com" },
-    });
+    const enterEmailPostResponse = await universalClient.login.identifier.$post(
+      {
+        query: { state },
+        form: { username: "foo2@example.com" },
+      },
+    );
     expect(enterEmailPostResponse.status).toBe(302);
 
     // --------------------------------
@@ -131,7 +133,7 @@ describe("passwords", () => {
       throw new Error("No state found");
     }
 
-    await universalClient["enter-email"].$post({
+    await universalClient.login.identifier.$post({
       query: { state: state2 },
       form: { username: "foo2@example.com" },
     });

--- a/packages/authhero/test/routes/universal-login/sms.spec.ts
+++ b/packages/authhero/test/routes/universal-login/sms.spec.ts
@@ -63,15 +63,17 @@ describe("sms", () => {
     // --------------------------------
     // enter phone number
     // --------------------------------
-    const enterEmailGetResponse = await universalClient["enter-email"].$get({
+    const enterEmailGetResponse = await universalClient.login.identifier.$get({
       query: { state },
     });
     expect(enterEmailGetResponse.status).toBe(200);
 
-    const enterEmailPostResponse = await universalClient["enter-email"].$post({
-      query: { state },
-      form: { username: "+1234567890" },
-    });
+    const enterEmailPostResponse = await universalClient.login.identifier.$post(
+      {
+        query: { state },
+        form: { username: "+1234567890" },
+      },
+    );
     expect(enterEmailPostResponse.status).toBe(302);
 
     const sentSms = getSentSms();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - None.

- **Refactor**
  - Updated the login flow by renaming the "enter-email" page and related routes to "login/identifier" for a more consistent user experience.
  - Updated component and route names to reflect this change across the app.

- **Bug Fixes**
  - None.

- **Tests**
  - Adjusted tests to align with the new "login/identifier" route and naming conventions.

- **Documentation**
  - Updated changelogs to reflect the new version and changes in the login flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->