### PR TITLE
Update the edit view for clients

### DIFF
--- a/apps/react-admin/src/components/clients/edit.tsx
+++ b/apps/react-admin/src/components/clients/edit.tsx
@@ -28,14 +28,18 @@ export function ClientEdit() {
           <TextInput source="name" />
           <TextInput source="client_secret" />
           <SelectInput
-            source="email_validation"
+            source="client_metadata.email_validation"
             choices={[
               { id: "disabled", name: "Disabled" },
               { id: "enabled", name: "Enabled" },
               { id: "enforced", name: "Enforced" },
             ]}
           />
-          <BooleanInput source="disable_sign_ups" />
+          <BooleanInput
+            source="client_metadata.disable_sign_ups"
+            format={(value) => value === "true" || value === true}
+            parse={(value) => (value ? "true" : "false")}
+          />
           <ArrayInput source="callbacks">
             <SimpleFormIterator inline>
               <TextInput source="" defaultValue="" />

--- a/apps/react-admin/src/components/resource-servers/edit.tsx
+++ b/apps/react-admin/src/components/resource-servers/edit.tsx
@@ -8,6 +8,7 @@ import {
   TabbedForm,
   required,
   NumberInput,
+  FormDataConsumer,
 } from "react-admin";
 import { Stack } from "@mui/material";
 
@@ -42,16 +43,10 @@ export function ResourceServerEdit() {
           </Stack>
 
           <Stack spacing={2} direction="row" sx={{ mt: 2 }}>
-            <BooleanInput source="enforce_policies" defaultValue={true} />
             <TextInput
               source="signing_alg"
               defaultValue="RS256"
               helperText="Signing algorithm for tokens"
-            />
-            <TextInput
-              source="token_dialect"
-              defaultValue="access_token_authz"
-              helperText="Token dialect format"
             />
           </Stack>
 
@@ -71,6 +66,31 @@ export function ResourceServerEdit() {
           <Stack spacing={2} direction="row" sx={{ mt: 4 }}>
             <TextField source="created_at" />
             <TextField source="updated_at" />
+          </Stack>
+        </TabbedForm.Tab>
+
+        <TabbedForm.Tab label="RBAC">
+          <Stack spacing={3}>
+            <BooleanInput
+              source="enforce_policies"
+              label="Enable RBAC"
+              helperText="Enable Role-Based Access Control for this resource server"
+            />
+
+            <FormDataConsumer>
+              {({ formData }) => (
+                <BooleanInput
+                  source="token_dialect"
+                  label="Add permissions in token"
+                  helperText="Include permissions directly in the access token"
+                  disabled={!formData?.enforce_policies}
+                  format={(value) => value === "access_token_authz"}
+                  parse={(checked) =>
+                    checked ? "access_token_authz" : "access_token"
+                  }
+                />
+              )}
+            </FormDataConsumer>
           </Stack>
         </TabbedForm.Tab>
 

--- a/packages/authhero/test/routes/management-api/clients.spec.ts
+++ b/packages/authhero/test/routes/management-api/clients.spec.ts
@@ -85,7 +85,7 @@ describe("clients", () => {
     expect(patchResult.status).toBe(200);
     const patchedClient = await patchResult.json();
     expect(patchedClient.name).toBe("new name");
-    expect(patchedClient.client_metadata.email_validation).toBe("disabled");
+    expect(patchedClient.client_metadata?.email_validation).toBe("disabled");
 
     // --------------------------------------------
     // GET


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated RBAC tab in Resource Servers with:
    * Enable RBAC toggle.
    * “Add permissions in token” option, available only when RBAC is enabled.

* **Bug Fixes**
  * Improved reliability of Client settings:
    * “Disable sign ups” and email validation now handle true/false values consistently.
  * Resource Server token permissions setting now uses a clearer toggle while preserving existing values behind the scenes.

* **Refactor**
  * Reorganized RBAC-related settings out of Details into the new RBAC tab for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->