### PR TITLE
Add type to keys

### DIFF
--- a/.changeset/full-lamps-beam.md
+++ b/.changeset/full-lamps-beam.md
@@ -1,5 +1,0 @@
----
-"authhero": patch
----
-
-pnpm changeset version

--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @authhero/demo
 
+## 0.20.0
+
+### Minor Changes
+
+- Add type to keys
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [e1c0b34]
+  - authhero@0.195.0
+  - @authhero/kysely-adapter@11.0.0
+
 ## 0.19.0
 
 ### Minor Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.19.0",
+  "version": "0.20.0",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
   "dependencies": {
-    "@authhero/kysely-adapter": "^10.36.0",
+    "@authhero/kysely-adapter": "^10.37.0",
     "@hono/swagger-ui": "^0.5.2",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.13.0",
-    "authhero": "^0.194.0",
+    "authhero": "^0.195.0",
     "better-sqlite3": "^12.2.0",
     "hono": "^4.9.1",
     "hono-openapi-middlewares": "^1.0.11",

--- a/apps/demo/src/bun.ts
+++ b/apps/demo/src/bun.ts
@@ -29,9 +29,9 @@ const app = createApp({
   allowedOrigins: ["http://localhost:5173", "https://local.authhe.ro"],
 });
 
-const keys = await dataAdapter.keys.list();
+const { signingKeys } = await dataAdapter.keys.list({ q: "type:jwt_signing" });
 
-if (keys.length === 0) {
+if (signingKeys.length === 0) {
   const signingKey = await createX509Certificate({
     name: `CN=demo`,
   });

--- a/apps/demo/src/helpers/encryption.ts
+++ b/apps/demo/src/helpers/encryption.ts
@@ -54,6 +54,7 @@ export async function createX509Certificate(
     thumbprint,
     fingerprint,
     pkcs7,
+    type: "jwt_signing" as const,
   };
 }
 

--- a/packages/adapter-interfaces/CHANGELOG.md
+++ b/packages/adapter-interfaces/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @authhero/adapter-interfaces
 
+## 0.83.0
+
+### Minor Changes
+
+- Add type to keys
+
 ## 0.82.0
 
 ### Minor Changes

--- a/packages/adapter-interfaces/package.json
+++ b/packages/adapter-interfaces/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/markusahlstrand/authhero"
   },
-  "version": "0.82.0",
+  "version": "0.83.0",
   "files": [
     "dist"
   ],

--- a/packages/adapter-interfaces/src/adapters/Keys.ts
+++ b/packages/adapter-interfaces/src/adapters/Keys.ts
@@ -1,8 +1,13 @@
-import { SigningKey } from "../types";
+import { SigningKey, Totals } from "../types";
+import { ListParams } from "../types/ListParams";
+
+export interface ListKeysResponse extends Totals {
+  signingKeys: SigningKey[];
+}
 
 export interface KeysAdapter {
   create: (key: SigningKey) => Promise<void>;
-  list: () => Promise<SigningKey[]>;
+  list: (params?: ListParams) => Promise<ListKeysResponse>;
   update: (
     kid: string,
     key: Partial<Omit<SigningKey, "kid">>,

--- a/packages/adapter-interfaces/src/adapters/Roles.ts
+++ b/packages/adapter-interfaces/src/adapters/Roles.ts
@@ -2,12 +2,8 @@ import { Role, RoleInsert } from "../types";
 import { ListParams } from "../types/ListParams";
 import { Totals } from "../types";
 
-export interface ListRolesResponse {
+export interface ListRolesResponse extends Totals {
   roles: Role[];
-  totals?: Totals;
-  start: number;
-  limit: number;
-  length: number;
 }
 
 export interface RolesAdapter {

--- a/packages/adapter-interfaces/src/adapters/index.ts
+++ b/packages/adapter-interfaces/src/adapters/index.ts
@@ -50,6 +50,7 @@ export interface DataAdapters {
   userRoles: UserRolesAdapter;
 }
 
+export * from "./Keys";
 export * from "./RolePermissions";
 export * from "./UserPermissions";
 export * from "./UserRoles";

--- a/packages/adapter-interfaces/src/types/ListParams.ts
+++ b/packages/adapter-interfaces/src/types/ListParams.ts
@@ -1,7 +1,7 @@
 export interface ListParams {
-  page: number;
-  per_page: number;
-  include_totals: boolean;
+  page?: number;
+  per_page?: number;
+  include_totals?: boolean;
   q?: string;
   sort?: {
     sort_by: string;

--- a/packages/adapter-interfaces/src/types/SigningKey.ts
+++ b/packages/adapter-interfaces/src/types/SigningKey.ts
@@ -36,6 +36,12 @@ export const signingKeySchema = z.object({
     .string()
     .optional()
     .openapi({ description: "The date and time when the key was revoked" }),
+  connection: z.string().optional().openapi({
+    description: "The connection identifier associated with the key",
+  }),
+  type: z.enum(["jwt_signing", "saml_encryption"]).openapi({
+    description: "The type of the signing key",
+  }),
 });
 
 export type SigningKey = z.infer<typeof signingKeySchema>;

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,17 @@
 # authhero
 
+## 0.195.0
+
+### Minor Changes
+
+- Add type to keys
+
+### Patch Changes
+
+- e1c0b34: pnpm changeset version
+- Updated dependencies
+  - @authhero/adapter-interfaces@0.83.0
+
 ## 0.194.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.194.0",
+  "version": "0.195.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -47,9 +47,11 @@ export async function createAuthTokens(
 ): Promise<TokenResponse> {
   const { authParams, user, client, session_id } = params;
 
-  const signingKeys = await ctx.env.data.keys.list();
+  const { signingKeys } = await ctx.env.data.keys.list({
+    q: "type:jwt_signing",
+  });
   const validKeys = signingKeys.filter(
-    (key) => !key.revoked_at || new Date(key.revoked_at) > new Date(),
+    (key: any) => !key.revoked_at || new Date(key.revoked_at) > new Date(),
   );
   const signingKey = validKeys[validKeys.length - 1];
 

--- a/packages/authhero/src/routes/saml/samlp.ts
+++ b/packages/authhero/src/routes/saml/samlp.ts
@@ -50,9 +50,12 @@ export const samlpRoutes = new OpenAPIHono<{
         });
       }
 
-      const signingKeys = await ctx.env.data.keys.list();
+      // TODO: This should be a saml_encryption certificate soon
+      const { signingKeys } = await ctx.env.data.keys.list({
+        q: "type:jwt_signing",
+      });
 
-      if (!signingKeys.length) {
+      if (signingKeys.length === 0) {
         throw new HTTPException(500, {
           message: "No signing key found",
         });

--- a/packages/authhero/src/strategies/saml.ts
+++ b/packages/authhero/src/strategies/saml.ts
@@ -90,8 +90,12 @@ export async function samlCallback(
     });
   }
 
-  const [signingKey] = await ctx.env.data.keys.list();
+  // TODO: This should be a saml_encryption certificate soon
+  const { signingKeys } = await ctx.env.data.keys.list({
+    q: "type:jwt_signing",
+  });
 
+  const [signingKey] = signingKeys;
   if (!signingKey) {
     throw new HTTPException(500, {
       message: "No signing key found",

--- a/packages/authhero/src/utils/encryption.ts
+++ b/packages/authhero/src/utils/encryption.ts
@@ -53,6 +53,7 @@ export async function createX509Certificate(
     thumbprint,
     fingerprint,
     pkcs7,
+    type: "jwt_signing" as const,
   };
 }
 

--- a/packages/authhero/src/utils/jwks.ts
+++ b/packages/authhero/src/utils/jwks.ts
@@ -6,9 +6,11 @@ import { X509Certificate } from "@peculiar/x509";
  * This can be used when JWKS_URL is not available or when running outside Cloudflare
  */
 export async function getJwksFromDatabase(data: DataAdapters) {
-  const signingKeys = await data.keys.list();
+  const { signingKeys } = await data.keys.list({
+    q: "type:jwt_signing",
+  });
   const keys = await Promise.all(
-    signingKeys.map(async (signingKey) => {
+    signingKeys.map(async (signingKey: any) => {
       const importedCert = new X509Certificate(signingKey.cert);
       const publicKey = await importedCert.publicKey.export();
       const jwkKey = await crypto.subtle.exportKey("jwk", publicKey);

--- a/packages/authhero/test/routes/auth-api/authenticate.spec.ts
+++ b/packages/authhero/test/routes/auth-api/authenticate.spec.ts
@@ -73,10 +73,10 @@ describe("authenticate", () => {
 
     expect(loginResponse.status).toEqual(403);
 
-    const logsResults = await env.data.logs.list("tenantId");
-    expect(logsResults).toHaveLength(1);
+    const { logs } = await env.data.logs.list("tenantId");
+    expect(logs).toHaveLength(1);
 
-    const [failedLoginLog] = logsResults.logs;
+    const [failedLoginLog] = logs;
     expect(failedLoginLog).toMatchObject({
       type: "fp",
       description: "Invalid user",
@@ -117,10 +117,9 @@ describe("authenticate", () => {
 
     expect(loginResponse.status).toEqual(403);
 
-    const logsResults = await env.data.logs.list("tenantId");
-    expect(logsResults).toHaveLength(1);
+    const { logs } = await env.data.logs.list("tenantId");
 
-    const [failedLoginLog] = logsResults.logs;
+    const [failedLoginLog] = logs;
     expect(failedLoginLog).toMatchObject({
       type: "fp",
       description: "Invalid password",
@@ -177,11 +176,10 @@ describe("authenticate", () => {
 
     expect(loginResponse.status).toEqual(403);
 
-    const logsResults = await env.data.logs.list("tenantId");
-    expect(logsResults).toHaveLength(4);
+    const { logs } = await env.data.logs.list("tenantId");
+    expect(logs).toHaveLength(4);
 
-    const [failedLoginLog] = logsResults.logs;
-    expect(failedLoginLog).toMatchObject({
+    expect(logs[0]).toMatchObject({
       type: "fp",
       description: "Invalid password",
     });

--- a/packages/authhero/test/routes/auth-api/callback.spec.ts
+++ b/packages/authhero/test/routes/auth-api/callback.spec.ts
@@ -109,7 +109,7 @@ describe("callback", () => {
     const redirectUri = new URL(location);
     expect(redirectUri.pathname).toEqual("/callback");
 
-    const logs = await env.data.logs.list("tenantId");
+    const { logs } = await env.data.logs.list("tenantId");
     expect(logs).toHaveLength(1);
 
     const user = await env.data.users.get("tenantId", "email|userId");

--- a/packages/authhero/test/routes/auth-api/dbconnections.spec.ts
+++ b/packages/authhero/test/routes/auth-api/dbconnections.spec.ts
@@ -38,7 +38,7 @@ describe("dbconnections", () => {
       });
       expect(createdUser._id).toBeTypeOf("string");
 
-      const logs = await env.data.logs.list("tenantId");
+      const { logs } = await env.data.logs.list("tenantId");
       expect(logs.length).toBe(1);
 
       const emails = getSentEmails();

--- a/packages/authhero/test/routes/universal-login/account.spec.ts
+++ b/packages/authhero/test/routes/universal-login/account.spec.ts
@@ -145,11 +145,8 @@ describe("account", () => {
     // -----------------------------------
     // Verify that there is a log entry for the email change
     // -----------------------------------
-    const logs = await env.data.logs.list("tenantId", {
+    const { logs } = await env.data.logs.list("tenantId", {
       q: `user_id:email|userId type:${LogTypes.SUCCESS_CHANGE_EMAIL}`,
-      page: 0,
-      per_page: 10,
-      include_totals: false,
     });
     expect(logs).toHaveLength(1);
   });

--- a/packages/cloudflare/CHANGELOG.md
+++ b/packages/cloudflare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/cloudflare-adapter
 
+## 1.22.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @authhero/adapter-interfaces@0.83.0
+
 ## 1.21.0
 
 ### Patch Changes

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/markusahlstrand/authhero"
   },
-  "version": "1.21.0",
+  "version": "1.22.0",
   "files": [
     "dist"
   ],

--- a/packages/drizzle/CHANGELOG.md
+++ b/packages/drizzle/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @authhero/drizzle
 
+## 0.3.11
+
+### Minor Changes
+
+- Add type to keys
+
+### Patch Changes
+
+- Updated dependencies
+  - @authhero/adapter-interfaces@0.83.0
+
 ## 0.3.10
 
 ### Patch Changes

--- a/packages/drizzle/drizzle/schema.ts
+++ b/packages/drizzle/drizzle/schema.ts
@@ -197,15 +197,22 @@ export const keys = mysqlTable(
   "keys",
   {
     kid: varchar({ length: 255 }).notNull(),
-    tenantId: varchar("tenant_id", { length: 255 }),
+    tenantId: varchar("tenant_id", { length: 255 }).references(
+      () => tenants.id,
+      { onDelete: "cascade" },
+    ),
     createdAt: varchar("created_at", { length: 255 }).notNull(),
     revokedAt: varchar("revoked_at", { length: 255 }),
-    cert: varchar({ length: 2048 }),
-    pkcs7: varchar({ length: 2048 }),
+    cert: varchar({ length: 4096 }),
+    pkcs7: varchar({ length: 4096 }),
     fingerprint: varchar({ length: 256 }),
     thumbprint: varchar({ length: 256 }),
     currentSince: varchar("current_since", { length: 256 }),
     currentUntil: varchar("current_until", { length: 256 }),
+    connection: varchar({ length: 255 }).references(() => connections.id, {
+      onDelete: "cascade",
+    }),
+    type: varchar({ length: 50 }).notNull().default("jwt_signing"),
   },
   (table) => [primaryKey({ columns: [table.kid], name: "keys_kid" })],
 );

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/markusahlstrand/authhero"
   },
-  "version": "0.3.10",
+  "version": "0.3.11",
   "files": [
     "dist"
   ],

--- a/packages/kysely/CHANGELOG.md
+++ b/packages/kysely/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @authhero/kysely-adapter
 
+## 10.37.0
+
+### Minor Changes
+
+- Add type to keys
+
+### Patch Changes
+
+- Updated dependencies
+  - @authhero/adapter-interfaces@0.83.0
+
 ## 10.36.0
 
 ### Minor Changes

--- a/packages/kysely/migrate/migrations/2023-12-26T10:58:00_signing-keys.ts
+++ b/packages/kysely/migrate/migrations/2023-12-26T10:58:00_signing-keys.ts
@@ -8,17 +8,21 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .addColumn("tenant_id", "varchar(255)", (col) =>
       col.references("tenants.id").onDelete("cascade"),
     )
-    // This will be removed in a future migration
-    // .addColumn("private_key", "varchar(8192)", (col) => col.notNull())
-    // .addColumn("public_key", "varchar(1024)", (col) => col.notNull())
+
     .addColumn("created_at", "varchar(255)", (col) => col.notNull())
     .addColumn("revoked_at", "varchar(255)")
-    .addColumn("cert", "varchar(2048)")
-    .addColumn("pkcs7", "varchar(2048)")
+    .addColumn("cert", "varchar(4096)")
+    .addColumn("pkcs7", "varchar(4096)")
     .addColumn("fingerprint", "varchar(256)")
     .addColumn("thumbprint", "varchar(256)")
     .addColumn("current_since", "varchar(256)")
     .addColumn("current_until", "varchar(256)")
+    .addColumn("type", "varchar(50)", (col) =>
+      col.notNull().defaultTo("jwt_signing"),
+    )
+    .addColumn("connection", "varchar(255)", (col) =>
+      col.references("connections.id").onDelete("cascade"),
+    )
     .execute();
 }
 

--- a/packages/kysely/migrate/migrations/2025-08-20T12:00:00_keys_connection_and_extend_columns.ts
+++ b/packages/kysely/migrate/migrations/2025-08-20T12:00:00_keys_connection_and_extend_columns.ts
@@ -1,0 +1,50 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/db";
+
+export async function up(_: Kysely<Database>): Promise<void> {
+  // export async function up(db: Kysely<Database>): Promise<void> {
+  // Add connection column to keys table with foreign key constraint
+  //   await db.schema
+  //     .alterTable("keys")
+  //     .addColumn("connection", "varchar(255)", (col) =>
+  //       col.references("connections.id").onDelete("cascade"),
+  //     )
+  //     .execute();
+  //   // Extend cert column from varchar(2048) to varchar(4096)
+  //   await db.schema
+  //     .alterTable("keys")
+  //     .alterColumn("cert", (col) => col.setDataType("varchar(4096)"))
+  //     .execute();
+  //   // Extend pkcs7 column from varchar(2048) to varchar(4096)
+  //   await db.schema
+  //     .alterTable("keys")
+  //     .alterColumn("pkcs7", (col) => col.setDataType("varchar(4096)"))
+  //     .execute();
+  // Add type column to keys table with default value for existing records
+  //   await db.schema
+  //     .alterTable("keys")
+  //     .addColumn("type", "varchar(50)", (col) =>
+  //       col.notNull().defaultTo("jwt_signing"),
+  //     )
+  // .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  // Remove connection column (this will also drop the foreign key constraint)
+  await db.schema.alterTable("keys").dropColumn("connection").execute();
+
+  // Revert cert column back to varchar(2048)
+  await db.schema
+    .alterTable("keys")
+    .alterColumn("cert", (col) => col.setDataType("varchar(2048)"))
+    .execute();
+
+  // Revert pkcs7 column back to varchar(2048)
+  await db.schema
+    .alterTable("keys")
+    .alterColumn("pkcs7", (col) => col.setDataType("varchar(2048)"))
+    .execute();
+
+  // Remove type column
+  await db.schema.alterTable("keys").dropColumn("type").execute();
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -90,6 +90,7 @@ import * as n90_themes from "./2025-07-23T14:30:00_themes";
 import * as n91_resource_servers_rules_permissions from "./2025-08-11T12:00:00_resource_servers_rules_permissions";
 import * as n92_role_permissions from "./2025-08-13T15:00:00_role_user_permissions";
 import * as n93_add_permissions_to_roles from "./2025-08-14T09:30:00_user_roles";
+import * as n94_keys_connection_and_extend_columns from "./2025-08-20T12:00:00_keys_connection_and_extend_columns";
 
 // These need to be in alphabetic order
 export default {
@@ -185,4 +186,5 @@ export default {
   n91_resource_servers_rules_permissions,
   n92_role_permissions,
   n93_add_permissions_to_roles,
+  n94_keys_connection_and_extend_columns,
 };

--- a/packages/kysely/package.json
+++ b/packages/kysely/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/markusahlstrand/authhero"
   },
-  "version": "10.36.0",
+  "version": "10.37.0",
   "files": [
     "dist"
   ],

--- a/packages/kysely/src/codes/list.ts
+++ b/packages/kysely/src/codes/list.ts
@@ -12,27 +12,19 @@ import getCountAsInt from "../utils/getCountAsInt";
 export function list(db: Kysely<Database>) {
   return async (
     tenant_id: string,
-    params: ListParams = {
-      page: 0,
-      per_page: 50,
-      include_totals: false,
-    },
+    params: ListParams = {},
   ): Promise<ListCodesResponse> => {
+    const { page = 0, per_page = 50, include_totals = false, q } = params;
+
     let query = db.selectFrom("codes").where("codes.tenant_id", "=", tenant_id);
 
-    if (params.q) {
-      query = luceneFilter(db, query, params.q, ["code", "login_id"]);
+    if (q) {
+      query = luceneFilter(db, query, q, ["code", "login_id"]);
     }
 
-    const filteredQuery = query
-      .offset(params.page * params.per_page)
-      .limit(params.per_page);
+    const filteredQuery = query.offset(page * per_page).limit(per_page);
 
     const results = await filteredQuery.selectAll().execute();
-
-    const { count } = await query
-      .select((eb) => eb.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
 
     const codes = results.map((hook) => {
       const { tenant_id, ...rest } = hook;
@@ -40,10 +32,23 @@ export function list(db: Kysely<Database>) {
       return codeSchema.parse(removeNullProperties(rest));
     });
 
+    if (!include_totals) {
+      return {
+        codes,
+        start: 0,
+        limit: 0,
+        length: 0,
+      };
+    }
+
+    const { count } = await query
+      .select((eb) => eb.fn.countAll().as("count"))
+      .executeTakeFirstOrThrow();
+
     return {
       codes,
-      start: params.page * params.per_page,
-      limit: params.per_page,
+      start: page * per_page,
+      limit: per_page,
       length: getCountAsInt(count),
     };
   };

--- a/packages/kysely/src/connections/list.ts
+++ b/packages/kysely/src/connections/list.ts
@@ -12,23 +12,19 @@ import getCountAsInt from "../utils/getCountAsInt";
 export function list(db: Kysely<Database>) {
   return async (
     tenantId: string,
-    params: ListParams = {
-      page: 0,
-      per_page: 50,
-      include_totals: false,
-    },
+    params: ListParams = {},
   ): Promise<ListConnectionsResponse> => {
+    const { page = 0, per_page = 50, include_totals = false, q } = params;
+
     let query = db
       .selectFrom("connections")
       .where("connections.tenant_id", "=", tenantId);
 
-    if (params.q) {
-      query = luceneFilter(db, query, params.q, ["user_id", "ip"]);
+    if (q) {
+      query = luceneFilter(db, query, q, ["user_id", "ip"]);
     }
 
-    const filteredQuery = query
-      .offset(params.page * params.per_page)
-      .limit(params.per_page);
+    const filteredQuery = query.offset(page * per_page).limit(per_page);
 
     const dbConnections = await filteredQuery.selectAll().execute();
     const connections: Connection[] = dbConnections.map((connection) =>
@@ -38,14 +34,23 @@ export function list(db: Kysely<Database>) {
       }),
     );
 
+    if (!include_totals) {
+      return {
+        connections,
+        start: 0,
+        limit: 0,
+        length: 0,
+      };
+    }
+
     const { count } = await query
       .select((eb) => eb.fn.countAll().as("count"))
       .executeTakeFirstOrThrow();
 
     return {
       connections,
-      start: params.page * params.per_page,
-      limit: params.per_page,
+      start: page * per_page,
+      limit: per_page,
       length: getCountAsInt(count),
     };
   };

--- a/packages/kysely/src/keys/list.ts
+++ b/packages/kysely/src/keys/list.ts
@@ -1,20 +1,72 @@
 import { Kysely } from "kysely";
 import { Database } from "../db";
-import { SigningKey } from "@authhero/adapter-interfaces";
+import { ListParams, SigningKey, Totals } from "@authhero/adapter-interfaces";
+import { luceneFilter } from "../helpers/filter";
+import getCountAsInt from "../utils/getCountAsInt";
+
+interface ListKeysResponse extends Totals {
+  signingKeys: SigningKey[];
+}
 
 export function list(db: Kysely<Database>) {
-  return async (): Promise<SigningKey[]> => {
-    const keys = await db
+  return async (params: ListParams = {}): Promise<ListKeysResponse> => {
+    const {
+      page = 0,
+      per_page = 100,
+      include_totals = false,
+      sort,
+      q,
+    } = params;
+    let query = db
       .selectFrom("keys")
       .where((eb) =>
         eb.or([
           eb("revoked_at", ">", new Date().toISOString()),
           eb("revoked_at", "is", null),
         ]),
-      )
-      .selectAll()
-      .execute();
+      );
 
-    return keys;
+    // Apply search filter if provided
+    if (q) {
+      query = luceneFilter(db, query, q, [
+        "kid",
+        "connection",
+        "fingerprint",
+        "thumbprint",
+        "type",
+      ]);
+    }
+
+    let countQuery = query.select((eb) => eb.fn.count("kid").as("count"));
+
+    const offset = page * per_page;
+
+    query = query.limit(per_page).offset(offset);
+
+    // Add sorting if specified
+    if (sort) {
+      query = query.orderBy(sort.sort_by as any, sort.sort_order);
+    }
+
+    const keys = await query.selectAll().execute();
+
+    if (!include_totals) {
+      return {
+        signingKeys: keys,
+        start: 0,
+        limit: 0,
+        length: 0,
+      };
+    }
+
+    const countResult = await countQuery.executeTakeFirst();
+    const total = getCountAsInt(countResult?.count ?? 0);
+
+    return {
+      signingKeys: keys,
+      start: offset,
+      limit: per_page,
+      length: total,
+    };
   };
 }

--- a/packages/kysely/src/logs/list.ts
+++ b/packages/kysely/src/logs/list.ts
@@ -6,44 +6,45 @@ import { Database } from "../db";
 import getCountAsInt from "../utils/getCountAsInt";
 
 export function listLogs(db: Kysely<Database>) {
-  return async (
-    tenant_id: string,
-    params: ListParams = {
-      page: 0,
-      per_page: 50,
-      include_totals: false,
-    },
-  ) => {
+  return async (tenant_id: string, params: ListParams = {}) => {
+    const { page = 0, per_page = 50, include_totals = false, sort, q } = params;
+
     let query = db.selectFrom("logs").where("logs.tenant_id", "=", tenant_id);
 
-    if (params.q) {
-      query = luceneFilter(db, query, params.q, ["user_id", "ip"]);
+    if (q) {
+      query = luceneFilter(db, query, q, ["user_id", "ip"]);
     }
 
     let filteredQuery = query;
 
-    if (params.sort && params.sort.sort_by) {
+    if (sort && sort.sort_by) {
       const { ref } = db.dynamic;
-      filteredQuery = filteredQuery.orderBy(
-        ref(params.sort.sort_by),
-        params.sort.sort_order,
-      );
+      filteredQuery = filteredQuery.orderBy(ref(sort.sort_by), sort.sort_order);
     }
 
-    filteredQuery = filteredQuery
-      .offset(params.page * params.per_page)
-      .limit(params.per_page);
+    filteredQuery = filteredQuery.offset(page * per_page).limit(per_page);
 
     const logs = await filteredQuery.selectAll().execute();
+
+    const mappedLogs = logs.map(getLogResponse);
+
+    if (!include_totals) {
+      return {
+        logs: mappedLogs,
+        start: 0,
+        limit: 0,
+        length: 0,
+      };
+    }
 
     const { count } = await query
       .select((eb) => eb.fn.countAll().as("count"))
       .executeTakeFirstOrThrow();
 
     return {
-      logs: logs.map(getLogResponse),
-      start: params.page * params.per_page,
-      limit: params.per_page,
+      logs: mappedLogs,
+      start: page * per_page,
+      limit: per_page,
       length: getCountAsInt(count),
     };
   };

--- a/packages/kysely/src/refreshTokens/list.ts
+++ b/packages/kysely/src/refreshTokens/list.ts
@@ -10,35 +10,46 @@ import getCountAsInt from "../utils/getCountAsInt";
 export function list(db: Kysely<Database>) {
   return async (
     tenant_id: string,
-    params: ListParams = {
-      page: 0,
-      per_page: 50,
-      include_totals: false,
-    },
+    params: ListParams = {},
   ): Promise<ListRefreshTokenResponse> => {
+    const { page = 0, per_page = 50, include_totals = false, sort, q } = params;
+
     let query = db
       .selectFrom("refresh_tokens")
       .where("refresh_tokens.tenant_id", "=", tenant_id);
 
-    if (params.q) {
-      query = luceneFilter(db, query, params.q, ["token", "session_id"]);
+    if (q) {
+      query = luceneFilter(db, query, q, ["token", "session_id"]);
     }
 
     let filteredQuery = query;
 
-    if (params.sort && params.sort.sort_by) {
+    if (sort && sort.sort_by) {
       const { ref } = db.dynamic;
-      filteredQuery = filteredQuery.orderBy(
-        ref(params.sort.sort_by),
-        params.sort.sort_order,
-      );
+      filteredQuery = filteredQuery.orderBy(ref(sort.sort_by), sort.sort_order);
     }
 
-    filteredQuery = filteredQuery
-      .offset(params.page * params.per_page)
-      .limit(params.per_page);
+    filteredQuery = filteredQuery.offset(page * per_page).limit(per_page);
 
     const refresh_tokens = await filteredQuery.selectAll().execute();
+
+    const mappedTokens = refresh_tokens.map((refresh_token) => ({
+      ...refresh_token,
+      rotating: !!refresh_token.rotating,
+      device: refresh_token.device ? JSON.parse(refresh_token.device) : {},
+      resource_servers: refresh_token.resource_servers
+        ? JSON.parse(refresh_token.resource_servers)
+        : [],
+    }));
+
+    if (!include_totals) {
+      return {
+        refresh_tokens: mappedTokens,
+        start: 0,
+        limit: 0,
+        length: 0,
+      };
+    }
 
     const { count } = await query
       .select((eb) => eb.fn.countAll().as("count"))
@@ -47,16 +58,9 @@ export function list(db: Kysely<Database>) {
     const countInt = getCountAsInt(count);
 
     return {
-      refresh_tokens: refresh_tokens.map((refresh_token) => ({
-        ...refresh_token,
-        rotating: !!refresh_token.rotating,
-        device: refresh_token.device ? JSON.parse(refresh_token.device) : {},
-        resource_servers: refresh_token.resource_servers
-          ? JSON.parse(refresh_token.resource_servers)
-          : [],
-      })),
-      start: params.page * params.per_page,
-      limit: params.per_page,
+      refresh_tokens: mappedTokens,
+      start: page * per_page,
+      limit: per_page,
       length: countInt,
     };
   };

--- a/packages/kysely/src/roles/list.ts
+++ b/packages/kysely/src/roles/list.ts
@@ -7,19 +7,28 @@ import { luceneFilter } from "../helpers/filter";
 export function list(db: Kysely<Database>) {
   return async (
     tenantId: string,
-    params: ListParams = { page: 0, per_page: 50, include_totals: false },
+    params: ListParams,
   ): Promise<ListRolesResponse> => {
     let query = db.selectFrom("roles").where("roles.tenant_id", "=", tenantId);
+
+    const { page = 0, per_page = 50, include_totals = false } = params;
 
     if (params.q) {
       query = luceneFilter(db, query, params.q, ["name"]);
     }
 
-    const filteredQuery = query
-      .offset(params.page * params.per_page)
-      .limit(params.per_page);
+    const filteredQuery = query.offset(page * per_page).limit(per_page);
 
     const roles = await filteredQuery.selectAll().execute();
+
+    if (!include_totals) {
+      return {
+        roles,
+        start: page * per_page,
+        limit: per_page,
+        length: roles.length,
+      };
+    }
 
     const { count } = await query
       .select((eb) => eb.fn.countAll().as("count"))
@@ -27,8 +36,8 @@ export function list(db: Kysely<Database>) {
 
     return {
       roles,
-      start: params.page * params.per_page,
-      limit: params.per_page,
+      start: page * per_page,
+      limit: per_page,
       length: getCountAsInt(count),
     };
   };

--- a/packages/kysely/src/sessions/list.ts
+++ b/packages/kysely/src/sessions/list.ts
@@ -10,35 +10,43 @@ import getCountAsInt from "../utils/getCountAsInt";
 export function list(db: Kysely<Database>) {
   return async (
     tenant_id: string,
-    params: ListParams = {
-      page: 0,
-      per_page: 50,
-      include_totals: false,
-    },
+    params: ListParams = {},
   ): Promise<ListSesssionsResponse> => {
+    const { page = 0, per_page = 50, include_totals = false, sort, q } = params;
+
     let query = db
       .selectFrom("sessions")
       .where("sessions.tenant_id", "=", tenant_id);
 
-    if (params.q) {
-      query = luceneFilter(db, query, params.q, ["user_id", "session_id"]);
+    if (q) {
+      query = luceneFilter(db, query, q, ["user_id", "session_id"]);
     }
 
     let filteredQuery = query;
 
-    if (params.sort && params.sort.sort_by) {
+    if (sort && sort.sort_by) {
       const { ref } = db.dynamic;
-      filteredQuery = filteredQuery.orderBy(
-        ref(params.sort.sort_by),
-        params.sort.sort_order,
-      );
+      filteredQuery = filteredQuery.orderBy(ref(sort.sort_by), sort.sort_order);
     }
 
-    filteredQuery = filteredQuery
-      .offset(params.page * params.per_page)
-      .limit(params.per_page);
+    filteredQuery = filteredQuery.offset(page * per_page).limit(per_page);
 
     const sessions = await filteredQuery.selectAll().execute();
+
+    const mappedSessions = sessions.map((session) => ({
+      ...session,
+      device: JSON.parse(session.device),
+      clients: JSON.parse(session.clients),
+    }));
+
+    if (!include_totals) {
+      return {
+        sessions: mappedSessions,
+        start: 0,
+        limit: 0,
+        length: 0,
+      };
+    }
 
     const { count } = await query
       .select((eb) => eb.fn.countAll().as("count"))
@@ -47,13 +55,9 @@ export function list(db: Kysely<Database>) {
     const countInt = getCountAsInt(count);
 
     return {
-      sessions: sessions.map((session) => ({
-        ...session,
-        device: JSON.parse(session.device),
-        clients: JSON.parse(session.clients),
-      })),
-      start: params.page * params.per_page,
-      limit: params.per_page,
+      sessions: mappedSessions,
+      start: page * per_page,
+      limit: per_page,
       length: countInt,
     };
   };

--- a/packages/kysely/src/tenants/list.ts
+++ b/packages/kysely/src/tenants/list.ts
@@ -5,33 +5,29 @@ import { ListParams } from "@authhero/adapter-interfaces";
 import getCountAsInt from "../utils/getCountAsInt";
 
 export function list(db: Kysely<Database>) {
-  return async (
-    params: ListParams = {
-      page: 0,
-      per_page: 50,
-      include_totals: false,
-    },
-  ) => {
+  return async (params: ListParams) => {
     let query = db.selectFrom("tenants");
 
-    if (params.sort && params.sort.sort_by) {
+    const { page = 0, per_page = 50, include_totals = false, sort, q } = params;
+
+    if (sort && sort.sort_by) {
       const { ref } = db.dynamic;
-      query = query.orderBy(ref(params.sort.sort_by), params.sort.sort_order);
+      query = query.orderBy(ref(sort.sort_by), sort.sort_order);
     }
 
-    if (params.q) {
-      query = query.where((eb) => eb.or([eb("name", "like", `%${params.q}%`)]));
+    if (q) {
+      query = query.where((eb) => eb.or([eb("name", "like", `%${q}%`)]));
     }
 
-    const filteredQuery = query
-      .offset(params.page * params.per_page)
-      .limit(params.per_page);
+    const filteredQuery = query.offset(page * per_page).limit(per_page);
 
     const tenants = await filteredQuery.selectAll().execute();
 
-    if (!params.include_totals) {
+    const mappedTenants = tenants.map(removeNullProperties);
+
+    if (!include_totals) {
       return {
-        tenants,
+        tenants: mappedTenants,
       };
     }
 
@@ -42,9 +38,9 @@ export function list(db: Kysely<Database>) {
     const countInt = getCountAsInt(count);
 
     return {
-      tenants: tenants.map(removeNullProperties),
-      start: (params.page - 1) * params.per_page,
-      limit: params.per_page,
+      tenants: mappedTenants,
+      start: page * per_page,
+      limit: per_page,
       length: countInt,
     };
   };

--- a/packages/kysely/test/connections/list.spec.ts
+++ b/packages/kysely/test/connections/list.spec.ts
@@ -24,7 +24,9 @@ describe("connections", () => {
         },
       });
 
-      const connections = await data.connections.list("tenantId");
+      const connections = await data.connections.list("tenantId", {
+        include_totals: true,
+      });
 
       expect(connections).toMatchObject({
         connections: [

--- a/packages/kysely/test/forms/list.spec.ts
+++ b/packages/kysely/test/forms/list.spec.ts
@@ -18,7 +18,9 @@ describe("forms", () => {
         name: "Basic Form",
       });
 
-      const result = await data.forms.list("tenantId");
+      const result = await data.forms.list("tenantId", {
+        include_totals: true,
+      });
 
       expect(result).toMatchObject({
         forms: [
@@ -51,7 +53,9 @@ describe("forms", () => {
         name: "Contact Form",
       });
 
-      const result = await data.forms.list("tenantId");
+      const result = await data.forms.list("tenantId", {
+        include_totals: true,
+      });
 
       expect(result.forms).toHaveLength(2);
       expect(result.length).toBe(2);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Keys now include a type (e.g., jwt_signing), enabling typed creation and filtered listing. Management and SAML flows use signing keys explicitly.

- Improvements
  - List endpoints accept optional pagination/filters and can return totals; responses are more consistent.
  - Key storage expanded: larger certificate fields and optional connection association for better organization.

- Documentation
  - Changelogs updated across packages to reflect changes.

- Chores
  - Version bumps across packages to align with the updated interfaces and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->