### PR TITLE
Fix options for resources servers in kysely

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @authhero/demo
 
+## 0.20.28
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.222.0
+  - @authhero/kysely-adapter@10.47.0
+
 ## 0.20.27
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.20.27",
+  "version": "0.20.28",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
   "dependencies": {
-    "@authhero/kysely-adapter": "^10.46.0",
+    "@authhero/kysely-adapter": "^10.47.0",
     "@hono/swagger-ui": "^0.5.2",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.13.0",
-    "authhero": "^0.221.0",
+    "authhero": "^0.222.0",
     "better-sqlite3": "^12.2.0",
     "hono": "^4.9.1",
     "hono-openapi-middlewares": "^1.0.11",

--- a/apps/react-admin/src/components/resource-servers/create.tsx
+++ b/apps/react-admin/src/components/resource-servers/create.tsx
@@ -29,7 +29,7 @@ export function ResourceServerCreate() {
             source="skip_consent_for_verifiable_first_party_clients"
             defaultValue={true}
           />
-          <BooleanInput source="enforce_policies" defaultValue={true} />
+          <BooleanInput source="options.enforce_policies" defaultValue={true} />
         </Stack>
 
         <Stack spacing={2} direction="row" sx={{ mt: 2 }}>
@@ -39,7 +39,7 @@ export function ResourceServerCreate() {
             helperText="Signing algorithm for tokens"
           />
           <TextInput
-            source="token_dialect"
+            source="options.token_dialect"
             defaultValue="access_token_authz"
             helperText="Token dialect format"
           />

--- a/apps/react-admin/src/components/resource-servers/edit.tsx
+++ b/apps/react-admin/src/components/resource-servers/edit.tsx
@@ -68,7 +68,7 @@ export function ResourceServerEdit() {
         <TabbedForm.Tab label="RBAC">
           <Stack spacing={3}>
             <BooleanInput
-              source="enforce_policies"
+              source="options.enforce_policies"
               label="Enable RBAC"
               helperText="Enable Role-Based Access Control for this resource server"
             />
@@ -76,10 +76,10 @@ export function ResourceServerEdit() {
             <FormDataConsumer>
               {({ formData }) => (
                 <BooleanInput
-                  source="token_dialect"
+                  source="options.token_dialect"
                   label="Add permissions in token"
                   helperText="Include permissions directly in the access token"
-                  disabled={!formData?.enforce_policies}
+                  disabled={!formData?.options?.enforce_policies}
                   format={(value) => value === "access_token_authz"}
                   parse={(checked) =>
                     checked ? "access_token_authz" : "access_token"

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.222.0
+
+### Minor Changes
+
+- Fix options for resource servers
+
 ## 0.221.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.221.0",
+  "version": "0.222.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/routes/auth-api/token.ts
+++ b/packages/authhero/src/routes/auth-api/token.ts
@@ -211,6 +211,8 @@ export const tokenRoutes = new OpenAPIHono<{
 
       // Calculate scopes and permissions before creating tokens
       // This will throw a 403 error if user is not a member of the required organization
+      let calculatedPermissions: string[] = [];
+      
       if (grantResult.authParams.audience) {
         try {
           let scopesAndPermissions;
@@ -249,8 +251,9 @@ export const tokenRoutes = new OpenAPIHono<{
             });
           }
 
-          // Update the authParams with calculated scopes
+          // Update the authParams with calculated scopes and store permissions
           grantResult.authParams.scope = scopesAndPermissions.scopes.join(" ");
+          calculatedPermissions = scopesAndPermissions.permissions;
         } catch (error) {
           // Re-throw HTTPExceptions (like 403 for organization membership)
           if (error instanceof HTTPException) {
@@ -264,6 +267,7 @@ export const tokenRoutes = new OpenAPIHono<{
       const tokens = await createAuthTokens(ctx, {
         ...grantResult,
         grantType: body.grant_type as GrantType,
+        permissions: calculatedPermissions.length > 0 ? calculatedPermissions : undefined,
       });
       return ctx.json(tokens, {
         headers: passwordlessHeaders,

--- a/packages/authhero/test/routes/auth-api/token.spec.ts
+++ b/packages/authhero/test/routes/auth-api/token.spec.ts
@@ -1209,4 +1209,265 @@ describe("token", () => {
       await env.data.users.remove("tenantId", user.user_id);
     });
   });
+
+  describe("permissions in JWT tokens", () => {
+    describe("authorization_code flow with access_token_authz", () => {
+      it("should include permissions in JWT token when resource server has enforce_policies=true and token_dialect=access_token_authz", async () => {
+        const { oauthApp, env } = await getTestServer();
+        const client = testClient(oauthApp, env);
+
+        // Create a resource server with RBAC enabled and access_token_authz dialect
+        const resourceServer = await env.data.resourceServers.create("tenantId", {
+          name: "Test API with Permissions",
+          identifier: "https://permissions-test-api.example.com",
+          scopes: [
+            { value: "read:users", description: "Read users" },
+            { value: "write:users", description: "Write users" },
+            { value: "delete:users", description: "Delete users" },
+          ],
+          options: {
+            enforce_policies: true, // RBAC enabled
+            token_dialect: "access_token_authz", // Should include permissions in token
+          },
+        });
+
+        // Create a user
+        const user = await env.data.users.create("tenantId", {
+          user_id: "email|permissions-test-user",
+          email: "permissions-test@example.com",
+          provider: "email",
+          connection: "email",
+          email_verified: true,
+          is_social: false,
+          name: "Permissions Test User",
+        });
+
+        // Give user direct permissions
+        await env.data.userPermissions.create("tenantId", user.user_id, {
+          user_id: user.user_id,
+          resource_server_identifier: "https://permissions-test-api.example.com",
+          permission_name: "read:users",
+        });
+
+        await env.data.userPermissions.create("tenantId", user.user_id, {
+          user_id: user.user_id,
+          resource_server_identifier: "https://permissions-test-api.example.com",
+          permission_name: "write:users",
+        });
+
+        // Create a login session
+        const loginSession = await env.data.loginSessions.create("tenantId", {
+          authParams: {
+            client_id: "clientId",
+            audience: "https://permissions-test-api.example.com",
+            scope: "read:users write:users delete:users", // Request all scopes
+            redirect_uri: "https://example.com/callback",
+            response_type: AuthorizationResponseType.CODE,
+          },
+          expires_at: new Date(Date.now() + 600000).toISOString(),
+          csrf_token: "test-csrf-token-permissions",
+        });
+
+        // Create an authorization code
+        const code = await env.data.codes.create("tenantId", {
+          code_id: "test-permissions-code",
+          user_id: user.user_id,
+          code_type: "authorization_code",
+          login_id: loginSession.id,
+          expires_at: new Date(Date.now() + 600000).toISOString(),
+          redirect_uri: "https://example.com/callback",
+        });
+
+        // Exchange code for tokens
+        const response = await client.oauth.token.$post({
+          form: {
+            grant_type: "authorization_code",
+            client_id: "clientId",
+            client_secret: "clientSecret",
+            code: "test-permissions-code",
+            redirect_uri: "https://example.com/callback",
+          },
+        });
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as TokenResponse;
+
+        expect(body).toHaveProperty("access_token");
+        expect(body).toHaveProperty("token_type", "Bearer");
+
+        // Parse the access token to check permissions
+        const accessToken = parseJWT(body.access_token);
+        const payload = accessToken?.payload as any;
+
+        expect(accessToken).not.toBeNull();
+        expect(payload.sub).toBe(user.user_id);
+        expect(payload.aud).toBe("https://permissions-test-api.example.com");
+
+        // Verify permissions are included in the token
+        expect(payload.permissions).toBeDefined();
+        expect(payload.permissions).toEqual(
+          expect.arrayContaining(["read:users", "write:users"])
+        );
+        // User should not have delete:users permission since it wasn't granted
+        expect(payload.permissions).not.toContain("delete:users");
+
+        // For access_token_authz dialect, scopes should be empty
+        expect(payload.scope).toBe("");
+
+        // Clean up
+        await env.data.resourceServers.remove("tenantId", resourceServer.id!);
+        await env.data.users.remove("tenantId", user.user_id);
+      });
+
+      it("should NOT include permissions when token_dialect is access_token (default)", async () => {
+        const { oauthApp, env } = await getTestServer();
+        const client = testClient(oauthApp, env);
+
+        // Create a resource server with RBAC enabled but default token_dialect
+        const resourceServer = await env.data.resourceServers.create("tenantId", {
+          name: "Test API with Scopes",
+          identifier: "https://scopes-test-api.example.com",
+          scopes: [
+            { value: "read:users", description: "Read users" },
+            { value: "write:users", description: "Write users" },
+          ],
+          options: {
+            enforce_policies: true, // RBAC enabled
+            token_dialect: "access_token", // Should use scopes, not permissions
+          },
+        });
+
+        // Create a user
+        const user = await env.data.users.create("tenantId", {
+          user_id: "email|scopes-test-user",
+          email: "scopes-test@example.com",
+          provider: "email",
+          connection: "email",
+          email_verified: true,
+          is_social: false,
+          name: "Scopes Test User",
+        });
+
+        // Give user permissions
+        await env.data.userPermissions.create("tenantId", user.user_id, {
+          user_id: user.user_id,
+          resource_server_identifier: "https://scopes-test-api.example.com",
+          permission_name: "read:users",
+        });
+
+        // Create a login session
+        const loginSession = await env.data.loginSessions.create("tenantId", {
+          authParams: {
+            client_id: "clientId",
+            audience: "https://scopes-test-api.example.com",
+            scope: "read:users write:users",
+            redirect_uri: "https://example.com/callback",
+            response_type: AuthorizationResponseType.CODE,
+          },
+          expires_at: new Date(Date.now() + 600000).toISOString(),
+          csrf_token: "test-csrf-token-scopes",
+        });
+
+        // Create an authorization code
+        const code = await env.data.codes.create("tenantId", {
+          code_id: "test-scopes-code",
+          user_id: user.user_id,
+          code_type: "authorization_code",
+          login_id: loginSession.id,
+          expires_at: new Date(Date.now() + 600000).toISOString(),
+          redirect_uri: "https://example.com/callback",
+        });
+
+        // Exchange code for tokens
+        const response = await client.oauth.token.$post({
+          form: {
+            grant_type: "authorization_code",
+            client_id: "clientId",
+            client_secret: "clientSecret",
+            code: "test-scopes-code",
+            redirect_uri: "https://example.com/callback",
+          },
+        });
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as TokenResponse;
+
+        // Parse the access token
+        const accessToken = parseJWT(body.access_token);
+        const payload = accessToken?.payload as any;
+
+        expect(accessToken).not.toBeNull();
+
+        // For access_token dialect, should use scopes not permissions
+        expect(payload.permissions).toBeUndefined();
+        expect(payload.scope).toBe("read:users"); // Only the scope user has permission for
+
+        // Clean up
+        await env.data.resourceServers.remove("tenantId", resourceServer.id!);
+        await env.data.users.remove("tenantId", user.user_id);
+      });
+    });
+
+    describe("client_credentials flow with access_token_authz", () => {
+      it("should include permissions in JWT token for client_credentials grant", async () => {
+        const { oauthApp, env } = await getTestServer();
+        const client = testClient(oauthApp, env);
+
+        // Create a resource server with access_token_authz dialect
+        const resourceServer = await env.data.resourceServers.create("tenantId", {
+          identifier: "https://client-permissions-api.example.com",
+          name: "Client Permissions API",
+          scopes: [
+            { value: "read:data", description: "Read data" },
+            { value: "write:data", description: "Write data" },
+          ],
+          options: {
+            enforce_policies: true, // RBAC enabled
+            token_dialect: "access_token_authz", // Should include permissions
+          },
+        });
+
+        // Create a client grant
+        await env.data.clientGrants.create("tenantId", {
+          client_id: "clientId",
+          audience: "https://client-permissions-api.example.com",
+          scope: ["read:data", "write:data"],
+        });
+
+        // Make client_credentials token request
+        const response = await client.oauth.token.$post({
+          form: {
+            grant_type: "client_credentials",
+            client_id: "clientId",
+            client_secret: "clientSecret",
+            audience: "https://client-permissions-api.example.com",
+            scope: "read:data write:data",
+          },
+        });
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as TokenResponse;
+
+        // Parse the access token
+        const accessToken = parseJWT(body.access_token);
+        const payload = accessToken?.payload as any;
+
+        expect(accessToken).not.toBeNull();
+        expect(payload.sub).toBe("clientId");
+        expect(payload.aud).toBe("https://client-permissions-api.example.com");
+
+        // Verify permissions are included for client_credentials
+        expect(payload.permissions).toBeDefined();
+        expect(payload.permissions).toEqual(
+          expect.arrayContaining(["read:data", "write:data"])
+        );
+
+        // For access_token_authz dialect, scopes should be empty
+        expect(payload.scope).toBe("");
+
+        // Clean up
+        await env.data.resourceServers.remove("tenantId", resourceServer.id!);
+      });
+    });
+  });
 });

--- a/packages/kysely/CHANGELOG.md
+++ b/packages/kysely/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @authhero/kysely-adapter
 
+## 10.47.0
+
+### Minor Changes
+
+- Fix options for resource servers
+
 ## 10.46.0
 
 ### Minor Changes

--- a/packages/kysely/package.json
+++ b/packages/kysely/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/markusahlstrand/authhero"
   },
-  "version": "10.46.0",
+  "version": "10.47.0",
   "files": [
     "dist"
   ],

--- a/packages/kysely/test/resourceServers/properties-persistence.spec.ts
+++ b/packages/kysely/test/resourceServers/properties-persistence.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+
+describe("resourceServers adapter - property persistence", () => {
+  it("should persist allow_offline_access and enforce_policies properties correctly", async () => {
+    const { data: adapters } = await getTestServer();
+    const tenant = "t1";
+
+    // Create a resource server with initial values
+    const created = await adapters.resourceServers.create(tenant, {
+      name: "Test API",
+      identifier: "https://api.test.com/",
+      scopes: [{ value: "read:data", description: "Read data" }],
+      signing_alg: "RS256",
+      token_lifetime: 3600,
+      allow_offline_access: false,
+      options: {
+        enforce_policies: false,
+      },
+    } as any);
+
+    expect(created.id).toBeTruthy();
+
+    // Verify initial values
+    const initial = await adapters.resourceServers.get(tenant, created.id!);
+    expect(initial?.allow_offline_access).toBe(false);
+    expect(initial?.options?.enforce_policies).toBe(false);
+
+    // Update both properties to true
+    const updated = await adapters.resourceServers.update(tenant, created.id!, {
+      allow_offline_access: true,
+      options: {
+        enforce_policies: true,
+      },
+    });
+    expect(updated).toBe(true);
+
+    // Verify both properties were updated correctly
+    const afterUpdate = await adapters.resourceServers.get(tenant, created.id!);
+    expect(afterUpdate?.allow_offline_access).toBe(true);
+    expect(afterUpdate?.options?.enforce_policies).toBe(true);
+
+    // Update only allow_offline_access back to false, should preserve enforce_policies
+    const updated2 = await adapters.resourceServers.update(
+      tenant,
+      created.id!,
+      {
+        allow_offline_access: false,
+      },
+    );
+    expect(updated2).toBe(true);
+
+    const afterUpdate2 = await adapters.resourceServers.get(
+      tenant,
+      created.id!,
+    );
+    expect(afterUpdate2?.allow_offline_access).toBe(false);
+    expect(afterUpdate2?.options?.enforce_policies).toBe(true); // Should still be true
+
+    // Update only enforce_policies back to false, should preserve allow_offline_access
+    const updated3 = await adapters.resourceServers.update(
+      tenant,
+      created.id!,
+      {
+        options: {
+          enforce_policies: false,
+        },
+      },
+    );
+    expect(updated3).toBe(true);
+
+    const afterUpdate3 = await adapters.resourceServers.get(
+      tenant,
+      created.id!,
+    );
+    expect(afterUpdate3?.allow_offline_access).toBe(false); // Should still be false
+    expect(afterUpdate3?.options?.enforce_policies).toBe(false);
+
+    // Clean up
+    await adapters.resourceServers.remove(tenant, created.id!);
+  });
+
+  it("should handle partial options updates correctly", async () => {
+    const { data: adapters } = await getTestServer();
+    const tenant = "t1";
+
+    // Create a resource server with multiple options
+    const created = await adapters.resourceServers.create(tenant, {
+      name: "Test API 2",
+      identifier: "https://api2.test.com/",
+      options: {
+        enforce_policies: true,
+        allow_skipping_userinfo: true,
+        persist_client_authorization: false,
+      },
+    } as any);
+
+    expect(created.id).toBeTruthy();
+
+    // Verify initial values
+    const initial = await adapters.resourceServers.get(tenant, created.id!);
+    expect(initial?.options?.enforce_policies).toBe(true);
+    expect(initial?.options?.allow_skipping_userinfo).toBe(true);
+    expect(initial?.options?.persist_client_authorization).toBe(false);
+
+    // Update only enforce_policies, should preserve other options
+    const updated = await adapters.resourceServers.update(tenant, created.id!, {
+      options: {
+        enforce_policies: false,
+        // Note: Not setting other options here
+      },
+    });
+    expect(updated).toBe(true);
+
+    const afterUpdate = await adapters.resourceServers.get(tenant, created.id!);
+    expect(afterUpdate?.options?.enforce_policies).toBe(false);
+    // These should be preserved from the original creation (not overwritten)
+    expect(afterUpdate?.options?.allow_skipping_userinfo).toBe(true);
+    expect(afterUpdate?.options?.persist_client_authorization).toBe(false);
+
+    // Clean up
+    await adapters.resourceServers.remove(tenant, created.id!);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Access tokens can now include permissions when using the access_token_authz dialect, improving RBAC token payloads.

- Bug Fixes
  - Resource server options are preserved on partial updates (no unintended overwrites).
  - RBAC-related fields (enforce_policies, token_dialect) correctly persist under options.
  - Safer scope/permission calculation with graceful fallback to existing scopes on non-critical errors.

- Chores
  - Updated dependencies: authhero to 0.222.0 and @authhero/kysely-adapter to 10.47.0.
  - Bumped demo app to 0.20.28 and refreshed changelogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->