### PR TITLE
Add client grants

### DIFF
--- a/.changeset/rare-trees-carry.md
+++ b/.changeset/rare-trees-carry.md
@@ -1,0 +1,7 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+"@authhero/kysely-adapter": minor
+---
+
+Add client grants

--- a/packages/adapter-interfaces/src/adapters/ClientGrants.ts
+++ b/packages/adapter-interfaces/src/adapters/ClientGrants.ts
@@ -1,0 +1,24 @@
+import { ListParams } from "../types/ListParams";
+import { ClientGrant, ClientGrantInsert, Totals } from "../types";
+
+export interface ListClientGrantsResponse extends Totals {
+  client_grants: ClientGrant[];
+}
+
+export interface ClientGrantsAdapter {
+  create(
+    tenant_id: string,
+    params: ClientGrantInsert,
+  ): Promise<ClientGrant>;
+  get(tenant_id: string, id: string): Promise<ClientGrant | null>;
+  list(
+    tenant_id: string,
+    params?: ListParams,
+  ): Promise<ListClientGrantsResponse>;
+  update(
+    tenant_id: string,
+    id: string,
+    clientGrant: Partial<ClientGrantInsert>,
+  ): Promise<boolean>;
+  remove(tenant_id: string, id: string): Promise<boolean>;
+}

--- a/packages/adapter-interfaces/src/adapters/ClientGrants.ts
+++ b/packages/adapter-interfaces/src/adapters/ClientGrants.ts
@@ -6,10 +6,7 @@ export interface ListClientGrantsResponse extends Totals {
 }
 
 export interface ClientGrantsAdapter {
-  create(
-    tenant_id: string,
-    params: ClientGrantInsert,
-  ): Promise<ClientGrant>;
+  create(tenant_id: string, params: ClientGrantInsert): Promise<ClientGrant>;
   get(tenant_id: string, id: string): Promise<ClientGrant | null>;
   list(
     tenant_id: string,

--- a/packages/adapter-interfaces/src/adapters/index.ts
+++ b/packages/adapter-interfaces/src/adapters/index.ts
@@ -1,5 +1,6 @@
 import { CacheAdapter } from "./Cache";
 import { ClientsAdapter } from "./Clients";
+import { ClientGrantsAdapter } from "./ClientGrants";
 import { CodesAdapter } from "./Codes";
 import { PasswordsAdapter } from "./Passwords";
 import { SessionsAdapter } from "./Sessions";
@@ -32,6 +33,7 @@ export interface DataAdapters {
   branding: BrandingAdapter;
   cache?: CacheAdapter;
   clients: ClientsAdapter;
+  clientGrants: ClientGrantsAdapter;
   legacyClients: LegacyClientsAdapter;
   codes: CodesAdapter;
   connections: ConnectionsAdapter;
@@ -60,6 +62,7 @@ export interface DataAdapters {
 
 export * from "./Cache";
 export * from "./Clients";
+export * from "./ClientGrants";
 export * from "./Keys";
 export * from "./RolePermissions";
 export * from "./UserPermissions";

--- a/packages/adapter-interfaces/src/types/ClientGrant.ts
+++ b/packages/adapter-interfaces/src/types/ClientGrant.ts
@@ -1,0 +1,50 @@
+import { z } from "@hono/zod-openapi";
+
+export const clientGrantInsertSchema = z.object({
+  client_id: z.string().min(1).openapi({
+    description: "ID of the client.",
+  }),
+  audience: z.string().min(1).openapi({
+    description: "The audience (API identifier) of this client grant.",
+  }),
+  scope: z.array(z.string()).optional().openapi({
+    description: "Scopes allowed for this client grant.",
+  }),
+  organization_usage: z
+    .enum(["deny", "allow", "require"])
+    .optional()
+    .openapi({
+      description:
+        "Defines whether organizations can be used with client credentials exchanges for this grant.",
+    }),
+  allow_any_organization: z.boolean().optional().openapi({
+    description:
+      "If enabled, any organization can be used with this grant. If disabled (default), the grant must be explicitly assigned to the desired organizations.",
+  }),
+  is_system: z.boolean().optional().openapi({
+    description:
+      "If enabled, this grant is a special grant created by Auth0. It cannot be modified or deleted directly.",
+  }),
+  subject_type: z.enum(["client", "user"]).optional().openapi({
+    description:
+      "The type of application access the client grant allows. Use of this field is subject to the applicable Free Trial terms in Okta's Master Subscription Agreement.",
+  }),
+  authorization_details_types: z.array(z.string()).optional().openapi({
+    description:
+      "Types of authorization_details allowed for this client grant. Use of this field is subject to the applicable Free Trial terms in Okta's Master Subscription Agreement.",
+  }),
+});
+export type ClientGrantInsert = z.input<typeof clientGrantInsertSchema>;
+
+export const clientGrantSchema = z.object({
+  id: z.string().openapi({
+    description: "ID of the client grant.",
+  }),
+  ...clientGrantInsertSchema.shape,
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+export type ClientGrant = z.infer<typeof clientGrantSchema>;
+
+export const clientGrantListSchema = z.array(clientGrantSchema);
+export type ClientGrantList = z.infer<typeof clientGrantListSchema>;

--- a/packages/adapter-interfaces/src/types/index.ts
+++ b/packages/adapter-interfaces/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from "./auth0";
 export * from "./Application";
 export * from "./Client";
+export * from "./ClientGrant";
 export * from "./Flows";
 export * from "./AuthParams";
 export * from "./Branding";

--- a/packages/authhero/src/routes/management-api/client-grants.ts
+++ b/packages/authhero/src/routes/management-api/client-grants.ts
@@ -1,13 +1,72 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { Bindings } from "../../types";
 import { HTTPException } from "hono/http-exception";
-import { querySchema } from "../../types";
 import {
   clientGrantInsertSchema,
   clientGrantSchema,
   totalsSchema,
 } from "@authhero/adapter-interfaces";
-import { parseSort } from "../../utils/sort";
+
+// Auth0-compatible query schema for client grants
+const clientGrantsQuerySchema = z.object({
+  per_page: z
+    .string()
+    .min(1)
+    .optional()
+    .default("50")
+    .transform((p) => parseInt(p, 10))
+    .openapi({
+      description: "Number of results per page. Defaults to 50.",
+    }),
+  page: z
+    .string()
+    .min(0)
+    .optional()
+    .default("0")
+    .transform((p) => parseInt(p, 10))
+    .openapi({
+      description: "Page index of the results to return. First page is 0.",
+    }),
+  include_totals: z
+    .string()
+    .optional()
+    .default("false")
+    .transform((it) => it === "true")
+    .openapi({
+      description:
+        "Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).",
+    }),
+  from: z.string().optional().openapi({
+    description: "Optional Id from which to start selection.",
+  }),
+  take: z
+    .string()
+    .min(1)
+    .optional()
+    .transform((p) => (p ? parseInt(p, 10) : undefined))
+    .openapi({
+      description: "Number of results per page. Defaults to 50.",
+    }),
+  audience: z.string().optional().openapi({
+    description: "Optional filter on audience.",
+  }),
+  client_id: z.string().optional().openapi({
+    description: "Optional filter on client_id.",
+  }),
+  allow_any_organization: z
+    .string()
+    .optional()
+    .transform((val) =>
+      val === "true" ? true : val === "false" ? false : undefined,
+    )
+    .openapi({
+      description: "Optional filter on allow_any_organization.",
+    }),
+  subject_type: z.enum(["client", "user"]).optional().openapi({
+    description:
+      "EA The type of application access the client grant allows. Use of this field is subject to the applicable Free Trial terms in Okta's Master Subscription Agreement.",
+  }),
+});
 
 const clientGrantsWithTotalsSchema = totalsSchema.extend({
   client_grants: z.array(clientGrantSchema),
@@ -23,7 +82,7 @@ export const clientGrantRoutes = new OpenAPIHono<{ Bindings: Bindings }>()
       method: "get",
       path: "/",
       request: {
-        query: querySchema,
+        query: clientGrantsQuerySchema,
         headers: z.object({
           "tenant-id": z.string(),
         }),
@@ -55,16 +114,48 @@ export const clientGrantRoutes = new OpenAPIHono<{ Bindings: Bindings }>()
         page,
         per_page,
         include_totals = false,
-        sort,
-        q,
+        from,
+        take,
+        audience,
+        client_id,
+        allow_any_organization,
+        subject_type,
       } = ctx.req.valid("query");
+
+      // Build lucene query from Auth0 parameters
+      const queryParts: string[] = [];
+
+      if (client_id) {
+        queryParts.push(`client_id:"${client_id}"`);
+      }
+
+      if (audience) {
+        queryParts.push(`audience:"${audience}"`);
+      }
+
+      if (allow_any_organization !== undefined) {
+        queryParts.push(`allow_any_organization:${allow_any_organization}`);
+      }
+
+      if (subject_type) {
+        queryParts.push(`subject_type:"${subject_type}"`);
+      }
+
+      if (from) {
+        queryParts.push(`id:>${from}`);
+      }
+
+      const luceneQuery =
+        queryParts.length > 0 ? queryParts.join(" AND ") : undefined;
+
+      // Use take parameter if provided, otherwise use per_page
+      const actualPerPage = take ?? per_page;
 
       const result = await ctx.env.data.clientGrants.list(tenant_id, {
         page,
-        per_page,
+        per_page: actualPerPage,
         include_totals,
-        sort: parseSort(sort),
-        q,
+        q: luceneQuery,
       });
 
       if (!include_totals) {

--- a/packages/authhero/src/routes/management-api/client-grants.ts
+++ b/packages/authhero/src/routes/management-api/client-grants.ts
@@ -1,0 +1,285 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { Bindings } from "../../types";
+import { HTTPException } from "hono/http-exception";
+import { querySchema } from "../../types";
+import {
+  clientGrantInsertSchema,
+  clientGrantSchema,
+  totalsSchema,
+} from "@authhero/adapter-interfaces";
+import { parseSort } from "../../utils/sort";
+
+const clientGrantsWithTotalsSchema = totalsSchema.extend({
+  client_grants: z.array(clientGrantSchema),
+});
+
+export const clientGrantRoutes = new OpenAPIHono<{ Bindings: Bindings }>()
+  // --------------------------------
+  // GET /api/v2/client-grants
+  // --------------------------------
+  .openapi(
+    createRoute({
+      tags: ["client-grants"],
+      method: "get",
+      path: "/",
+      request: {
+        query: querySchema,
+        headers: z.object({
+          "tenant-id": z.string(),
+        }),
+      },
+
+      security: [
+        {
+          Bearer: ["auth:read"],
+        },
+      ],
+      responses: {
+        200: {
+          content: {
+            "application/json": {
+              schema: z.union([
+                z.array(clientGrantSchema),
+                clientGrantsWithTotalsSchema,
+              ]),
+            },
+          },
+          description: "List of client grants",
+        },
+      },
+    }),
+    async (ctx) => {
+      const { "tenant-id": tenant_id } = ctx.req.valid("header");
+
+      const {
+        page,
+        per_page,
+        include_totals = false,
+        sort,
+        q,
+      } = ctx.req.valid("query");
+
+      const result = await ctx.env.data.clientGrants.list(tenant_id, {
+        page,
+        per_page,
+        include_totals,
+        sort: parseSort(sort),
+        q,
+      });
+
+      if (!include_totals) {
+        return ctx.json(result.client_grants);
+      }
+
+      return ctx.json(result);
+    },
+  )
+  // --------------------------------
+  // GET /api/v2/client-grants/:id
+  // --------------------------------
+  .openapi(
+    createRoute({
+      tags: ["client-grants"],
+      method: "get",
+      path: "/{id}",
+      request: {
+        params: z.object({
+          id: z.string(),
+        }),
+        headers: z.object({
+          "tenant-id": z.string(),
+        }),
+      },
+
+      security: [
+        {
+          Bearer: ["auth:read"],
+        },
+      ],
+      responses: {
+        200: {
+          content: {
+            "application/json": {
+              schema: clientGrantSchema,
+            },
+          },
+          description: "A client grant",
+        },
+      },
+    }),
+    async (ctx) => {
+      const { "tenant-id": tenant_id } = ctx.req.valid("header");
+      const { id } = ctx.req.valid("param");
+
+      const clientGrant = await ctx.env.data.clientGrants.get(tenant_id, id);
+
+      if (!clientGrant) {
+        throw new HTTPException(404, {
+          message: "Client grant not found",
+        });
+      }
+
+      return ctx.json(clientGrant);
+    },
+  )
+  // --------------------------------
+  // DELETE /api/v2/client-grants/:id
+  // --------------------------------
+  .openapi(
+    createRoute({
+      tags: ["client-grants"],
+      method: "delete",
+      path: "/{id}",
+      request: {
+        params: z.object({
+          id: z.string(),
+        }),
+        headers: z.object({
+          "tenant-id": z.string(),
+        }),
+      },
+      security: [
+        {
+          Bearer: ["auth:write"],
+        },
+      ],
+      responses: {
+        200: {
+          description: "Status",
+        },
+      },
+    }),
+    async (ctx) => {
+      const { "tenant-id": tenant_id } = ctx.req.valid("header");
+      const { id } = ctx.req.valid("param");
+
+      const result = await ctx.env.data.clientGrants.remove(tenant_id, id);
+      if (!result) {
+        throw new HTTPException(404, {
+          message: "Client grant not found",
+        });
+      }
+
+      return ctx.text("OK");
+    },
+  )
+  // --------------------------------
+  // PATCH /api/v2/client-grants/:id
+  // --------------------------------
+  .openapi(
+    createRoute({
+      tags: ["client-grants"],
+      method: "patch",
+      path: "/{id}",
+      request: {
+        params: z.object({
+          id: z.string(),
+        }),
+        body: {
+          content: {
+            "application/json": {
+              schema: z.object(clientGrantInsertSchema.shape).partial(),
+            },
+          },
+        },
+        headers: z.object({
+          "tenant-id": z.string(),
+        }),
+      },
+      security: [
+        {
+          Bearer: ["auth:write"],
+        },
+      ],
+      responses: {
+        200: {
+          content: {
+            "application/json": {
+              schema: clientGrantSchema,
+            },
+          },
+          description: "The updated client grant",
+        },
+      },
+    }),
+    async (ctx) => {
+      const { "tenant-id": tenant_id } = ctx.req.valid("header");
+      const { id } = ctx.req.valid("param");
+      const body = ctx.req.valid("json");
+
+      const exists = await ctx.env.data.clientGrants.get(tenant_id, id);
+      if (!exists) {
+        throw new HTTPException(404, {
+          message: "Client grant not found",
+        });
+      }
+
+      const updated = await ctx.env.data.clientGrants.update(
+        tenant_id,
+        id,
+        body,
+      );
+
+      if (!updated) {
+        throw new HTTPException(500, {
+          message: "Failed to update client grant",
+        });
+      }
+
+      const clientGrant = await ctx.env.data.clientGrants.get(tenant_id, id);
+      if (!clientGrant) {
+        throw new HTTPException(404, {
+          message: "Client grant not found",
+        });
+      }
+      return ctx.json(clientGrant);
+    },
+  )
+  // --------------------------------
+  // POST /api/v2/client-grants
+  // --------------------------------
+  .openapi(
+    createRoute({
+      tags: ["client-grants"],
+      method: "post",
+      path: "/",
+      request: {
+        body: {
+          content: {
+            "application/json": {
+              schema: z.object(clientGrantInsertSchema.shape),
+            },
+          },
+        },
+        headers: z.object({
+          "tenant-id": z.string(),
+        }),
+      },
+      security: [
+        {
+          Bearer: ["auth:write"],
+        },
+      ],
+      responses: {
+        201: {
+          content: {
+            "application/json": {
+              schema: clientGrantSchema,
+            },
+          },
+          description: "A client grant",
+        },
+      },
+    }),
+    async (ctx) => {
+      const { "tenant-id": tenant_id } = ctx.req.valid("header");
+      const body = ctx.req.valid("json");
+
+      const clientGrant = await ctx.env.data.clientGrants.create(
+        tenant_id,
+        body,
+      );
+
+      return ctx.json(clientGrant, { status: 201 });
+    },
+  );

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -26,6 +26,7 @@ import { createInMemoryCache } from "../../adapters/cache/in-memory";
 import { formsRoutes } from "./forms";
 import { roleRoutes } from "./roles";
 import { resourceServerRoutes } from "./resource-servers";
+import { clientGrantRoutes } from "./client-grants";
 import { organizationRoutes } from "./organizations";
 // import { permissionRoutes } from "./permissions"; // Commented out - using role/user permissions instead
 
@@ -109,6 +110,7 @@ export default function create(config: AuthHeroConfig) {
     .route("/keys", keyRoutes)
     .route("/users-by-email", usersByEmailRoutes)
     .route("/clients", clientRoutes)
+    .route("/client-grants", clientGrantRoutes)
     .route("/tenants", tenantRoutes)
     .route("/logs", logRoutes)
     .route("/hooks", hooksRoutes)

--- a/packages/authhero/test/routes/management-api/client-grants.spec.ts
+++ b/packages/authhero/test/routes/management-api/client-grants.spec.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { testClient } from "hono/testing";
+import { getAdminToken } from "../../helpers/token";
+import { getTestServer } from "../../helpers/test-server";
+
+describe("client-grants", () => {
+  let managementClient: any;
+  let token: string;
+
+  beforeEach(async () => {
+    const { managementApp, env } = await getTestServer();
+    managementClient = testClient(managementApp, env);
+    token = await getAdminToken();
+  });
+
+  it("should support CRUD operations", async () => {
+    // First create a client and resource server that we can use for the grant
+    const createClientResponse = await managementClient.clients.$post(
+      {
+        json: {
+          client_id: "test-client-for-grants",
+          name: "Test Client for Grants",
+          callbacks: [],
+          allowed_logout_urls: [],
+          allowed_origins: [],
+          web_origins: [],
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(createClientResponse.status).toBe(201);
+    const createdClient = await createClientResponse.json();
+
+    const createResourceServerResponse = await managementClient[
+      "resource-servers"
+    ].$post(
+      {
+        json: {
+          identifier: "https://api.grants-test.com",
+          name: "Test API for Grants",
+          scopes: [
+            {
+              value: "read:users",
+              description: "Read user information",
+            },
+            {
+              value: "write:users",
+              description: "Write user information",
+            },
+          ],
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(createResourceServerResponse.status).toBe(201);
+    const createdResourceServer = await createResourceServerResponse.json();
+
+    // --------------------------------------------
+    // CREATE
+    // --------------------------------------------
+    const createClientGrantResponse = await managementClient[
+      "client-grants"
+    ].$post(
+      {
+        json: {
+          client_id: createdClient.client_id,
+          audience: createdResourceServer.identifier,
+          scope: ["read:users", "write:users"],
+          organization_usage: "allow",
+          allow_any_organization: true,
+          is_system: false,
+          subject_type: "client",
+          authorization_details_types: ["payment_initiation"],
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(createClientGrantResponse.status).toBe(201);
+    const createdClientGrant = await createClientGrantResponse.json();
+    expect(createdClientGrant.client_id).toBe(createdClient.client_id);
+    expect(createdClientGrant.audience).toBe(createdResourceServer.identifier);
+    expect(createdClientGrant.scope).toEqual(["read:users", "write:users"]);
+    expect(createdClientGrant.organization_usage).toBe("allow");
+    expect(createdClientGrant.allow_any_organization).toBe(true);
+    expect(createdClientGrant.is_system).toBe(false);
+    expect(createdClientGrant.subject_type).toBe("client");
+    expect(createdClientGrant.authorization_details_types).toEqual([
+      "payment_initiation",
+    ]);
+
+    // --------------------------------------------
+    // GET
+    // --------------------------------------------
+    const getClientGrantResponse = await managementClient["client-grants"][
+      ":id"
+    ].$get(
+      {
+        param: {
+          id: createdClientGrant.id,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(getClientGrantResponse.status).toBe(200);
+    const fetchedClientGrant = await getClientGrantResponse.json();
+    expect(fetchedClientGrant.client_id).toBe(createdClient.client_id);
+    expect(fetchedClientGrant.audience).toBe(createdResourceServer.identifier);
+
+    // --------------------------------------------
+    // LIST
+    // --------------------------------------------
+    const listClientGrantsResponse = await managementClient[
+      "client-grants"
+    ].$get(
+      {
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(listClientGrantsResponse.status).toBe(200);
+    const clientGrantsList = await listClientGrantsResponse.json();
+    expect(Array.isArray(clientGrantsList)).toBe(true);
+    expect(clientGrantsList.length).toBeGreaterThan(0);
+
+    // --------------------------------------------
+    // PATCH (Update)
+    // --------------------------------------------
+    const patchClientGrantResponse = await managementClient["client-grants"][
+      ":id"
+    ].$patch(
+      {
+        param: {
+          id: createdClientGrant.id,
+        },
+        json: {
+          scope: ["read:users"],
+          organization_usage: "deny",
+          allow_any_organization: false,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(patchClientGrantResponse.status).toBe(200);
+    const updatedClientGrant = await patchClientGrantResponse.json();
+    expect(updatedClientGrant.scope).toEqual(["read:users"]);
+    expect(updatedClientGrant.organization_usage).toBe("deny");
+    expect(updatedClientGrant.allow_any_organization).toBe(false);
+
+    // --------------------------------------------
+    // DELETE
+    // --------------------------------------------
+    const deleteClientGrantResponse = await managementClient["client-grants"][
+      ":id"
+    ].$delete(
+      {
+        param: {
+          id: createdClientGrant.id,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(deleteClientGrantResponse.status).toBe(200);
+
+    // --------------------------------------------
+    // GET 404 after deletion
+    // --------------------------------------------
+    const get404Response = await managementClient["client-grants"][":id"].$get(
+      {
+        param: {
+          id: createdClientGrant.id,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(get404Response.status).toBe(404);
+
+    // Cleanup - Delete the client and resource server
+    await managementClient.clients[":id"].$delete(
+      {
+        param: {
+          id: createdClient.client_id,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    await managementClient["resource-servers"][":id"].$delete(
+      {
+        param: {
+          id: createdResourceServer.id,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+  });
+});

--- a/packages/kysely/migrate/migrations/2025-09-18T12:00:00_client_grants.ts
+++ b/packages/kysely/migrate/migrations/2025-09-18T12:00:00_client_grants.ts
@@ -1,0 +1,51 @@
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // client_grants table
+  await db.schema
+    .createTable("client_grants")
+    .addColumn("id", "varchar(21)", (col) => col.notNull())
+    .addColumn("tenant_id", "varchar(191)", (col) =>
+      col.notNull().references("tenants.id").onDelete("cascade"),
+    )
+    .addColumn("client_id", "varchar(191)", (col) => col.notNull())
+    .addColumn("audience", "varchar(191)", (col) => col.notNull())
+    .addColumn("scope", "text", (col) => col.defaultTo("[]"))
+    .addColumn("organization_usage", "varchar(32)")
+    .addColumn("allow_any_organization", "integer", (col) => col.defaultTo(0))
+    .addColumn("is_system", "integer", (col) => col.defaultTo(0))
+    .addColumn("subject_type", "varchar(32)")
+    .addColumn("authorization_details_types", "text", (col) =>
+      col.defaultTo("[]"),
+    )
+    .addColumn("created_at", "varchar(35)", (col) => col.notNull())
+    .addColumn("updated_at", "varchar(35)", (col) => col.notNull())
+    .addPrimaryKeyConstraint("pk_client_grants", ["tenant_id", "id"])
+    .addForeignKeyConstraint(
+      "fk_client_grants_clients",
+      ["tenant_id", "client_id"],
+      "clients",
+      ["tenant_id", "client_id"],
+      (cb) => cb.onDelete("cascade"),
+    )
+    .execute();
+
+  // Unique index on tenant_id + client_id + audience
+  await db.schema
+    .createIndex("uq_client_grants_tenant_client_audience")
+    .on("client_grants")
+    .columns(["tenant_id", "client_id", "audience"])
+    .unique()
+    .execute();
+
+  // Index for audience lookups
+  await db.schema
+    .createIndex("idx_client_grants_audience")
+    .on("client_grants")
+    .columns(["audience"])
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable("client_grants").execute();
+}

--- a/packages/kysely/migrate/migrations/2025-09-19T10:56:35_drop_applications.ts
+++ b/packages/kysely/migrate/migrations/2025-09-19T10:56:35_drop_applications.ts
@@ -1,0 +1,37 @@
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // Drop the applications table
+  await db.schema.dropTable("applications").execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  // Recreate the applications table (based on the original schema)
+  await db.schema
+    .createTable("applications")
+    .addColumn("id", "varchar(21)", (col) => col.notNull())
+    .addColumn("tenant_id", "varchar(191)", (col) =>
+      col.notNull().references("tenants.id").onDelete("cascade"),
+    )
+    .addColumn("name", "varchar(255)", (col) => col.notNull())
+    .addColumn("client_secret", "varchar(255)")
+    .addColumn("callbacks", "text", (col) => col.defaultTo("[]"))
+    .addColumn("allowed_origins", "text", (col) => col.defaultTo("[]"))
+    .addColumn("web_origins", "text", (col) => col.defaultTo("[]"))
+    .addColumn("allowed_logout_urls", "text", (col) => col.defaultTo("[]"))
+    .addColumn("allowed_clients", "text", (col) => col.defaultTo("[]"))
+    .addColumn("disable_sign_ups", "integer", (col) => col.defaultTo(0))
+    .addColumn("addons", "text", (col) => col.defaultTo("{}"))
+    .addColumn("client_metadata", "text", (col) => col.defaultTo("{}"))
+    .addColumn("created_at", "varchar(35)", (col) => col.notNull())
+    .addColumn("updated_at", "varchar(35)", (col) => col.notNull())
+    .addPrimaryKeyConstraint("pk_applications", ["tenant_id", "id"])
+    .execute();
+
+  // Recreate indexes
+  await db.schema
+    .createIndex("idx_applications_tenant_id")
+    .on("applications")
+    .columns(["tenant_id"])
+    .execute();
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -96,7 +96,7 @@ import * as n96_create_user_organizations_table from "./2025-09-10T11:00:00_crea
 import * as n97_add_organization_to_user_permissions_and_roles from "./2025-09-11T12:00:00_add_organization_to_user_permissions_and_roles";
 import * as n98_clients from "./2025-09-16T12:00:00_clients";
 import * as n99_update_client_foreign_keys from "./2025-09-16T12:30:00_update_client_foreign_keys";
-import * as m001_client_grants from "./2025-09-18T12:00:00_client_grants";
+import * as o001_client_grants from "./2025-09-18T12:00:00_client_grants";
 
 // These need to be in alphabetic order
 export default {
@@ -198,5 +198,5 @@ export default {
   n97_add_organization_to_user_permissions_and_roles,
   n98_clients,
   n99_update_client_foreign_keys,
-  m001_client_grants,
+  o001_client_grants,
 };

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -96,6 +96,7 @@ import * as n96_create_user_organizations_table from "./2025-09-10T11:00:00_crea
 import * as n97_add_organization_to_user_permissions_and_roles from "./2025-09-11T12:00:00_add_organization_to_user_permissions_and_roles";
 import * as n98_clients from "./2025-09-16T12:00:00_clients";
 import * as n99_update_client_foreign_keys from "./2025-09-16T12:30:00_update_client_foreign_keys";
+import * as m001_client_grants from "./2025-09-18T12:00:00_client_grants";
 
 // These need to be in alphabetic order
 export default {
@@ -197,4 +198,5 @@ export default {
   n97_add_organization_to_user_permissions_and_roles,
   n98_clients,
   n99_update_client_foreign_keys,
+  m001_client_grants,
 };

--- a/packages/kysely/src/clientGrants/create.ts
+++ b/packages/kysely/src/clientGrants/create.ts
@@ -1,0 +1,57 @@
+import { nanoid } from "nanoid";
+import { Kysely } from "kysely";
+import { ClientGrant, ClientGrantInsert } from "@authhero/adapter-interfaces";
+import { Database, sqlClientGrantSchema } from "../db";
+import { removeNullProperties } from "../helpers/remove-nulls";
+import { z } from "@hono/zod-openapi";
+
+type ClientGrantDbInsert = z.infer<typeof sqlClientGrantSchema>;
+
+export function create(db: Kysely<Database>) {
+  return async (
+    tenant_id: string,
+    params: ClientGrantInsert,
+  ): Promise<ClientGrant> => {
+    const now = new Date().toISOString();
+    const id = nanoid();
+
+    // Extract arrays for proper handling
+    const { scope, authorization_details_types, ...rest } = params;
+
+    // Prepare data for database (arrays as JSON strings, booleans as integers)
+    const dbClientGrant: ClientGrantDbInsert = {
+      id,
+      tenant_id,
+      ...rest,
+      scope: scope ? JSON.stringify(scope) : "[]",
+      authorization_details_types: authorization_details_types
+        ? JSON.stringify(authorization_details_types)
+        : "[]",
+      // Convert booleans to integers for database storage
+      allow_any_organization: rest.allow_any_organization !== undefined 
+        ? (rest.allow_any_organization ? 1 : 0) 
+        : undefined,
+      is_system: rest.is_system !== undefined 
+        ? (rest.is_system ? 1 : 0) 
+        : undefined,
+      created_at: now,
+      updated_at: now,
+    };
+
+    await db.insertInto("client_grants").values(dbClientGrant).execute();
+
+    // Return with arrays as proper arrays for the API response
+    return removeNullProperties({
+      id,
+      tenant_id,
+      ...rest,
+      scope: scope || [],
+      authorization_details_types: authorization_details_types || [],
+      // Ensure boolean fields have proper defaults
+      allow_any_organization: rest.allow_any_organization ?? false,
+      is_system: rest.is_system ?? false,
+      created_at: now,
+      updated_at: now,
+    });
+  };
+}

--- a/packages/kysely/src/clientGrants/get.ts
+++ b/packages/kysely/src/clientGrants/get.ts
@@ -1,0 +1,45 @@
+import { Kysely } from "kysely";
+import { ClientGrant } from "@authhero/adapter-interfaces";
+import { Database } from "../db";
+import { removeNullProperties } from "../helpers/remove-nulls";
+
+export function get(db: Kysely<Database>) {
+  return async (
+    tenant_id: string,
+    id: string,
+  ): Promise<ClientGrant | null> => {
+    const result = await db
+      .selectFrom("client_grants")
+      .selectAll()
+      .where("client_grants.tenant_id", "=", tenant_id)
+      .where("client_grants.id", "=", id)
+      .executeTakeFirst();
+
+    if (!result) {
+      return null;
+    }
+
+    const clientGrant: ClientGrant = {
+      id: result.id,
+      client_id: result.client_id,
+      audience: result.audience,
+      scope: result.scope ? JSON.parse(result.scope) : [],
+      organization_usage: result.organization_usage as "deny" | "allow" | "require" | undefined,
+      // Convert integers back to booleans for API response (with defaults)
+      allow_any_organization: result.allow_any_organization !== undefined 
+        ? Boolean(result.allow_any_organization) 
+        : false,
+      is_system: result.is_system !== undefined 
+        ? Boolean(result.is_system) 
+        : false,
+      subject_type: result.subject_type as "client" | "user" | undefined,
+      authorization_details_types: result.authorization_details_types
+        ? JSON.parse(result.authorization_details_types)
+        : [],
+      created_at: result.created_at,
+      updated_at: result.updated_at,
+    };
+
+    return removeNullProperties(clientGrant);
+  };
+}

--- a/packages/kysely/src/clientGrants/index.ts
+++ b/packages/kysely/src/clientGrants/index.ts
@@ -1,0 +1,20 @@
+import { Kysely } from "kysely";
+import { ClientGrantsAdapter } from "@authhero/adapter-interfaces";
+import { Database } from "../db";
+import { create } from "./create";
+import { get } from "./get";
+import { list } from "./list";
+import { remove } from "./remove";
+import { update } from "./update";
+
+export function createClientGrantsAdapter(
+  db: Kysely<Database>,
+): ClientGrantsAdapter {
+  return {
+    create: create(db),
+    get: get(db),
+    list: list(db),
+    remove: remove(db),
+    update: update(db),
+  };
+}

--- a/packages/kysely/src/clientGrants/list.ts
+++ b/packages/kysely/src/clientGrants/list.ts
@@ -9,60 +9,63 @@ import getCountAsInt from "../utils/getCountAsInt";
 import { luceneFilter } from "../helpers/filter";
 import { removeNullProperties } from "../helpers/remove-nulls";
 
-interface ClientGrantListParams extends ListParams {
-  audience?: string;
-  client_id?: string;
-}
-
 export function list(db: Kysely<Database>) {
   return async (
     tenantId: string,
-    params: ClientGrantListParams = {},
+    params: ListParams = {},
   ): Promise<ListClientGrantsResponse> => {
-    const { page = 0, per_page = 50, include_totals = false, q, audience, client_id } = params;
+    const { page = 0, per_page = 50, include_totals = false, q, sort } = params;
 
     let query = db
       .selectFrom("client_grants")
       .where("client_grants.tenant_id", "=", tenantId);
 
-    // Handle direct parameter filtering
-    if (audience) {
-      query = query.where("client_grants.audience", "=", audience);
-    }
-    if (client_id) {
-      query = query.where("client_grants.client_id", "=", client_id);
-    }
-
     if (q) {
       const trimmedQ = q.trim();
       const parts = trimmedQ.split(/\s+/);
       const one = parts.length === 1 ? parts[0] : undefined;
-      const match = one ? one.match(/^(-)?(client_id|audience):(.*)$/) : null;
+      // Handle both quoted and unquoted values: field:"value" or field:value
+      const match = one ? one.match(/^(-)?([a-zA-Z_][a-zA-Z0-9_]*):"?([^"]*)"?$/) : null;
       const value = match ? match[3] : "";
       const hasRangeOp = /^(>=|>|<=|<)/.test(value || "");
       if (match && !hasRangeOp && value) {
         const neg = !!match[1];
-        const field =
-          match[2] === "client_id"
-            ? "client_grants.client_id"
-            : "client_grants.audience";
-        if (neg) {
-          query = query.where(field, "!=", value);
+        const fieldName = match[2];
+        const { ref } = db.dynamic;
+        const columnRef = ref(`client_grants.${fieldName}`);
+        
+        // Special handling for boolean fields that are stored as integers
+        if (fieldName === "allow_any_organization") {
+          const boolValue = value === "true" ? 1 : 0;
+          if (neg) {
+            query = query.where(columnRef, "!=", boolValue);
+          } else {
+            query = query.where(columnRef, "=", boolValue);
+          }
         } else {
-          query = query.where(field, "=", value);
+          // Generic handling for string fields
+          if (neg) {
+            query = query.where(columnRef, "!=", value);
+          } else {
+            query = query.where(columnRef, "=", value);
+          }
         }
       } else {
-        query = luceneFilter(db, query, trimmedQ, [
-          "client_grants.client_id",
-          "client_grants.audience",
-        ]);
+        query = luceneFilter(db, query, trimmedQ, []);
       }
     }
 
-    const filteredQuery = query
-      .orderBy("client_grants.created_at", "desc")
-      .limit(per_page)
-      .offset(page * per_page);
+    let filteredQuery = query;
+
+    // Add sorting if specified
+    if (sort) {
+      const { ref } = db.dynamic;
+      filteredQuery = filteredQuery.orderBy(ref(sort.sort_by), sort.sort_order);
+    } else {
+      filteredQuery = filteredQuery.orderBy("client_grants.created_at", "desc");
+    }
+
+    filteredQuery = filteredQuery.limit(per_page).offset(page * per_page);
 
     const results = await filteredQuery.selectAll().execute();
 
@@ -72,14 +75,18 @@ export function list(db: Kysely<Database>) {
         client_id: result.client_id,
         audience: result.audience,
         scope: result.scope ? JSON.parse(result.scope) : [],
-        organization_usage: result.organization_usage as "deny" | "allow" | "require" | undefined,
+        organization_usage: result.organization_usage as
+          | "deny"
+          | "allow"
+          | "require"
+          | undefined,
         // Convert integers back to booleans for API response (with defaults)
-        allow_any_organization: result.allow_any_organization !== undefined 
-          ? Boolean(result.allow_any_organization) 
-          : false,
-        is_system: result.is_system !== undefined 
-          ? Boolean(result.is_system) 
-          : false,
+        allow_any_organization:
+          result.allow_any_organization !== undefined
+            ? Boolean(result.allow_any_organization)
+            : false,
+        is_system:
+          result.is_system !== undefined ? Boolean(result.is_system) : false,
         subject_type: result.subject_type as "client" | "user" | undefined,
         authorization_details_types: result.authorization_details_types
           ? JSON.parse(result.authorization_details_types)

--- a/packages/kysely/src/clientGrants/list.ts
+++ b/packages/kysely/src/clientGrants/list.ts
@@ -1,0 +1,114 @@
+import { Kysely } from "kysely";
+import {
+  ListParams,
+  ListClientGrantsResponse,
+  ClientGrant,
+} from "@authhero/adapter-interfaces";
+import { Database } from "../db";
+import getCountAsInt from "../utils/getCountAsInt";
+import { luceneFilter } from "../helpers/filter";
+import { removeNullProperties } from "../helpers/remove-nulls";
+
+interface ClientGrantListParams extends ListParams {
+  audience?: string;
+  client_id?: string;
+}
+
+export function list(db: Kysely<Database>) {
+  return async (
+    tenantId: string,
+    params: ClientGrantListParams = {},
+  ): Promise<ListClientGrantsResponse> => {
+    const { page = 0, per_page = 50, include_totals = false, q, audience, client_id } = params;
+
+    let query = db
+      .selectFrom("client_grants")
+      .where("client_grants.tenant_id", "=", tenantId);
+
+    // Handle direct parameter filtering
+    if (audience) {
+      query = query.where("client_grants.audience", "=", audience);
+    }
+    if (client_id) {
+      query = query.where("client_grants.client_id", "=", client_id);
+    }
+
+    if (q) {
+      const trimmedQ = q.trim();
+      const parts = trimmedQ.split(/\s+/);
+      const one = parts.length === 1 ? parts[0] : undefined;
+      const match = one ? one.match(/^(-)?(client_id|audience):(.*)$/) : null;
+      const value = match ? match[3] : "";
+      const hasRangeOp = /^(>=|>|<=|<)/.test(value || "");
+      if (match && !hasRangeOp && value) {
+        const neg = !!match[1];
+        const field =
+          match[2] === "client_id"
+            ? "client_grants.client_id"
+            : "client_grants.audience";
+        if (neg) {
+          query = query.where(field, "!=", value);
+        } else {
+          query = query.where(field, "=", value);
+        }
+      } else {
+        query = luceneFilter(db, query, trimmedQ, [
+          "client_grants.client_id",
+          "client_grants.audience",
+        ]);
+      }
+    }
+
+    const filteredQuery = query
+      .orderBy("client_grants.created_at", "desc")
+      .limit(per_page)
+      .offset(page * per_page);
+
+    const results = await filteredQuery.selectAll().execute();
+
+    const clientGrants: ClientGrant[] = results.map((result) => {
+      const clientGrant: ClientGrant = {
+        id: result.id,
+        client_id: result.client_id,
+        audience: result.audience,
+        scope: result.scope ? JSON.parse(result.scope) : [],
+        organization_usage: result.organization_usage as "deny" | "allow" | "require" | undefined,
+        // Convert integers back to booleans for API response (with defaults)
+        allow_any_organization: result.allow_any_organization !== undefined 
+          ? Boolean(result.allow_any_organization) 
+          : false,
+        is_system: result.is_system !== undefined 
+          ? Boolean(result.is_system) 
+          : false,
+        subject_type: result.subject_type as "client" | "user" | undefined,
+        authorization_details_types: result.authorization_details_types
+          ? JSON.parse(result.authorization_details_types)
+          : [],
+        created_at: result.created_at,
+        updated_at: result.updated_at,
+      };
+
+      return removeNullProperties(clientGrant);
+    });
+
+    if (!include_totals) {
+      return {
+        client_grants: clientGrants,
+        start: 0,
+        limit: 0,
+        length: 0,
+      };
+    }
+
+    const { count } = await query
+      .select((eb) => eb.fn.countAll().as("count"))
+      .executeTakeFirstOrThrow();
+
+    return {
+      client_grants: clientGrants,
+      start: page * per_page,
+      limit: per_page,
+      length: getCountAsInt(count),
+    };
+  };
+}

--- a/packages/kysely/src/clientGrants/remove.ts
+++ b/packages/kysely/src/clientGrants/remove.ts
@@ -1,0 +1,14 @@
+import { Kysely } from "kysely";
+import { Database } from "../db";
+
+export function remove(db: Kysely<Database>) {
+  return async (tenant_id: string, id: string): Promise<boolean> => {
+    const result = await db
+      .deleteFrom("client_grants")
+      .where("client_grants.tenant_id", "=", tenant_id)
+      .where("client_grants.id", "=", id)
+      .executeTakeFirst();
+
+    return (result.numDeletedRows ?? 0n) > 0n;
+  };
+}

--- a/packages/kysely/src/clientGrants/update.ts
+++ b/packages/kysely/src/clientGrants/update.ts
@@ -1,0 +1,48 @@
+import { Kysely } from "kysely";
+import { ClientGrantInsert } from "@authhero/adapter-interfaces";
+import { Database } from "../db";
+
+export function update(db: Kysely<Database>) {
+  return async (
+    tenant_id: string,
+    id: string,
+    clientGrant: Partial<ClientGrantInsert>,
+  ): Promise<boolean> => {
+    const now = new Date().toISOString();
+
+    const {
+      scope,
+      authorization_details_types,
+      ...rest
+    } = clientGrant;
+
+    const dbUpdate: any = {
+      ...rest,
+      updated_at: now,
+    };
+
+    if (scope !== undefined) {
+      dbUpdate.scope = JSON.stringify(scope);
+    }
+    if (authorization_details_types !== undefined) {
+      dbUpdate.authorization_details_types = JSON.stringify(authorization_details_types);
+    }
+
+    // Convert booleans to integers for database storage
+    if (rest.allow_any_organization !== undefined) {
+      dbUpdate.allow_any_organization = rest.allow_any_organization ? 1 : 0;
+    }
+    if (rest.is_system !== undefined) {
+      dbUpdate.is_system = rest.is_system ? 1 : 0;
+    }
+
+    const result = await db
+      .updateTable("client_grants")
+      .set(dbUpdate)
+      .where("client_grants.tenant_id", "=", tenant_id)
+      .where("client_grants.id", "=", id)
+      .executeTakeFirst();
+
+    return (result.numUpdatedRows ?? 0n) > 0n;
+  };
+}

--- a/packages/kysely/src/db.ts
+++ b/packages/kysely/src/db.ts
@@ -150,6 +150,21 @@ export const sqlRoleSchema = z.object({
   updated_at: z.string(),
 });
 
+export const sqlClientGrantSchema = z.object({
+  id: z.string(),
+  tenant_id: z.string(),
+  client_id: z.string(),
+  audience: z.string(),
+  scope: z.string().optional().default("[]"), // JSON array string (stored as text)
+  organization_usage: z.string().optional(),
+  allow_any_organization: z.number().optional(), // Convert boolean to integer for SQL storage
+  is_system: z.number().optional(), // Convert boolean to integer for SQL storage
+  subject_type: z.string().optional(),
+  authorization_details_types: z.string().optional().default("[]"), // JSON array string (stored as text)
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
 export const sqlRolePermissionSchema = z.object({
   tenant_id: z.string(),
   role_id: z.string(),
@@ -236,6 +251,7 @@ export interface Database {
   applications: z.infer<typeof sqlApplicationSchema>;
   branding: z.infer<typeof sqlBrandingSchema>;
   clients: z.infer<typeof sqlClientSchema>;
+  client_grants: z.infer<typeof sqlClientGrantSchema>;
   codes: Code & { tenant_id: string };
   connections: z.infer<typeof sqlConnectionSchema>;
   custom_domains: z.infer<typeof sqlCustomDomainSchema>;

--- a/packages/kysely/src/index.ts
+++ b/packages/kysely/src/index.ts
@@ -9,6 +9,7 @@ import { createCodesAdapter } from "./codes";
 import { createApplicationsAdapter } from "./applications";
 import { createConnectionsAdapter } from "./connections";
 import { createClientsAdapter } from "./clients";
+import { createClientGrantsAdapter } from "./clientGrants";
 import { createLegacyClientsAdapter } from "./legacy-clients";
 import { createKeysAdapter } from "./keys";
 import { createCustomDomainsAdapter } from "./customDomains";
@@ -40,6 +41,7 @@ export default function createAdapters(db: Kysely<Database>): DataAdapters & {
     branding: createBrandingAdapter(db),
     cleanup: createCleanup(db),
     clients: createClientsAdapter(db),
+    clientGrants: createClientGrantsAdapter(db),
     legacyClients: createLegacyClientsAdapter(db),
     codes: createCodesAdapter(db),
     connections: createConnectionsAdapter(db),

--- a/packages/kysely/test/clientGrants.test.ts
+++ b/packages/kysely/test/clientGrants.test.ts
@@ -1,0 +1,577 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestServer } from "./helpers/test-server";
+import { ClientGrantInsert } from "@authhero/adapter-interfaces";
+
+describe("ClientGrantsAdapter", () => {
+  let adapter: any;
+  let db: any;
+  const tenantId = "test-tenant";
+
+  beforeEach(async () => {
+    const testServer = await getTestServer();
+    adapter = testServer.data;
+    db = testServer.db;
+
+    // Create a test tenant
+    await db
+      .insertInto("tenants")
+      .values({
+        id: tenantId,
+        name: "Test Tenant",
+        audience: "https://test.authhero.com/api/v2/",
+        sender_email: "test@authhero.com",
+        sender_name: "Test Sender",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
+
+    // Create a test client
+    await db
+      .insertInto("clients")
+      .values({
+        tenant_id: tenantId,
+        client_id: "test-client-id",
+        name: "Test Client",
+        client_secret: "test-secret",
+        callbacks: "[]",
+        allowed_origins: "[]",
+        web_origins: "[]",
+        client_aliases: "[]",
+        allowed_clients: "[]",
+        allowed_logout_urls: "[]",
+        session_transfer: "{}",
+        oidc_logout: "{}",
+        grant_types: "[]",
+        jwt_configuration: "{}",
+        signing_keys: "[]",
+        encryption_key: "{}",
+        addons: "{}",
+        client_metadata: "{}",
+        mobile: "{}",
+        native_social_login: "{}",
+        refresh_token: "{}",
+        default_organization: "{}",
+        client_authentication_methods: "{}",
+        signed_request_object: "{}",
+        token_quota: "{}",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
+
+    // Create a test resource server (for audience)
+    await db
+      .insertInto("resource_servers")
+      .values({
+        id: "test-api-id",
+        tenant_id: tenantId,
+        identifier: "https://test.api.com",
+        name: "Test API",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
+  });
+
+  it("should create a client grant", async () => {
+    const clientGrantData: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:users", "write:users"],
+      organization_usage: "allow",
+      allow_any_organization: false,
+      is_system: false,
+      subject_type: "client",
+      authorization_details_types: ["payment_initiation", "account_information"],
+    };
+
+    const clientGrant = await adapter.clientGrants.create(
+      tenantId,
+      clientGrantData,
+    );
+
+    expect(clientGrant).toBeDefined();
+    expect(clientGrant.id).toBeDefined();
+    expect(clientGrant.client_id).toBe("test-client-id");
+    expect(clientGrant.audience).toBe("https://test.api.com");
+    expect(clientGrant.scope).toEqual(["read:users", "write:users"]);
+    expect(clientGrant.organization_usage).toBe("allow");
+    expect(clientGrant.allow_any_organization).toBe(false);
+    expect(clientGrant.is_system).toBe(false);
+    expect(clientGrant.subject_type).toBe("client");
+    expect(clientGrant.authorization_details_types).toEqual([
+      "payment_initiation",
+      "account_information",
+    ]);
+    expect(clientGrant.created_at).toBeDefined();
+    expect(clientGrant.updated_at).toBeDefined();
+  });
+
+  it("should create a client grant with minimal data", async () => {
+    const clientGrantData: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+    };
+
+    const clientGrant = await adapter.clientGrants.create(
+      tenantId,
+      clientGrantData,
+    );
+
+    expect(clientGrant).toBeDefined();
+    expect(clientGrant.id).toBeDefined();
+    expect(clientGrant.client_id).toBe("test-client-id");
+    expect(clientGrant.audience).toBe("https://test.api.com");
+    expect(clientGrant.scope).toEqual([]);
+    expect(clientGrant.authorization_details_types).toEqual([]);
+    expect(clientGrant.allow_any_organization).toBe(false);
+    expect(clientGrant.is_system).toBe(false);
+  });
+
+  it("should get a client grant by id", async () => {
+    const clientGrantData: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:profile"],
+    };
+
+    const created = await adapter.clientGrants.create(
+      tenantId,
+      clientGrantData,
+    );
+    const retrieved = await adapter.clientGrants.get(tenantId, created.id);
+
+    expect(retrieved).toBeDefined();
+    expect(retrieved!.id).toBe(created.id);
+    expect(retrieved!.client_id).toBe("test-client-id");
+    expect(retrieved!.audience).toBe("https://test.api.com");
+    expect(retrieved!.scope).toEqual(["read:profile"]);
+  });
+
+  it("should return null when getting non-existent client grant", async () => {
+    const retrieved = await adapter.clientGrants.get(
+      tenantId,
+      "non-existent-id",
+    );
+
+    expect(retrieved).toBeNull();
+  });
+
+  it("should list client grants", async () => {
+    // Create another resource server for the second grant
+    await db
+      .insertInto("resource_servers")
+      .values({
+        id: "test-api-2-id",
+        tenant_id: tenantId,
+        identifier: "https://api2.example.com",
+        name: "Test API 2",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
+
+    const grant1: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:users"],
+    };
+    const grant2: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://api2.example.com",
+      scope: ["write:users"],
+    };
+
+    await adapter.clientGrants.create(tenantId, grant1);
+    await adapter.clientGrants.create(tenantId, grant2);
+
+    const result = await adapter.clientGrants.list(tenantId);
+
+    expect(result.client_grants).toHaveLength(2);
+    expect(result.client_grants[0].client_id).toBe("test-client-id");
+    expect(result.client_grants[1].client_id).toBe("test-client-id");
+    
+    const scopes = result.client_grants.map((g: any) => g.scope);
+    expect(scopes).toContainEqual(["read:users"]);
+    expect(scopes).toContainEqual(["write:users"]);
+  });
+
+  it("should list client grants with pagination", async () => {
+    // Create multiple resource servers for different grants
+    for (let i = 0; i < 5; i++) {
+      await db
+        .insertInto("resource_servers")
+        .values({
+          id: `api-${i}-id`,
+          tenant_id: tenantId,
+          identifier: `https://api${i}.example.com`,
+          name: `API ${i}`,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .execute();
+    }
+
+    // Create multiple client grants
+    for (let i = 0; i < 5; i++) {
+      const grant: ClientGrantInsert = {
+        client_id: "test-client-id",
+        audience: `https://api${i}.example.com`,
+        scope: [`read:resource${i}`],
+      };
+      await adapter.clientGrants.create(tenantId, grant);
+    }
+
+    const result = await adapter.clientGrants.list(tenantId, {
+      page: 0,
+      per_page: 3,
+      include_totals: true,
+    });
+
+    expect(result.client_grants).toHaveLength(3);
+    expect(result.length).toBe(5);
+    expect(result.start).toBe(0);
+    expect(result.limit).toBe(3);
+  });
+
+  it("should filter client grants by audience", async () => {
+    // Create another resource server
+    await db
+      .insertInto("resource_servers")
+      .values({
+        id: "test-api-2-id",
+        tenant_id: tenantId,
+        identifier: "https://api2.test.com",
+        name: "Test API 2",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
+
+    const grant1: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:users"],
+    };
+    const grant2: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://api2.test.com",
+      scope: ["write:users"],
+    };
+
+    await adapter.clientGrants.create(tenantId, grant1);
+    await adapter.clientGrants.create(tenantId, grant2);
+
+    const result = await adapter.clientGrants.list(tenantId, {
+      audience: "https://test.api.com",
+    });
+
+    expect(result.client_grants).toHaveLength(1);
+    expect(result.client_grants[0].audience).toBe("https://test.api.com");
+    expect(result.client_grants[0].scope).toEqual(["read:users"]);
+  });
+
+  it("should filter client grants by client_id", async () => {
+    // Create another client
+    await db
+      .insertInto("clients")
+      .values({
+        tenant_id: tenantId,
+        client_id: "test-client-2-id",
+        name: "Test Client 2",
+        client_secret: "test-secret-2",
+        callbacks: "[]",
+        allowed_origins: "[]",
+        web_origins: "[]",
+        client_aliases: "[]",
+        allowed_clients: "[]",
+        allowed_logout_urls: "[]",
+        session_transfer: "{}",
+        oidc_logout: "{}",
+        grant_types: "[]",
+        jwt_configuration: "{}",
+        signing_keys: "[]",
+        encryption_key: "{}",
+        addons: "{}",
+        client_metadata: "{}",
+        mobile: "{}",
+        native_social_login: "{}",
+        refresh_token: "{}",
+        default_organization: "{}",
+        client_authentication_methods: "{}",
+        signed_request_object: "{}",
+        token_quota: "{}",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
+
+    const grant1: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:users"],
+    };
+    const grant2: ClientGrantInsert = {
+      client_id: "test-client-2-id",
+      audience: "https://test.api.com",
+      scope: ["write:users"],
+    };
+
+    await adapter.clientGrants.create(tenantId, grant1);
+    await adapter.clientGrants.create(tenantId, grant2);
+
+    const result = await adapter.clientGrants.list(tenantId, {
+      client_id: "test-client-id",
+    });
+
+    expect(result.client_grants).toHaveLength(1);
+    expect(result.client_grants[0].client_id).toBe("test-client-id");
+    expect(result.client_grants[0].scope).toEqual(["read:users"]);
+  });
+
+  it("should update a client grant", async () => {
+    const clientGrantData: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:users"],
+      organization_usage: "deny",
+      allow_any_organization: false,
+    };
+
+    const created = await adapter.clientGrants.create(
+      tenantId,
+      clientGrantData,
+    );
+    
+    // Add a delay to ensure different timestamps
+    await new Promise(resolve => setTimeout(resolve, 100));
+    
+    const updated = await adapter.clientGrants.update(tenantId, created.id, {
+      scope: ["read:users", "write:users", "delete:users"],
+      organization_usage: "allow",
+      allow_any_organization: true,
+      subject_type: "user",
+    });
+
+    expect(updated).toBe(true);
+
+    const retrieved = await adapter.clientGrants.get(tenantId, created.id);
+    expect(retrieved!.scope).toEqual([
+      "read:users",
+      "write:users",
+      "delete:users",
+    ]);
+    expect(retrieved!.organization_usage).toBe("allow");
+    expect(retrieved!.allow_any_organization).toBe(true);
+    expect(retrieved!.subject_type).toBe("user");
+    expect(new Date(retrieved!.updated_at!).getTime()).toBeGreaterThanOrEqual(new Date(created.updated_at!).getTime());
+  });
+
+  it("should not update non-existent client grant", async () => {
+    const updated = await adapter.clientGrants.update(
+      tenantId,
+      "non-existent-id",
+      {
+        scope: ["read:users"],
+      },
+    );
+
+    expect(updated).toBe(false);
+  });
+
+  it("should remove a client grant", async () => {
+    const clientGrantData: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:users"],
+    };
+
+    const created = await adapter.clientGrants.create(
+      tenantId,
+      clientGrantData,
+    );
+    const removed = await adapter.clientGrants.remove(tenantId, created.id);
+
+    expect(removed).toBe(true);
+
+    const retrieved = await adapter.clientGrants.get(tenantId, created.id);
+    expect(retrieved).toBeNull();
+  });
+
+  it("should not remove non-existent client grant", async () => {
+    const removed = await adapter.clientGrants.remove(
+      tenantId,
+      "non-existent-id",
+    );
+
+    expect(removed).toBe(false);
+  });
+
+  it("should enforce unique constraint on tenant_id + client_id + audience", async () => {
+    const clientGrantData: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:users"],
+    };
+
+    // Create first client grant
+    await adapter.clientGrants.create(tenantId, clientGrantData);
+
+    // Attempt to create duplicate should fail
+    await expect(
+      adapter.clientGrants.create(tenantId, clientGrantData),
+    ).rejects.toThrow();
+  });
+
+  it("should handle JSON serialization for scope and authorization_details_types", async () => {
+    const clientGrantData: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:users", "write:users", "admin:users"],
+      authorization_details_types: [
+        "payment_initiation",
+        "account_information",
+        "fundsconfirmation",
+      ],
+    };
+
+    const created = await adapter.clientGrants.create(
+      tenantId,
+      clientGrantData,
+    );
+    const retrieved = await adapter.clientGrants.get(tenantId, created.id);
+
+    expect(retrieved!.scope).toEqual([
+      "read:users",
+      "write:users",
+      "admin:users",
+    ]);
+    expect(retrieved!.authorization_details_types).toEqual([
+      "payment_initiation",
+      "account_information",
+      "fundsconfirmation",
+    ]);
+  });
+
+  it("should handle empty arrays for scope and authorization_details_types", async () => {
+    const clientGrantData: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: [],
+      authorization_details_types: [],
+    };
+
+    const created = await adapter.clientGrants.create(
+      tenantId,
+      clientGrantData,
+    );
+    const retrieved = await adapter.clientGrants.get(tenantId, created.id);
+
+    expect(retrieved!.scope).toEqual([]);
+    expect(retrieved!.authorization_details_types).toEqual([]);
+  });
+
+  it("should handle tenant isolation", async () => {
+    const anotherTenantId = "another-tenant";
+
+    // Create another tenant
+    await db
+      .insertInto("tenants")
+      .values({
+        id: anotherTenantId,
+        name: "Another Tenant",
+        audience: "https://another.authhero.com/api/v2/",
+        sender_email: "another@authhero.com",
+        sender_name: "Another Sender",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
+
+    // Create client for another tenant
+    await db
+      .insertInto("clients")
+      .values({
+        tenant_id: anotherTenantId,
+        client_id: "another-client-id",
+        name: "Another Client",
+        client_secret: "another-secret",
+        callbacks: "[]",
+        allowed_origins: "[]",
+        web_origins: "[]",
+        client_aliases: "[]",
+        allowed_clients: "[]",
+        allowed_logout_urls: "[]",
+        session_transfer: "{}",
+        oidc_logout: "{}",
+        grant_types: "[]",
+        jwt_configuration: "{}",
+        signing_keys: "[]",
+        encryption_key: "{}",
+        addons: "{}",
+        client_metadata: "{}",
+        mobile: "{}",
+        native_social_login: "{}",
+        refresh_token: "{}",
+        default_organization: "{}",
+        client_authentication_methods: "{}",
+        signed_request_object: "{}",
+        token_quota: "{}",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
+
+    // Create resource server for another tenant
+    await db
+      .insertInto("resource_servers")
+      .values({
+        id: "another-api-id",
+        tenant_id: anotherTenantId,
+        identifier: "https://another.api.com",
+        name: "Another API",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
+
+    const grant1: ClientGrantInsert = {
+      client_id: "test-client-id",
+      audience: "https://test.api.com",
+      scope: ["read:users"],
+    };
+    const grant2: ClientGrantInsert = {
+      client_id: "another-client-id",
+      audience: "https://another.api.com",
+      scope: ["write:users"],
+    };
+
+    // Create grants in different tenants
+    const created1 = await adapter.clientGrants.create(tenantId, grant1);
+    const created2 = await adapter.clientGrants.create(anotherTenantId, grant2);
+
+    // Each tenant should only see their own grants
+    const tenant1Grants = await adapter.clientGrants.list(tenantId);
+    const tenant2Grants = await adapter.clientGrants.list(anotherTenantId);
+
+    expect(tenant1Grants.client_grants).toHaveLength(1);
+    expect(tenant1Grants.client_grants[0].id).toBe(created1.id);
+
+    expect(tenant2Grants.client_grants).toHaveLength(1);
+    expect(tenant2Grants.client_grants[0].id).toBe(created2.id);
+
+    // Cross-tenant access should return null
+    const crossAccess1 = await adapter.clientGrants.get(
+      tenantId,
+      created2.id,
+    );
+    const crossAccess2 = await adapter.clientGrants.get(
+      anotherTenantId,
+      created1.id,
+    );
+
+    expect(crossAccess1).toBeNull();
+    expect(crossAccess2).toBeNull();
+  });
+});

--- a/packages/kysely/test/clientGrants.test.ts
+++ b/packages/kysely/test/clientGrants.test.ts
@@ -264,7 +264,7 @@ describe("ClientGrantsAdapter", () => {
     await adapter.clientGrants.create(tenantId, grant2);
 
     const result = await adapter.clientGrants.list(tenantId, {
-      audience: "https://test.api.com",
+      q: 'audience:"https://test.api.com"',
     });
 
     expect(result.client_grants).toHaveLength(1);
@@ -322,7 +322,7 @@ describe("ClientGrantsAdapter", () => {
     await adapter.clientGrants.create(tenantId, grant2);
 
     const result = await adapter.clientGrants.list(tenantId, {
-      client_id: "test-client-id",
+      q: 'client_id:"test-client-id"',
     });
 
     expect(result.client_grants).toHaveLength(1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Client Grants resource to the Management API with full CRUD, listing (pagination/sorting/filtering), totals, validation, and OpenAPI metadata.
  - Exposed a new Client Grants adapter and public types for consumers; database-backed persistence added.

- Tests
  - Added end-to-end and adapter tests covering full CRUD, filtering, pagination, uniqueness, JSON fields, and tenant isolation.

- Chores
  - Database migrations: create client_grants table and related indexes; also migration touching applications table.
  - Bumped package minor versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->