### PR TITLE
Export cloudflare cache

### DIFF
--- a/packages/cloudflare/CHANGELOG.md
+++ b/packages/cloudflare/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @authhero/cloudflare-adapter
 
+## 1.27.0
+
+### Minor Changes
+
+- Export the cache
+
 ## 1.26.0
 
 ### Minor Changes

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/markusahlstrand/authhero"
   },
-  "version": "1.26.0",
+  "version": "1.27.0",
   "files": [
     "dist"
   ],

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -1,15 +1,30 @@
-import { CustomDomainsAdapter } from "@authhero/adapter-interfaces";
+import {
+  CustomDomainsAdapter,
+  CacheAdapter,
+} from "@authhero/adapter-interfaces";
 import { createCustomDomainsAdapter } from "./customDomains";
+import { createCloudflareCache } from "./cache";
 import { CloudflareConfig } from "./types/CloudflareConfig";
 
 export default function createAdapters(config: CloudflareConfig): {
   customDomains: CustomDomainsAdapter;
+  cache?: CacheAdapter;
 } {
-  return {
+  const adapters: {
+    customDomains: CustomDomainsAdapter;
+    cache?: CacheAdapter;
+  } = {
     customDomains: createCustomDomainsAdapter(config),
   };
-}
 
-// Export cache adapter creators separately since they have different config requirements
-export { createCloudflareCache, createGlobalCloudflareCache } from "./cache";
-export type { CloudflareCacheConfig } from "./cache";
+  // Create cache adapter if any cache config is provided
+  if (config.cacheName || config.defaultTtlSeconds || config.keyPrefix) {
+    adapters.cache = createCloudflareCache({
+      cacheName: config.cacheName,
+      defaultTtlSeconds: config.defaultTtlSeconds,
+      keyPrefix: config.keyPrefix,
+    });
+  }
+
+  return adapters;
+}

--- a/packages/cloudflare/src/types/CloudflareConfig.ts
+++ b/packages/cloudflare/src/types/CloudflareConfig.ts
@@ -6,4 +6,16 @@ export interface CloudflareConfig {
   authEmail: string;
   enterprise?: boolean;
   customDomainAdapter: CustomDomainsAdapter;
+  /**
+   * Cache name to use (optional, defaults to "default")
+   */
+  cacheName?: string;
+  /**
+   * Default TTL in seconds for cache entries (optional)
+   */
+  defaultTtlSeconds?: number;
+  /**
+   * Key prefix to namespace cache entries (optional)
+   */
+  keyPrefix?: string;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional Cloudflare cache adapter added when cache settings are provided.
  - Cache can be configured by name, default TTL, and key prefix.
  - Improved TTL handling for cache entries.

- Refactor
  - Cache resolution now uses named caches for safer, environment-aware access.
  - Cache builder consolidated into main adapter flow; legacy global helper deprecated.

- Documentation
  - Changelog added for 1.27.0 noting cache export.

- Chores
  - Version bumped to 1.27.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->