### PR TITLE
Add audience and scope to logs

### DIFF
--- a/.changeset/public-moments-report.md
+++ b/.changeset/public-moments-report.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Add audience and scope to logs

--- a/packages/authhero/src/hooks/index.ts
+++ b/packages/authhero/src/hooks/index.ts
@@ -503,6 +503,8 @@ export async function postUserLoginHook(
     strategy_type,
     strategy,
     connection: strategy, // Use the same value for both strategy and connection
+    audience: params?.authParams?.audience,
+    scope: params?.authParams?.scope,
   });
 
   await data.logs.create(tenant_id, logMessage);

--- a/packages/authhero/src/routes/auth-api/callback.ts
+++ b/packages/authhero/src/routes/auth-api/callback.ts
@@ -8,8 +8,6 @@ import { connectionCallback } from "../../authentication-flows/connection";
 import { createLogMessage } from "../../utils/create-log-message";
 import { waitUntil } from "../../helpers/wait-until";
 import { getUniversalLoginUrl } from "../../variables";
-// Ensure Response is available, usually global or from Hono if specific types are needed.
-// import { Response } from 'hono'; // Not usually needed for instanceof global Response
 
 async function returnError(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,

--- a/packages/authhero/src/utils/create-log-message.ts
+++ b/packages/authhero/src/utils/create-log-message.ts
@@ -10,6 +10,8 @@ export type LogParams = {
   strategy?: string;
   strategy_type?: string;
   connection?: string;
+  audience?: string;
+  scope?: string;
 };
 
 export function createLogMessage(
@@ -41,8 +43,8 @@ export function createLogMessage(
     connection: params.connection || ctx.var.connection || "",
     strategy: params.strategy || "",
     strategy_type: params.strategy_type || "",
-    audience: "",
-    scope: [],
+    audience: params.audience || "",
+    scope: params.scope ? params.scope.split(" ") : [],
   };
 
   return log;

--- a/packages/authhero/test/routes/auth-api/authenticate.spec.ts
+++ b/packages/authhero/test/routes/auth-api/authenticate.spec.ts
@@ -50,9 +50,11 @@ describe("authenticate", () => {
     const logsResults = await env.data.logs.list("tenantId");
     expect(logsResults.logs).toHaveLength(1);
 
-    const [successfulLoginLog] = logsResults.logs;
-    expect(successfulLoginLog.type).toBe("s");
-    expect(successfulLoginLog.description).toContain("Successful login");
+    const successfulLoginLog = logsResults.logs[0];
+    if (successfulLoginLog) {
+      expect(successfulLoginLog.type).toBe("s");
+      expect(successfulLoginLog.description).toContain("Successful login");
+    }
   });
 
   it("should create a log message for a login attempt for a non-existing user", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Post-login logs now include audience and scope for improved traceability. Scope is parsed into an array when provided; both fields are omitted when absent.
- Tests
  - Improved test robustness by safely handling cases where no logs are produced.
- Documentation
  - Added a changeset entry describing the log enhancements.
- Chores
  - Cleaned up obsolete comments in authentication callback code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->