### PR TITLE
Add org support to token endpoint

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.20.31
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.225.0
+
 ## 0.20.30
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.20.30",
+  "version": "0.20.31",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.2",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.13.0",
-    "authhero": "^0.224.0",
+    "authhero": "^0.225.0",
     "better-sqlite3": "^12.2.0",
     "hono": "^4.9.1",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.225.0
+
+### Minor Changes
+
+- Organization support in token endpoint
+
 ## 0.224.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.224.0",
+  "version": "0.225.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/routes/auth-api/token.ts
+++ b/packages/authhero/src/routes/auth-api/token.ts
@@ -40,12 +40,14 @@ const CreateRequestSchema = z.union([
     code: z.string(),
     redirect_uri: z.string(),
     code_verifier: z.string().min(43).max(128),
+    organization: z.string().optional(),
   }),
   // Code grant
   z.object({
     grant_type: z.literal("authorization_code"),
     code: z.string(),
     redirect_uri: z.string().optional(),
+    organization: z.string().optional(),
     ...optionalClientCredentials.shape,
   }),
   // Refresh token
@@ -212,7 +214,7 @@ export const tokenRoutes = new OpenAPIHono<{
       // Calculate scopes and permissions before creating tokens
       // This will throw a 403 error if user is not a member of the required organization
       let calculatedPermissions: string[] = [];
-      
+
       if (grantResult.authParams.audience) {
         try {
           let scopesAndPermissions;
@@ -267,7 +269,8 @@ export const tokenRoutes = new OpenAPIHono<{
       const tokens = await createAuthTokens(ctx, {
         ...grantResult,
         grantType: body.grant_type as GrantType,
-        permissions: calculatedPermissions.length > 0 ? calculatedPermissions : undefined,
+        permissions:
+          calculatedPermissions.length > 0 ? calculatedPermissions : undefined,
       });
       return ctx.json(tokens, {
         headers: passwordlessHeaders,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Token endpoint now accepts an optional organization parameter for authorization_code flows, enabling organization-aware token exchanges with validation against the active login session. Backward compatible when no organization is provided.
* Tests
  * Added comprehensive tests covering organization-matching, mismatch errors, absence scenarios, and backward compatibility.
* Documentation
  * Changelogs updated to reflect the new version and organization support.
* Chores
  * Bumped demo app to 0.20.31.
  * Updated dependency to authhero 0.225.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->