### PR TITLE
fix: remove redundant redirect checks

### DIFF
--- a/.changeset/slow-eyes-check.md
+++ b/.changeset/slow-eyes-check.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+pnpm changeset version

--- a/.changeset/slow-eyes-check.md
+++ b/.changeset/slow-eyes-check.md
@@ -1,5 +1,0 @@
----
-"authhero": minor
----
-
-pnpm changeset version

--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @authhero/demo
 
+## 0.10.6
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [51c5158]
+  - authhero@0.115.0
+
 ## 0.10.5
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.10.5",
+  "version": "0.10.6",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.12.3",
-    "authhero": "^0.114.0",
+    "authhero": "^0.115.0",
     "hono": "^4.6.15",
     "hono-openapi-middlewares": "^1.0.11",
     "kysely": "^0.27.4",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,12 @@
 # authhero
 
+## 0.115.0
+
+### Minor Changes
+
+- Use idle expires at for refresh tokens
+- 51c5158: pnpm changeset version
+
 ## 0.114.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -227,21 +227,23 @@ export async function createRefreshToken(
     session_id,
   } = params;
 
+  const clientInfo = getClientInfo(ctx.req);
+
   const refreshToken = await ctx.env.data.refreshTokens.create(
     client.tenant.id,
     {
       id: nanoid(),
       session_id,
       client_id: client.id,
-      expires_at: new Date(
+      idle_expires_at: new Date(
         Date.now() + SILENT_AUTH_MAX_AGE_IN_SECONDS * 1000,
       ).toISOString(),
       user_id: params.user.user_id,
       device: {
-        last_ip: ctx.req.header("x-real-ip") || "",
-        initial_ip: ctx.req.header("x-real-ip") || "",
-        last_user_agent: ctx.req.header("user-agent") || "",
-        initial_user_agent: ctx.req.header("user-agent") || "",
+        last_ip: clientInfo.ip || "",
+        initial_ip: clientInfo.ip || "",
+        last_user_agent: clientInfo.useragent || "",
+        initial_user_agent: clientInfo.useragent || "",
         // TODO: add Authentication Strength Name
         initial_asn: "",
         last_asn: "",

--- a/packages/authhero/src/authentication-flows/connection.ts
+++ b/packages/authhero/src/authentication-flows/connection.ts
@@ -10,7 +10,6 @@ import {
 } from "../constants";
 import { getStrategy } from "../strategies";
 import { getClientWithDefaults } from "../helpers/client";
-import { isValidRedirectUrl } from "../utils/is-valid-redirect-url";
 import { getOrCreateUserByProvider } from "../helpers/users";
 import { createAuthResponse } from "./common";
 import { nanoid } from "nanoid";
@@ -130,24 +129,6 @@ export async function connectionCallback(
     });
     await env.data.logs.create(client.tenant.id, log);
     throw new HTTPException(403, { message: "Redirect URI not defined" });
-  }
-
-  if (
-    !isValidRedirectUrl(
-      loginSession.authParams.redirect_uri,
-      client.callbacks || [],
-      { allowPathWildcards: true },
-    )
-  ) {
-    const invalidRedirectUriMessage = `Invalid redirect URI - ${loginSession.authParams.redirect_uri}`;
-    const log = createLogMessage(ctx, {
-      type: LogTypes.FAILED_LOGIN,
-      description: invalidRedirectUriMessage,
-    });
-    await env.data.logs.create(client.tenant.id, log);
-    throw new HTTPException(403, {
-      message: invalidRedirectUriMessage,
-    });
   }
 
   const strategy = getStrategy(ctx, connection.strategy);

--- a/packages/authhero/src/authentication-flows/passwordless.ts
+++ b/packages/authhero/src/authentication-flows/passwordless.ts
@@ -11,7 +11,6 @@ import { Bindings, Variables } from "../types";
 import { HTTPException } from "hono/http-exception";
 import { getClientInfo } from "../utils/client-info";
 import { getUniversalLoginUrl } from "../variables";
-import { isValidRedirectUrl } from "../utils/is-valid-redirect-url";
 import { getOrCreateUserByProvider } from "../helpers/users";
 import { createAuthResponse } from "./common";
 import { getConnectionFromUsername } from "../utils/username";
@@ -105,17 +104,6 @@ export async function loginWithPasswordless(
     return ctx.redirect(
       `${getUniversalLoginUrl(ctx.env)}invalid-session?state=${loginSession.id}`,
     );
-  }
-
-  if (
-    authParams.redirect_uri &&
-    !isValidRedirectUrl(authParams.redirect_uri, client.callbacks, {
-      allowPathWildcards: true,
-    })
-  ) {
-    throw new HTTPException(400, {
-      message: `Invalid redirect URI - ${authParams.redirect_uri}`,
-    });
   }
 
   const user = await getOrCreateUserByProvider(ctx, {


### PR DESCRIPTION
The redirect is verified in the authorize endpoints so these checks are redundant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved refresh token handling by using "idle expires at" for expiration and more accurate device information.
- **Chores**
	- Updated dependencies to use the latest version of the authentication package.
	- Incremented package versions and updated changelogs to reflect recent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->