### PR TITLE
Fix client credentials permissions

### DIFF
--- a/.changeset/twenty-lines-take.md
+++ b/.changeset/twenty-lines-take.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Fix permissions for client credentials flow

--- a/packages/authhero/src/authentication-flows/client-credentials.ts
+++ b/packages/authhero/src/authentication-flows/client-credentials.ts
@@ -34,7 +34,7 @@ export async function clientCredentialsGrant(
   const authParams: AuthParams = {
     client_id: client.client_id,
     scope: params.scope,
-    audience: params.audience,
+    audience: params.audience || client.tenant.default_audience,
   };
 
   return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permissions handling in client credentials authentication flow when using default tenant audience configuration.

* **Tests**
  * Added test coverage for client credentials flow with tenant default audience settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->