### PR TITLE
Add json support for token endpoint

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.20.35
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.229.0
+
 ## 0.20.34
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.20.34",
+  "version": "0.20.35",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.2",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.13.0",
-    "authhero": "^0.228.0",
+    "authhero": "^0.229.0",
     "better-sqlite3": "^12.2.0",
     "hono": "^4.9.1",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.229.0
+
+### Minor Changes
+
+- Add json support for token endpoint
+
 ## 0.228.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.228.0",
+  "version": "0.229.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/routes/auth-api/token.ts
+++ b/packages/authhero/src/routes/auth-api/token.ts
@@ -98,6 +98,9 @@ export const tokenRoutes = new OpenAPIHono<{
             "application/x-www-form-urlencoded": {
               schema: CreateRequestSchema,
             },
+            "application/json": {
+              schema: CreateRequestSchema,
+            },
           },
         },
       },
@@ -152,7 +155,10 @@ export const tokenRoutes = new OpenAPIHono<{
       },
     }),
     async (ctx) => {
-      const body = ctx.req.valid("form");
+      const contentType = ctx.req.header("Content-Type") || "";
+      const body = contentType.includes("application/json")
+        ? ctx.req.valid("json")
+        : ctx.req.valid("form");
 
       const basicAuth = parseBasicAuthHeader(ctx.req.header("Authorization"));
       const params = { ...body, ...basicAuth };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Token endpoint now accepts JSON request bodies in addition to form-encoded, improving client compatibility.
- Tests
  - Added comprehensive tests covering JSON and form payloads across common OAuth2 grant flows and error cases.
- Documentation
  - Updated changelogs for the demo app (0.20.35) and auth package (0.229.0).
- Chores
  - Bumped demo app version to 0.20.35.
  - Upgraded authentication dependency to 0.229.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->