### PR TITLE
Add org-name to id-token

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.20.26
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.220.0
+
 ## 0.20.25
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.20.25",
+  "version": "0.20.26",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.2",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.13.0",
-    "authhero": "^0.219.0",
+    "authhero": "^0.220.0",
     "better-sqlite3": "^12.2.0",
     "hono": "^4.9.1",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.220.0
+
+### Minor Changes
+
+- Add org name to id-token
+
 ## 0.219.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.219.0",
+  "version": "0.220.0",
   "files": [
     "dist"
   ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - ID tokens now include the organization name when an organization is specified and available, providing richer context alongside existing organization identifiers.

- Chores
  - Updated demo app to version 0.20.26.
  - Upgraded authentication dependency to version 0.220.0.

- Documentation
  - Added changelog entries for the demo app (0.20.26) and authentication package (0.220.0), reflecting the new token enrichment and version bumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->