### PR TITLE
Fix id-token org format

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.22.4
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.245.0
+
 ## 0.22.3
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.22.3",
+  "version": "0.22.4",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.2",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.13.0",
-    "authhero": "^0.244.0",
+    "authhero": "^0.245.0",
     "better-sqlite3": "^12.2.0",
     "hono": "^4.9.1",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.245.0
+
+### Minor Changes
+
+- Fix id-token org format
+
 ## 0.244.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.244.0",
+  "version": "0.245.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -110,12 +110,8 @@ export async function createAuthTokens(
           act: impersonatingUser
             ? { sub: impersonatingUser.user_id }
             : undefined,
-          organization: organization
-            ? {
-                org_id: organization.id,
-                org_name: organization.name,
-              }
-            : undefined,
+          org_id: organization?.id,
+          org_name: organization?.name,
         }
       : undefined;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Standardized id token organization claims: replaces the nested organization object with top-level org_id and org_name for consistency and easier integration. Integrations relying on the previous structure may need minor updates.

- Chores
  - Bumped application and library versions.
  - Updated changelogs.
  - Refreshed authentication-related dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->