### PR TITLE
fix impersonation response type

### DIFF
--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @authhero/demo
 
+## 0.22.19
+
+### Patch Changes
+
+- Updated dependencies
+  - authhero@0.260.0
+
 ## 0.22.18
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authhero/demo",
   "private": true,
-  "version": "0.22.18",
+  "version": "0.22.19",
   "scripts": {
     "dev": "bun --watch src/bun.ts"
   },
@@ -10,7 +10,7 @@
     "@hono/swagger-ui": "^0.5.2",
     "@hono/zod-openapi": "^0.19.2",
     "@peculiar/x509": "^1.13.0",
-    "authhero": "^0.259.0",
+    "authhero": "^0.260.0",
     "better-sqlite3": "^12.2.0",
     "hono": "^4.9.1",
     "hono-openapi-middlewares": "^1.0.11",

--- a/packages/authhero/CHANGELOG.md
+++ b/packages/authhero/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authhero
 
+## 0.260.0
+
+### Minor Changes
+
+- Use authorization type form authorize request when impersonating
+
 ## 0.259.0
 
 ### Minor Changes

--- a/packages/authhero/package.json
+++ b/packages/authhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authhero",
-  "version": "0.259.0",
+  "version": "0.260.0",
   "files": [
     "dist"
   ],

--- a/packages/authhero/src/routes/universal-login/impersonate.tsx
+++ b/packages/authhero/src/routes/universal-login/impersonate.tsx
@@ -10,11 +10,7 @@ import MessagePage from "../../components/MessagePage";
 import i18next from "i18next";
 import { createLogMessage } from "../../utils/create-log-message";
 import { waitUntil } from "../../helpers/wait-until";
-import {
-  LogTypes,
-  AuthorizationResponseType,
-  AuthorizationResponseMode,
-} from "@authhero/adapter-interfaces";
+import { LogTypes } from "@authhero/adapter-interfaces";
 
 export const impersonateRoutes = new OpenAPIHono<{
   Bindings: Bindings;
@@ -363,14 +359,10 @@ export const impersonateRoutes = new OpenAPIHono<{
       waitUntil(ctx, ctx.env.data.logs.create(client.tenant.id, logMessage));
 
       // Continue with the authentication flow using the impersonated user
-      // Force response_type to token_id_token for impersonation to include act claim immediately
+      // Use the original response_type and response_mode from the authorize request
       return createFrontChannelAuthResponse(ctx, {
         client,
-        authParams: {
-          ...loginSession.authParams,
-          response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
-          response_mode: AuthorizationResponseMode.QUERY,
-        },
+        authParams: loginSession.authParams,
         loginSession,
         user: targetUser,
         sessionId: currentSession.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Impersonation now respects the original authorization type and parameters from the initial request instead of forcing a predetermined flow.

* **Minor Changes**
  * User context information is now included in impersonation authorization responses to properly track impersonation origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->