### PR TITLE
Return all scopes by default for client credentials

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,14 +1,21 @@
 # @authhero/demo
 
+## 0.20.25
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.219.0
+
 ## 0.20.24
 
 ### Patch Changes
 
 <<<<<<< HEAD
-- Updated dependencies [6858af2]
-=======
+
+- # Updated dependencies [6858af2]
 - Updated dependencies [149ab91]
->>>>>>> main
+  > > > > > > > main
 - Updated dependencies [b0e9595]
   - authhero@0.218.0
   - @authhero/kysely-adapter@10.45.0

--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -11,11 +11,8 @@
 
 ### Patch Changes
 
-<<<<<<< HEAD
-
 - # Updated dependencies [6858af2]
 - Updated dependencies [149ab91]
-  > > > > > > > main
 - Updated dependencies [b0e9595]
   - authhero@0.218.0
   - @authhero/kysely-adapter@10.45.0

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.20.24",
+  "version": "0.20.25",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.2",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.13.0",
-    "authhero": "^0.218.0",
+    "authhero": "^0.219.0",
     "better-sqlite3": "^12.2.0",
     "hono": "^4.9.1",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### Minor Changes
 
-<<<<<<< HEAD
-
 - # 6858af2: Add client credentials scopes and permissions
 - 149ab91: Drop the old application table
   > > > > > > > main
@@ -19,10 +17,7 @@
 
 ### Patch Changes
 
-# <<<<<<< HEAD
-
 - Updated dependencies [149ab91]
-  > > > > > > > main
 - Updated dependencies [b0e9595]
   - @authhero/adapter-interfaces@0.91.0
 

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,22 +1,28 @@
 # authhero
 
+## 0.219.0
+
+### Minor Changes
+
+- Return all scopes as default for client credentials
+
 ## 0.218.0
 
 ### Minor Changes
 
 <<<<<<< HEAD
-- 6858af2: Add client credentials scopes and permissions
-=======
+
+- # 6858af2: Add client credentials scopes and permissions
 - 149ab91: Drop the old application table
->>>>>>> main
+  > > > > > > > main
 - b0e9595: Add client grants
 
 ### Patch Changes
 
-<<<<<<< HEAD
-=======
+# <<<<<<< HEAD
+
 - Updated dependencies [149ab91]
->>>>>>> main
+  > > > > > > > main
 - Updated dependencies [b0e9595]
   - @authhero/adapter-interfaces@0.91.0
 

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.218.0",
+  "version": "0.219.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/helpers/scopes-permissions.ts
+++ b/packages/authhero/src/helpers/scopes-permissions.ts
@@ -119,10 +119,23 @@ async function calculateClientCredentialsScopes(
   // If RBAC is not enabled, return requested scopes that are both:
   // 1. Defined on the resource server
   // 2. Granted to the client via client grants
+  // Special case: if no scopes are requested, return all granted scopes
   if (!rbacEnabled) {
-    const allowedScopes = requestedScopes.filter(
-      (scope) => definedScopes.includes(scope) && grantedScopes.includes(scope),
-    );
+    let allowedScopes: string[];
+
+    if (requestedScopes.length === 0) {
+      // No specific scopes requested - return all granted scopes that are defined on the resource server
+      allowedScopes = grantedScopes.filter((scope) =>
+        definedScopes.includes(scope),
+      );
+    } else {
+      // Specific scopes requested - return intersection of requested, defined, and granted
+      allowedScopes = requestedScopes.filter(
+        (scope) =>
+          definedScopes.includes(scope) && grantedScopes.includes(scope),
+      );
+    }
+
     const allAllowedScopes = [
       ...new Set([...defaultOidcScopes, ...allowedScopes]),
     ];
@@ -141,9 +154,21 @@ async function calculateClientCredentialsScopes(
   }
 
   // For access_token dialect, return scopes that are requested, defined, and granted
-  const allowedScopes = requestedScopes.filter(
-    (scope) => definedScopes.includes(scope) && grantedScopes.includes(scope),
-  );
+  // Special case: if no scopes are requested, return all granted scopes
+  let allowedScopes: string[];
+
+  if (requestedScopes.length === 0) {
+    // No specific scopes requested - return all granted scopes that are defined on the resource server
+    allowedScopes = grantedScopes.filter((scope) =>
+      definedScopes.includes(scope),
+    );
+  } else {
+    // Specific scopes requested - return intersection of requested, defined, and granted
+    allowedScopes = requestedScopes.filter(
+      (scope) => definedScopes.includes(scope) && grantedScopes.includes(scope),
+    );
+  }
+
   const allAllowedScopes = [
     ...new Set([...defaultOidcScopes, ...allowedScopes]),
   ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Client Credentials tokens now include all granted scopes by default when no scope is requested; when scopes are specified, only the requested and permitted scopes are included.

- Tests
  - Added tests covering default and explicit scope handling in the Client Credentials flow.

- Documentation
  - Changelogs updated for new package versions and scope behavior.

- Chores
  - Demo app version bumped to 0.20.25; auth package upgraded to 0.219.0.

- Bug Fixes
  - Changelog files contain unresolved merge markers that need cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->