### PR TITLE
user code_vefifier to store the code challenge

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.13.3
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.150.0
+
 ## 0.13.2
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.13.3",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.12.3",
-    "authhero": "^0.149.0",
+    "authhero": "^0.150.0",
     "better-sqlite3": "^11.5.0",
     "hono": "^4.6.15",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.150.0
+
+### Minor Changes
+
+- Use codes-code_verifier to store pkce challenge
+
 ## 0.149.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.149.0",
+  "version": "0.150.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -182,6 +182,7 @@ export async function createCodeData(
     expires_at: new Date(
       Date.now() + AUTHORIZATION_CODE_EXPIRES_IN_SECONDS * 1000,
     ).toISOString(),
+    code_verifier: params.authParams.code_challenge,
   });
 
   return {
@@ -474,7 +475,7 @@ export async function createAuthResponse(
       user: postHookUser,
       client,
       authParams,
-      login_id: params.loginSession.id, // Use login session id instead of session_id
+      login_id: params.loginSession.id,
     });
 
     if (!authParams.redirect_uri) {

--- a/packages/authhero/test/authentication-flows/silent.spec.ts
+++ b/packages/authhero/test/authentication-flows/silent.spec.ts
@@ -71,6 +71,7 @@ describe("silent", () => {
           state: "state",
           prompt: "none",
           response_type: AuthorizationResponseType.CODE,
+          code_challenge: "ZLQ3m0EnuZ-kdlU1aRGNOPN_dTW8ewOVqEEfZd0cFZE",
         },
       },
       {
@@ -94,6 +95,9 @@ describe("silent", () => {
     );
     expect(code).toBeDefined();
     expect(code?.login_id).toEqual(loginSession.id);
+    expect(code?.code_verifier).toEqual(
+      "ZLQ3m0EnuZ-kdlU1aRGNOPN_dTW8ewOVqEEfZd0cFZE",
+    );
 
     // Check that the session was updated
     const updatedSession = await env.data.sessions.get("tenantId", "sessionId");

--- a/packages/authhero/test/routes/auth-api/token.spec.ts
+++ b/packages/authhero/test/routes/auth-api/token.spec.ts
@@ -673,6 +673,7 @@ describe("token", () => {
           code_id: "123456",
           login_id: loginSesssion.id,
           expires_at: new Date(Date.now() + 1000 * 60 * 5).toISOString(),
+          code_verifier: codeChallenge,
         });
 
         const response = await client.oauth.token.$post(

--- a/packages/kysely/migrate/migrations/2025-06-04T13:00:00_index_sessions_login_session_id.ts
+++ b/packages/kysely/migrate/migrations/2025-06-04T13:00:00_index_sessions_login_session_id.ts
@@ -1,0 +1,17 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/db";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .createIndex("IDX_sessions_login_session_id")
+    .on("sessions")
+    .column("login_session_id")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .dropIndex("IDX_sessions_login_session_id")
+    .on("sessions")
+    .execute();
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -82,6 +82,7 @@ import * as n82_forms from "./2025-05-21T10:00:00_forms";
 import * as n83_addFormsIdToHooks from "./2025-05-29T00:00:00_add_forms_id_to_hooks";
 import * as n84_login_completed from "./2025-05-30T00:00:00_login_completed";
 import * as n85_add_login_session_id_to_sessions from "./2025-06-04T12:00:00_add_login_session_id_to_sessions";
+import * as n86_index_sessions_login_session_id from "./2025-06-04T13:00:00_index_sessions_login_session_id";
 
 // These need to be in alphabetic order
 export default {
@@ -169,4 +170,5 @@ export default {
   n83_addFormsIdToHooks,
   n84_login_completed,
   n85_add_login_session_id_to_sessions,
+  n86_index_sessions_login_session_id,
 };


### PR DESCRIPTION
As each silent auth session will use it's own pkce challange we can't use the auth-params of the login-session to store this info. As a temporary solution I'll use the code_verifier in the codes table for now, even though it's really the code challenge. I'll add a new column with a better name soon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling and storage of PKCE code challenges during authentication flows.
  - Enhanced silent authentication to validate PKCE code challenge storage.

- **Chores**
  - Updated dependencies and package versions for `authhero` and `@authhero/demo`.
  - Added a new database index to optimize session queries.
  - Updated changelogs to reflect recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->