### PR TITLE
Redirect directly to single oidc

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.13.11
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.158.0
+
 ## 0.13.10
 
 ### Patch Changes
@@ -181,7 +188,7 @@
 
 - Updated dependencies
   - authhero@0.135.0
-  - @authhero/kysely-adapter@11.0.0
+  - @authhero/kysely-adapter@10.22.0
 
 ## 0.11.16
 
@@ -203,7 +210,7 @@
 
 - Updated dependencies
   - authhero@0.132.0
-  - @authhero/kysely-adapter@11.0.0
+  - @authhero/kysely-adapter@10.21.0
 
 ## 0.11.13
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -6,11 +6,11 @@
     "dev": "bun --watch src/bun.ts"
   },
   "dependencies": {
-    "@authhero/kysely-adapter": "^11.0.0",
+    "@authhero/kysely-adapter": "^10.22.0",
     "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.12.3",
-    "authhero": "^0.157.0",
+    "authhero": "^0.158.0",
     "better-sqlite3": "^11.5.0",
     "hono": "^4.6.15",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.158.0
+
+### Minor Changes
+
+- Redirect straight to single OIDC connection
+
 ## 0.157.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.157.0",
+  "version": "0.158.0",
   "files": [
     "dist"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
   apps/demo:
     dependencies:
       '@authhero/kysely-adapter':
-        specifier: ^10.12.0
-        version: 10.12.0(@authhero/adapter-interfaces@0.62.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4)))(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(kysely-bun-sqlite@0.3.2(kysely@0.27.4))(kysely-planetscale@1.5.0(@planetscale/database@1.18.0)(kysely@0.27.4))
+        specifier: ^10.22.0
+        version: 10.22.0(@authhero/adapter-interfaces@0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4)))(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(kysely-bun-sqlite@0.3.2(kysely@0.27.4))(kysely-planetscale@1.5.0(@planetscale/database@1.18.0)(kysely@0.27.4))
       '@hono/swagger-ui':
         specifier: ^0.5.0
         version: 0.5.0(hono@4.6.15)
@@ -79,8 +79,8 @@ importers:
         specifier: ^1.12.3
         version: 1.12.3
       authhero:
-        specifier: ^0.138.0
-        version: 0.138.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(typescript@5.8.3)
+        specifier: ^0.157.0
+        version: 0.157.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(typescript@5.8.3)
       better-sqlite3:
         specifier: ^11.5.0
         version: 11.5.0
@@ -489,15 +489,15 @@ packages:
   '@auth0/auth0-spa-js@2.1.3':
     resolution: {integrity: sha512-NMTBNuuG4g3rame1aCnNS5qFYIzsTUV5qTFPRfTyYFS1feS6jsCBR+eTq9YkxCp1yuoM2UIcjunPaoPl77U9xQ==}
 
-  '@authhero/adapter-interfaces@0.62.0':
-    resolution: {integrity: sha512-YX44SueoLExChVlRoguG98QGpG0ZBL8/abL0kUxCF+CY6501lkFvCPYBKjcuQsFRl0KwHeAk6LdyP2Uqhbej+w==}
+  '@authhero/adapter-interfaces@0.72.0':
+    resolution: {integrity: sha512-jP3z8VSmXeX2kMHcSwUZj0zLK6ofk73//cZ0j4AleSMkCIfSom24iBjqpjJrhxA0iaOxCoZokpxPugK133EsDQ==}
     peerDependencies:
       '@hono/zod-openapi': ^0.19.2
 
-  '@authhero/kysely-adapter@10.12.0':
-    resolution: {integrity: sha512-XIW2j+sL/4Hj0OsDIhLwLByjRrLoShczKSomBCMwr7r+ddy/QBXof350Qvoy7TJ02CqnD3zM9HFdyPCX7wI12g==}
+  '@authhero/kysely-adapter@10.22.0':
+    resolution: {integrity: sha512-Qp9LTQ/JOMJR1sUpEY1ua/N/eY7ZkFj1/pP1IeKySpy5G712Sv3AF3X3aRvK2pwr91UH6oWMRLVQJLv5SDGVDw==}
     peerDependencies:
-      '@authhero/adapter-interfaces': 0.62.0
+      '@authhero/adapter-interfaces': 0.72.0
       '@hono/zod-openapi': ^0.19.2
       hono: ^4.6.8
       kysely-bun-sqlite: ^0.3.2
@@ -2624,8 +2624,8 @@ packages:
     resolution: {integrity: sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==}
     engines: {node: '>=4'}
 
-  authhero@0.138.0:
-    resolution: {integrity: sha512-agjyaBSwof1x10KJ3820wkD90NcyfhipOqV9VoVc3GB/3QFRvM2qh86rRZHUc8mFAK6XnvRi4hj0PsyP82nYpA==}
+  authhero@0.157.0:
+    resolution: {integrity: sha512-zL24xHSf9QsBScTDscCnrYui3M8PzSelymvRppf+ChM9XpfV4/aKyRYF7i5JgjJGTm6B0ugQg9K0VZuzFxG0gw==}
     peerDependencies:
       '@hono/zod-openapi': ^0.19.2
       hono: ^4.6.11
@@ -5938,14 +5938,14 @@ snapshots:
 
   '@auth0/auth0-spa-js@2.1.3': {}
 
-  '@authhero/adapter-interfaces@0.62.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))':
+  '@authhero/adapter-interfaces@0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))':
     dependencies:
       '@hono/zod-openapi': 0.19.2(hono@4.6.15)(zod@3.24.4)
       nanoid: 5.0.8
 
-  '@authhero/kysely-adapter@10.12.0(@authhero/adapter-interfaces@0.62.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4)))(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(kysely-bun-sqlite@0.3.2(kysely@0.27.4))(kysely-planetscale@1.5.0(@planetscale/database@1.18.0)(kysely@0.27.4))':
+  '@authhero/kysely-adapter@10.22.0(@authhero/adapter-interfaces@0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4)))(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(kysely-bun-sqlite@0.3.2(kysely@0.27.4))(kysely-planetscale@1.5.0(@planetscale/database@1.18.0)(kysely@0.27.4))':
     dependencies:
-      '@authhero/adapter-interfaces': 0.62.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))
+      '@authhero/adapter-interfaces': 0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))
       '@hono/zod-openapi': 0.19.2(hono@4.6.15)(zod@3.24.4)
       hono: 4.6.15
       kysely: 0.27.4
@@ -8070,9 +8070,9 @@ snapshots:
 
   attr-accept@2.2.2: {}
 
-  authhero@0.138.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(typescript@5.8.3):
+  authhero@0.157.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(typescript@5.8.3):
     dependencies:
-      '@authhero/adapter-interfaces': 0.62.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))
+      '@authhero/adapter-interfaces': 0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))
       '@hono/zod-openapi': 0.19.2(hono@4.6.15)(zod@3.24.4)
       '@peculiar/x509': 1.12.3
       arctic: 3.1.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users are now redirected directly to a single OIDC connection when available.

- **Documentation**
  - Updated changelogs to reflect dependency version changes and new features.

- **Chores**
  - Upgraded the `authhero` package to version 0.158.0.
  - Downgraded the `@authhero/kysely-adapter` dependency to version 10.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->