### PR TITLE
Remove fragments from redirect_uri

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.14.4
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.163.0
+
 ## 0.14.3
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.14.3",
+  "version": "0.14.4",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.12.3",
-    "authhero": "^0.162.0",
+    "authhero": "^0.163.0",
     "better-sqlite3": "^11.5.0",
     "hono": "^4.6.15",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.163.0
+
+### Minor Changes
+
+- Remove fragments from redirect_uri
+
 ## 0.162.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.162.0",
+  "version": "0.163.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/routes/auth-api/authorize.ts
+++ b/packages/authhero/src/routes/auth-api/authorize.ts
@@ -138,7 +138,7 @@ export const authorizeRoutes = new OpenAPIHono<{
       ctx.set("tenant_id", client.tenant.id);
 
       const authParams: AuthParams = {
-        redirect_uri,
+        redirect_uri: redirect_uri.split("#")[0], // Remove fragment if present
         scope,
         state,
         client_id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authorization logic to ensure fragments are removed from redirect URIs during authentication.
* **Tests**
  * Added a test to verify that fragments are excluded from stored redirect URIs.
* **Chores**
  * Updated dependencies and version numbers for the demo app and authhero package.
  * Added changelog entries for the latest patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->