### PR TITLE
Add saml support

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.14.1
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.160.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.12.3",
-    "authhero": "^0.159.0",
+    "authhero": "^0.160.0",
     "better-sqlite3": "^11.5.0",
     "hono": "^4.6.15",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.160.0
+
+### Minor Changes
+
+- Add saml support
+
 ## 0.159.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.159.0",
+  "version": "0.160.0",
   "files": [
     "dist"
   ],
@@ -57,7 +57,8 @@
     "i18next": "^24.2.0",
     "libphonenumber-js": "^1.12.8",
     "nanoid": "^5.0.8",
-    "oslo": "^1.2.1"
+    "oslo": "^1.2.1",
+    "xml-crypto": "^6.1.2"
   },
   "peerDependencies": {
     "@hono/zod-openapi": "^0.19.2",

--- a/packages/authhero/src/helpers/saml.ts
+++ b/packages/authhero/src/helpers/saml.ts
@@ -40,6 +40,7 @@ export interface SAMLResponseParams {
 export async function inflateRaw(
   compressedData: Uint8Array,
 ): Promise<Uint8Array> {
+  // TODO: this is not supported in Node.js, so we need to use a polyfill
   const ds = new DecompressionStream("deflate-raw");
   const decompressedStream = new Blob([compressedData])
     .stream()
@@ -267,6 +268,7 @@ async function signSAML(
       action: "after",
     },
   });
+
   return sig.getSignedXml();
 }
 

--- a/packages/authhero/src/helpers/saml.ts
+++ b/packages/authhero/src/helpers/saml.ts
@@ -1,0 +1,575 @@
+import { XMLBuilder, XMLParser } from "fast-xml-parser";
+import { samlRequestSchema, SAMLResponseJSON } from "../types/saml";
+import { base64 } from "oslo/encoding";
+import { nanoid } from "nanoid";
+import { SignedXml } from "xml-crypto";
+
+const signatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+const digestAlgorithm = "http://www.w3.org/2001/04/xmlenc#sha256";
+const canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
+
+export interface SAMLMetadataParams {
+  entityId: string;
+  assertionConsumerServiceUrl: string;
+  singleLogoutServiceUrl: string;
+  cert: string;
+}
+
+export interface SAMLResponseParams {
+  destination: string;
+  inResponseTo: string;
+  audience: string;
+  issuer: string;
+  email: string;
+  notBefore?: string;
+  notAfter?: string;
+  responseId?: string;
+  assertionId?: string;
+  sessionNotOnOrAfter?: string;
+  issueInstant?: string;
+  sessionIndex: string;
+  userId: string;
+  signature?: {
+    privateKeyPem: string;
+    cert: string;
+    kid: string;
+  };
+  encode?: boolean;
+}
+
+export async function inflateRaw(
+  compressedData: Uint8Array,
+): Promise<Uint8Array> {
+  const ds = new DecompressionStream("deflate-raw");
+  const decompressedStream = new Blob([compressedData])
+    .stream()
+    .pipeThrough(ds);
+  return new Uint8Array(await new Response(decompressedStream).arrayBuffer());
+}
+
+export async function inflateDecompress(input: string): Promise<string> {
+  const decodedBytes = await base64.decode(input.replace(/ /g, "+"));
+
+  try {
+    // Try to decompress using pako
+    const decompressed = await inflateRaw(decodedBytes);
+    return new TextDecoder().decode(decompressed);
+  } catch (error) {
+    console.warn(
+      "Decompression failed, assuming data is not compressed:",
+      error,
+    );
+    // If decompression fails, assume the data is not compressed
+    return new TextDecoder().decode(decodedBytes);
+  }
+}
+
+export async function parseSamlRequestQuery(samlRequestQuery: string) {
+  const samlRequesteXml = await inflateDecompress(samlRequestQuery);
+
+  const parser = new XMLParser({
+    attributeNamePrefix: "@_",
+    alwaysCreateTextNode: true,
+    ignoreAttributes: false,
+  });
+  const samlRequestJson = parser.parse(samlRequesteXml);
+
+  return samlRequestSchema.parse(samlRequestJson);
+}
+
+export function createSamlMetadata(samlMetadataParams: SAMLMetadataParams) {
+  const samlMetadataJSON = [
+    {
+      ":@": {
+        "@_entityID": samlMetadataParams.entityId,
+        "@_xmlns": "urn:oasis:names:tc:SAML:2.0:metadata",
+      },
+      EntityDescriptor: [
+        {
+          ":@": {
+            "@_protocolSupportEnumeration":
+              "urn:oasis:names:tc:SAML:2.0:protocol",
+          },
+          IDPSSODescriptor: [
+            {
+              ":@": {
+                "@_use": "signing",
+              },
+              KeyDescriptor: [
+                {
+                  ":@": {
+                    "@_xmlns": "http://www.w3.org/2000/09/xmldsig#",
+                  },
+                  KeyInfo: [
+                    {
+                      X509Data: [
+                        {
+                          X509Certificate: [
+                            { "#text": samlMetadataParams.cert },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              ":@": {
+                "@_Binding":
+                  "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                "@_Location": samlMetadataParams.singleLogoutServiceUrl,
+              },
+              SingleLogoutService: [],
+            },
+            {
+              ":@": {
+                "@_Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                "@_Location": samlMetadataParams.singleLogoutServiceUrl,
+              },
+              SingleLogoutService: [],
+            },
+            {
+              NameIDFormat: [
+                {
+                  "#text":
+                    "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+                },
+              ],
+            },
+            {
+              NameIDFormat: [
+                {
+                  "#text":
+                    "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+                },
+              ],
+            },
+            {
+              NameIDFormat: [
+                {
+                  "#text":
+                    "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+                },
+              ],
+            },
+            {
+              ":@": {
+                "@_Binding":
+                  "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                "@_Location": samlMetadataParams.assertionConsumerServiceUrl,
+              },
+              SingleSignOnService: [],
+            },
+            {
+              ":@": {
+                "@_Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                "@_Location": samlMetadataParams.assertionConsumerServiceUrl,
+              },
+              SingleSignOnService: [],
+            },
+            {
+              ":@": {
+                "@_Name":
+                  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+                "@_NameFormat":
+                  "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                "@_FriendlyName": "E-Mail Address",
+                "@_xmlns": "urn:oasis:names:tc:SAML:2.0:assertion",
+              },
+              Attribute: [],
+            },
+            {
+              ":@": {
+                "@_Name":
+                  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+                "@_NameFormat":
+                  "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                "@_FriendlyName": "Given Name",
+                "@_xmlns": "urn:oasis:names:tc:SAML:2.0:assertion",
+              },
+              Attribute: [],
+            },
+            {
+              ":@": {
+                "@_Name":
+                  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+                "@_NameFormat":
+                  "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                "@_FriendlyName": "Name",
+                "@_xmlns": "urn:oasis:names:tc:SAML:2.0:assertion",
+              },
+              Attribute: [],
+            },
+            {
+              ":@": {
+                "@_Name":
+                  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+                "@_NameFormat":
+                  "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                "@_FriendlyName": "Surname",
+                "@_xmlns": "urn:oasis:names:tc:SAML:2.0:assertion",
+              },
+              Attribute: [],
+            },
+            {
+              ":@": {
+                "@_Name":
+                  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+                "@_NameFormat":
+                  "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                "@_FriendlyName": "Name ID",
+                "@_xmlns": "urn:oasis:names:tc:SAML:2.0:assertion",
+              },
+              Attribute: [],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const builder = new XMLBuilder({
+    ignoreAttributes: false,
+    suppressEmptyNode: true,
+    preserveOrder: true,
+    format: true,
+  });
+
+  // Generate XML
+  return builder.build(samlMetadataJSON);
+}
+
+async function signSAML(
+  xmlContent: string,
+  privateKey: string,
+  publicCert: string,
+): Promise<string> {
+  const sig = new SignedXml({ privateKey, publicCert });
+  sig.canonicalizationAlgorithm = canonicalizationAlgorithm;
+  sig.addReference({
+    xpath: "(/*[local-name()='Response']/*[local-name()='Assertion'])[1]",
+    digestAlgorithm: digestAlgorithm,
+    transforms: [
+      "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+      canonicalizationAlgorithm,
+    ],
+  });
+
+  sig.signatureAlgorithm = signatureAlgorithm;
+  sig.computeSignature(xmlContent, {
+    // according to:
+    // https://docs.oasis-open.org/security/saml/v2.0/saml-schema-assertion-2.0.xsd
+    // Assertion's ds:Signature must be after Assertion/Issuer
+    location: {
+      reference:
+        "/*[local-name()='Response']/*[local-name()='Assertion']/*[local-name()='Issuer']",
+      action: "after",
+    },
+  });
+  return sig.getSignedXml();
+}
+
+export async function createSamlResponse(
+  samlResponseParams: SAMLResponseParams,
+): Promise<string> {
+  const notBefore = samlResponseParams.notBefore || new Date().toISOString();
+  const notAfter =
+    samlResponseParams.notAfter ||
+    new Date(new Date(notBefore).getTime() + 10 * 60 * 1000).toISOString();
+  const issueInstant = samlResponseParams.issueInstant || notBefore;
+  const sessionNotOnOrAfter =
+    samlResponseParams.sessionNotOnOrAfter || notAfter;
+  const responseId = samlResponseParams.responseId || `_${nanoid()}`;
+  const assertionId = samlResponseParams.assertionId || `_${nanoid()}`;
+
+  const samlResponseJson: SAMLResponseJSON = [
+    {
+      "samlp:Response": [
+        {
+          "saml:Issuer": [{ "#text": samlResponseParams.issuer }],
+        },
+        {
+          "samlp:Status": [
+            {
+              "samlp:StatusCode": [],
+              ":@": { "@_Value": "urn:oasis:names:tc:SAML:2.0:status:Success" },
+            },
+          ],
+        },
+        {
+          "saml:Assertion": [
+            {
+              "saml:Issuer": [
+                {
+                  "#text": samlResponseParams.issuer,
+                },
+              ],
+            },
+            {
+              "saml:Subject": [
+                {
+                  "saml:NameID": [{ "#text": samlResponseParams.email }],
+                  ":@": {
+                    "@_Format":
+                      "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+                  },
+                },
+                {
+                  "saml:SubjectConfirmation": [
+                    {
+                      "saml:SubjectConfirmationData": [],
+                      ":@": {
+                        "@_InResponseTo": samlResponseParams.inResponseTo,
+                        "@_NotOnOrAfter": notAfter,
+                        "@_Recipient": samlResponseParams.destination,
+                      },
+                    },
+                  ],
+                  ":@": { "@_Method": "urn:oasis:names:tc:SAML:2.0:cm:bearer" },
+                },
+              ],
+            },
+            {
+              "saml:Conditions": [
+                {
+                  "saml:AudienceRestriction": [
+                    {
+                      "saml:Audience": [
+                        {
+                          "#text": samlResponseParams.audience,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+              ":@": {
+                "@_NotBefore": notBefore,
+                "@_NotOnOrAfter": notAfter,
+              },
+            },
+            {
+              "saml:AuthnStatement": [
+                {
+                  "saml:AuthnContext": [
+                    {
+                      "saml:AuthnContextClassRef": [
+                        {
+                          "#text":
+                            "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+              ":@": {
+                "@_AuthnInstant": issueInstant,
+                "@_SessionIndex": samlResponseParams.sessionIndex,
+                "@_SessionNotOnOrAfter": sessionNotOnOrAfter,
+              },
+            },
+            {
+              "saml:AttributeStatement": [
+                {
+                  "saml:Attribute": [
+                    {
+                      "saml:AttributeValue": [
+                        { "#text": samlResponseParams.userId },
+                      ],
+                      ":@": {
+                        "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                        "@_xmlns:xsi":
+                          "http://www.w3.org/2001/XMLSchema-instance",
+                        "@_xsi:type": "xs:string",
+                      },
+                    },
+                  ],
+                  ":@": {
+                    "@_FriendlyName": "persistent",
+                    "@_Name": "id",
+                    "@_NameFormat":
+                      "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
+                  },
+                },
+                {
+                  "saml:Attribute": [
+                    {
+                      "saml:AttributeValue": [
+                        { "#text": samlResponseParams.email },
+                      ],
+                      ":@": {
+                        "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                        "@_xmlns:xsi":
+                          "http://www.w3.org/2001/XMLSchema-instance",
+                        "@_xsi:type": "xs:string",
+                      },
+                    },
+                  ],
+                  ":@": {
+                    "@_Name": "email",
+                    "@_NameFormat":
+                      "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                  },
+                },
+                {
+                  "saml:Attribute": [
+                    {
+                      "saml:AttributeValue": [{ "#text": "manage-account" }],
+                      ":@": {
+                        "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                        "@_xmlns:xsi":
+                          "http://www.w3.org/2001/XMLSchema-instance",
+                        "@_xsi:type": "xs:string",
+                      },
+                    },
+                  ],
+                  ":@": {
+                    "@_Name": "Role",
+                    "@_NameFormat":
+                      "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                  },
+                },
+                {
+                  "saml:Attribute": [
+                    {
+                      "saml:AttributeValue": [
+                        { "#text": "default-roles-master" },
+                      ],
+                      ":@": {
+                        "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                        "@_xmlns:xsi":
+                          "http://www.w3.org/2001/XMLSchema-instance",
+                        "@_xsi:type": "xs:string",
+                      },
+                    },
+                  ],
+                  ":@": {
+                    "@_Name": "Role",
+                    "@_NameFormat":
+                      "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                  },
+                },
+                {
+                  "saml:Attribute": [
+                    {
+                      "saml:AttributeValue": [{ "#text": "offline_access" }],
+                      ":@": {
+                        "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                        "@_xmlns:xsi":
+                          "http://www.w3.org/2001/XMLSchema-instance",
+                        "@_xsi:type": "xs:string",
+                      },
+                    },
+                  ],
+                  ":@": {
+                    "@_Name": "Role",
+                    "@_NameFormat":
+                      "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                  },
+                },
+                {
+                  "saml:Attribute": [
+                    {
+                      "saml:AttributeValue": [{ "#text": "view-profile" }],
+                      ":@": {
+                        "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                        "@_xmlns:xsi":
+                          "http://www.w3.org/2001/XMLSchema-instance",
+                        "@_xsi:type": "xs:string",
+                      },
+                    },
+                  ],
+                  ":@": {
+                    "@_Name": "Role",
+                    "@_NameFormat":
+                      "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                  },
+                },
+                {
+                  "saml:Attribute": [
+                    {
+                      "saml:AttributeValue": [{ "#text": "uma_authorization" }],
+                      ":@": {
+                        "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                        "@_xmlns:xsi":
+                          "http://www.w3.org/2001/XMLSchema-instance",
+                        "@_xsi:type": "xs:string",
+                      },
+                    },
+                  ],
+                  ":@": {
+                    "@_Name": "Role",
+                    "@_NameFormat":
+                      "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                  },
+                },
+                {
+                  "saml:Attribute": [
+                    {
+                      "saml:AttributeValue": [
+                        { "#text": "manage-account-links" },
+                      ],
+                      ":@": {
+                        "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                        "@_xmlns:xsi":
+                          "http://www.w3.org/2001/XMLSchema-instance",
+                        "@_xsi:type": "xs:string",
+                      },
+                    },
+                  ],
+                  ":@": {
+                    "@_Name": "Role",
+                    "@_NameFormat":
+                      "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                  },
+                },
+              ],
+            },
+          ],
+          ":@": {
+            "@_xmlns": "urn:oasis:names:tc:SAML:2.0:assertion",
+            "@_ID": assertionId,
+            "@_IssueInstant": issueInstant,
+            "@_Version": "2.0",
+          },
+        },
+      ],
+      ":@": {
+        "@_xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+        "@_xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion",
+        "@_Destination": samlResponseParams.destination,
+        "@_ID": responseId,
+        "@_InResponseTo": samlResponseParams.inResponseTo,
+        "@_IssueInstant": issueInstant,
+        "@_Version": "2.0",
+      },
+    },
+  ];
+
+  const builder = new XMLBuilder({
+    ignoreAttributes: false,
+    suppressEmptyNode: true,
+    preserveOrder: true,
+  });
+
+  // Generate XML
+  let xmlContent = builder.build(samlResponseJson);
+
+  if (samlResponseParams.signature) {
+    xmlContent = await signSAML(
+      xmlContent,
+      samlResponseParams.signature.privateKeyPem,
+      samlResponseParams.signature.cert,
+    );
+  }
+
+  if (samlResponseParams.encode === false) {
+    return xmlContent;
+  }
+
+  const encodedResponse = btoa(xmlContent);
+
+  return encodedResponse;
+}

--- a/packages/authhero/src/index.ts
+++ b/packages/authhero/src/index.ts
@@ -5,6 +5,7 @@ import { Bindings, Variables, AuthHeroConfig } from "./types";
 import createManagementApi from "./routes/management-api";
 import createOauthApi from "./routes/auth-api";
 import createUniversalLogin from "./routes/universal-login";
+import createSamlpApi from "./routes/saml";
 import { createX509Certificate } from "./utils/encryption";
 import { en, it, nb, sv, pl, cs, fi, da } from "./locales";
 
@@ -46,10 +47,14 @@ export function init(config: AuthHeroConfig) {
   const universalApp = createUniversalLogin(config);
   app.route("/u", universalApp);
 
+  const samlApp = createSamlpApi(config);
+  app.route("/samlp", samlApp);
+
   return {
     app,
     managementApp,
     oauthApp,
+    samlApp,
     universalApp,
     createX509Certificate,
   };

--- a/packages/authhero/src/routes/saml/index.ts
+++ b/packages/authhero/src/routes/saml/index.ts
@@ -1,0 +1,50 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { AuthHeroConfig, Bindings, Variables } from "../../types";
+import { registerComponent } from "../../middlewares/register-component";
+import { createAuthMiddleware } from "../../middlewares/authentication";
+import { addDataHooks } from "../../hooks";
+import { addTimingLogs } from "../../helpers/server-timing";
+import { addCaching } from "../../helpers/cache-wrapper";
+import { tenantMiddleware } from "../../middlewares/tenant";
+import { samlpRoutes } from "./samlp";
+
+export default function create(config: AuthHeroConfig) {
+  const app = new OpenAPIHono<{
+    Bindings: Bindings;
+    Variables: Variables;
+  }>();
+
+  app.use(async (ctx, next) => {
+    // First add data hooks
+    const dataWithHooks = addDataHooks(ctx, config.dataAdapter);
+    // Then wrap with caching (specifically for tenants, connections, and clients)
+    const cachedData = addCaching(dataWithHooks, {
+      defaultTtl: 300000, // 5 minutes default TTL
+      cacheEntities: ["tenants", "connections", "clients"],
+    });
+    // Finally wrap with timing logs
+    ctx.env.data = addTimingLogs(ctx, cachedData);
+    return next();
+  });
+
+  app.use(tenantMiddleware).use(createAuthMiddleware(app));
+
+  const samlApp = app.route("/", samlpRoutes);
+
+  samlApp.doc("/spec", {
+    openapi: "3.0.0",
+    info: {
+      version: "1.0.0",
+      title: "SAML API",
+    },
+    security: [
+      {
+        oauth2: ["openid", "email", "profile"],
+      },
+    ],
+  });
+
+  registerComponent(samlApp);
+
+  return samlApp;
+}

--- a/packages/authhero/src/routes/saml/samlp.ts
+++ b/packages/authhero/src/routes/saml/samlp.ts
@@ -1,0 +1,146 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { HTTPException } from "hono/http-exception";
+import { UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS } from "../../constants";
+import { X509Certificate } from "@peculiar/x509";
+import { getClientInfo } from "../../utils/client-info";
+import { nanoid } from "nanoid";
+import { Bindings, Variables } from "../../types";
+import { AuthorizationResponseMode } from "@authhero/adapter-interfaces";
+import { createSamlMetadata, parseSamlRequestQuery } from "../../helpers/saml";
+
+export const samlpRoutes = new OpenAPIHono<{
+  Bindings: Bindings;
+  Variables: Variables;
+}>()
+  // --------------------------------
+  // GET /samlp/metadata/{client_id}
+  // --------------------------------
+  .openapi(
+    createRoute({
+      tags: ["saml"],
+      method: "get",
+      path: "/metadata/{client_id}",
+      request: {
+        params: z.object({
+          client_id: z.string(),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Decoded SAML Request",
+          content: {
+            "text/xml": {
+              schema: z.string(),
+            },
+          },
+        },
+        400: {
+          description: "Bad Request",
+        },
+      },
+    }),
+    async (ctx) => {
+      const { client_id } = ctx.req.valid("param");
+
+      const client = await ctx.env.data.clients.get(client_id);
+
+      if (!client) {
+        throw new HTTPException(404, {
+          message: "Client not found",
+        });
+      }
+
+      const [signingKey] = await ctx.env.data.keys.list();
+
+      if (!signingKey) {
+        throw new HTTPException(500, {
+          message: "No signing key found",
+        });
+      }
+
+      const cert = new X509Certificate(signingKey.cert);
+
+      const issuer = ctx.env.ISSUER;
+
+      const metadata = createSamlMetadata({
+        entityId: client.addons?.samlp?.audience || client.id,
+        cert: cert.toString("base64"),
+        assertionConsumerServiceUrl: `${issuer}samlp/${client_id}`,
+        singleLogoutServiceUrl: `${issuer}samlp/${client_id}/logout`,
+      });
+
+      return new Response(metadata, {
+        headers: {
+          "Content-Type": "text/xml",
+        },
+      });
+    },
+  )
+  // --------------------------------
+  // GET /samlp/{client_id}
+  // --------------------------------
+  .openapi(
+    createRoute({
+      tags: ["saml"],
+      method: "get",
+      path: "/{client_id}",
+      request: {
+        query: z.object({
+          SAMLRequest: z.string(),
+          RelayState: z.string().optional(),
+          SigAlg: z.string().optional(),
+          Signature: z.string().optional(),
+        }),
+        params: z.object({
+          client_id: z.string(),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Decoded SAML Request",
+          content: {
+            "text/xml": {
+              schema: z.string(),
+            },
+          },
+        },
+        400: {
+          description: "Bad Request",
+        },
+      },
+    }),
+    async (ctx) => {
+      const { client_id } = ctx.req.valid("param");
+      const { SAMLRequest, RelayState } = ctx.req.valid("query");
+
+      const samlRequest = await parseSamlRequestQuery(SAMLRequest);
+      const issuer = samlRequest["samlp:AuthnRequest"]["saml:Issuer"]["#text"];
+
+      // Create a new Login session
+      const loginSession = await ctx.env.data.loginSessions.create(
+        ctx.var.tenant_id,
+        {
+          csrf_token: nanoid(),
+          authParams: {
+            client_id: client_id,
+            state: JSON.stringify({
+              requestId: samlRequest["samlp:AuthnRequest"]["@_ID"],
+              relayState: RelayState,
+            }),
+            response_mode: AuthorizationResponseMode.SAML_POST,
+            redirect_uri:
+              samlRequest["samlp:AuthnRequest"][
+                "@_AssertionConsumerServiceURL"
+              ] || "https://auth.sesamy.dev/login/callback",
+            audience: issuer,
+          },
+          expires_at: new Date(
+            Date.now() + UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS * 1000,
+          ).toISOString(),
+          ...getClientInfo(ctx.req),
+        },
+      );
+
+      return ctx.redirect(`/u/login/identifier?state=${loginSession.id}`);
+    },
+  );

--- a/packages/authhero/src/routes/saml/samlp.ts
+++ b/packages/authhero/src/routes/saml/samlp.ts
@@ -50,6 +50,7 @@ export const samlpRoutes = new OpenAPIHono<{
         });
       }
 
+      // TODO: Get the most recent signing key
       const [signingKey] = await ctx.env.data.keys.list();
 
       if (!signingKey) {
@@ -113,6 +114,8 @@ export const samlpRoutes = new OpenAPIHono<{
       const { client_id } = ctx.req.valid("param");
       const { SAMLRequest, RelayState } = ctx.req.valid("query");
 
+      // TODO: Validate the Signature and SigAlg if provided
+
       const samlRequest = await parseSamlRequestQuery(SAMLRequest);
       const issuer = samlRequest["samlp:AuthnRequest"]["saml:Issuer"]["#text"];
 
@@ -129,9 +132,10 @@ export const samlpRoutes = new OpenAPIHono<{
             }),
             response_mode: AuthorizationResponseMode.SAML_POST,
             redirect_uri:
+              // TODO: validate this URL against the saml settings
               samlRequest["samlp:AuthnRequest"][
                 "@_AssertionConsumerServiceURL"
-              ] || "https://auth.sesamy.dev/login/callback",
+              ],
             audience: issuer,
           },
           expires_at: new Date(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
   apps/demo:
     dependencies:
       '@authhero/kysely-adapter':
-        specifier: ^10.22.0
-        version: 10.22.0(@authhero/adapter-interfaces@0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4)))(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(kysely-bun-sqlite@0.3.2(kysely@0.27.4))(kysely-planetscale@1.5.0(@planetscale/database@1.18.0)(kysely@0.27.4))
+        specifier: ^10.23.0
+        version: 10.23.0(@authhero/adapter-interfaces@0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4)))(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(kysely-bun-sqlite@0.3.2(kysely@0.27.4))(kysely-planetscale@1.5.0(@planetscale/database@1.18.0)(kysely@0.27.4))
       '@hono/swagger-ui':
         specifier: ^0.5.0
         version: 0.5.0(hono@4.6.15)
@@ -79,11 +79,11 @@ importers:
         specifier: ^1.12.3
         version: 1.12.3
       authhero:
-        specifier: ^0.157.0
-        version: 0.157.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(typescript@5.8.3)
+        specifier: ^0.159.0
+        version: 0.159.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(typescript@5.8.3)
       better-sqlite3:
         specifier: ^11.5.0
-        version: 11.5.0
+        version: 11.10.0
       hono:
         specifier: ^4.6.15
         version: 4.6.15
@@ -264,6 +264,9 @@ importers:
       oslo:
         specifier: ^1.2.1
         version: 1.2.1
+      xml-crypto:
+        specifier: ^6.1.2
+        version: 6.1.2
     devDependencies:
       '@ape-egg/tailwind-rows-columns':
         specifier: ^1.0.2
@@ -282,7 +285,7 @@ importers:
         version: 10.4.18(postcss@8.4.36)
       better-sqlite3:
         specifier: ^11.5.0
-        version: 11.5.0
+        version: 11.10.0
       cssnano:
         specifier: 6.0.5
         version: 6.0.5(postcss@8.4.36)
@@ -346,7 +349,7 @@ importers:
         version: 22.15.17
       better-sqlite3:
         specifier: ^11.5.0
-        version: 11.5.0
+        version: 11.10.0
       dts-bundle-generator:
         specifier: ^9.5.1
         version: 9.5.1
@@ -494,8 +497,8 @@ packages:
     peerDependencies:
       '@hono/zod-openapi': ^0.19.2
 
-  '@authhero/kysely-adapter@10.22.0':
-    resolution: {integrity: sha512-Qp9LTQ/JOMJR1sUpEY1ua/N/eY7ZkFj1/pP1IeKySpy5G712Sv3AF3X3aRvK2pwr91UH6oWMRLVQJLv5SDGVDw==}
+  '@authhero/kysely-adapter@10.23.0':
+    resolution: {integrity: sha512-uHsZ5CuEylw6IxF31vl/dUlHQr65ZaeNgzT43s8A0seFfPxkzc45sjM2xQ4Wt8tOdOPjWS6ksfj9C5nt/SW6Ow==}
     peerDependencies:
       '@authhero/adapter-interfaces': 0.72.0
       '@hono/zod-openapi': ^0.19.2
@@ -2445,6 +2448,14 @@ packages:
   '@vue/shared@3.4.31':
     resolution: {integrity: sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA==}
 
+  '@xmldom/is-dom-node@1.0.1':
+    resolution: {integrity: sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==}
+    engines: {node: '>= 16'}
+
+  '@xmldom/xmldom@0.8.10':
+    resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
+    engines: {node: '>=10.0.0'}
+
   '@xyflow/react@12.6.4':
     resolution: {integrity: sha512-/dOQ43Nu217cwHzy7f8kNUrFMeJJENzftVgT2VdFFHi6fHlG83pF+gLmvkRW9Be7alCsR6G+LFxxCdsQQbazHg==}
     peerDependencies:
@@ -2624,8 +2635,8 @@ packages:
     resolution: {integrity: sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==}
     engines: {node: '>=4'}
 
-  authhero@0.157.0:
-    resolution: {integrity: sha512-zL24xHSf9QsBScTDscCnrYui3M8PzSelymvRppf+ChM9XpfV4/aKyRYF7i5JgjJGTm6B0ugQg9K0VZuzFxG0gw==}
+  authhero@0.159.0:
+    resolution: {integrity: sha512-TRv3hrQH+8jHTvoaS7dvlin9JZ8KBZrWnhsDF9Gmah2TqazW/MpipIxKrHRhbGm3ii7iOp1tnwh1FhzlC44tjg==}
     peerDependencies:
       '@hono/zod-openapi': ^0.19.2
       hono: ^4.6.11
@@ -2663,9 +2674,6 @@ packages:
 
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
-
-  better-sqlite3@11.5.0:
-    resolution: {integrity: sha512-e/6eggfOutzoK0JWiU36jsisdWoHOfN9iWiW/SieKvb7SAa6aGNmBM/UKyp+/wWSXpLlWNN8tCPwoDNPhzUvuQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -5844,12 +5852,20 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-crypto@6.1.2:
+    resolution: {integrity: sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==}
+    engines: {node: '>=16'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xpath@0.0.33:
+    resolution: {integrity: sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==}
+    engines: {node: '>=0.6.0'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -5946,7 +5962,7 @@ snapshots:
       '@hono/zod-openapi': 0.19.2(hono@4.6.15)(zod@3.24.4)
       nanoid: 5.0.8
 
-  '@authhero/kysely-adapter@10.22.0(@authhero/adapter-interfaces@0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4)))(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(kysely-bun-sqlite@0.3.2(kysely@0.27.4))(kysely-planetscale@1.5.0(@planetscale/database@1.18.0)(kysely@0.27.4))':
+  '@authhero/kysely-adapter@10.23.0(@authhero/adapter-interfaces@0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4)))(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(kysely-bun-sqlite@0.3.2(kysely@0.27.4))(kysely-planetscale@1.5.0(@planetscale/database@1.18.0)(kysely@0.27.4))':
     dependencies:
       '@authhero/adapter-interfaces': 0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))
       '@hono/zod-openapi': 0.19.2(hono@4.6.15)(zod@3.24.4)
@@ -7864,6 +7880,10 @@ snapshots:
 
   '@vue/shared@3.4.31': {}
 
+  '@xmldom/is-dom-node@1.0.1': {}
+
+  '@xmldom/xmldom@0.8.10': {}
+
   '@xyflow/react@12.6.4(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@xyflow/system': 0.0.61
@@ -8073,7 +8093,7 @@ snapshots:
 
   attr-accept@2.2.2: {}
 
-  authhero@0.157.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(typescript@5.8.3):
+  authhero@0.159.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))(hono@4.6.15)(typescript@5.8.3):
     dependencies:
       '@authhero/adapter-interfaces': 0.72.0(@hono/zod-openapi@0.19.2(hono@4.6.15)(zod@3.24.4))
       '@hono/zod-openapi': 0.19.2(hono@4.6.15)(zod@3.24.4)
@@ -8126,11 +8146,6 @@ snapshots:
       is-windows: 1.0.2
 
   better-sqlite3@11.10.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.2
-
-  better-sqlite3@11.5.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.2
@@ -11619,9 +11634,17 @@ snapshots:
 
   ws@8.18.2: {}
 
+  xml-crypto@6.1.2:
+    dependencies:
+      '@xmldom/is-dom-node': 1.0.1
+      '@xmldom/xmldom': 0.8.10
+      xpath: 0.0.33
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xpath@0.0.33: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
This is slightly experimental but looks like we should be able to use xml-crypto with the node-support on cloudflare now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SAML protocol support, including SAML metadata and authentication endpoints.
  - Introduced new endpoints for retrieving SAML metadata and handling SAML authentication requests.
- **Chores**
  - Updated dependencies to include SAML support and added a new dependency for XML cryptography.
  - Incremented package versions to reflect the new features and updates.
- **Documentation**
  - Updated changelogs to document the addition of SAML support and dependency changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->