### PR TITLE
Update refresh token error code

### DIFF
--- a/.changeset/mean-hats-march.md
+++ b/.changeset/mean-hats-march.md
@@ -1,0 +1,6 @@
+---
+"authhero": minor
+"@authhero/docs": minor
+---
+
+Change to return 400 for refresh token error code

--- a/apps/docs/auth0-comparison/index.md
+++ b/apps/docs/auth0-comparison/index.md
@@ -189,6 +189,29 @@ Migrate from Auth0 with minimal code changes:
 
 ## Key Behavioral Differences
 
+### Refresh Token Error Status Codes
+
+**Auth0 Behavior**: Auth0 returns a `403 Forbidden` status code when a refresh token is invalid or expired.
+
+**AuthHero Behavior**: AuthHero returns a `400 Bad Request` status code for invalid or expired refresh tokens, in compliance with [RFC 6749 (OAuth 2.0)](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) which specifies that invalid grant errors should use HTTP 400.
+
+**Why the difference?**
+
+- **Standards Compliance**: OAuth 2.0 specification requires 400 for invalid grant errors
+- **Industry Standard**: Other major identity providers (Okta, Azure AD, Google) also return 400
+- **Proper Semantics**: 400 indicates a client error (bad request), while 403 indicates authorization failure
+
+**Impact**: While most OAuth clients validate the error response body rather than the status code, some clients and monitoring tools may rely on the status code. This difference ensures better interoperability with standard OAuth 2.0 clients and tools.
+
+**Example Error Response**:
+
+```json
+{
+  "error": "invalid_grant",
+  "error_description": "Invalid refresh token"
+}
+```
+
 ### Token Issuance Without Audience
 
 **Auth0 Behavior**: When no `audience` parameter is provided in the token request and no default audience is configured, Auth0 returns an **opaque (non-JWT) access token**.

--- a/packages/authhero/src/authentication-flows/refresh-token.ts
+++ b/packages/authhero/src/authentication-flows/refresh-token.ts
@@ -41,10 +41,9 @@ export async function refreshTokenGrant(
     params.refresh_token,
   );
 
-  // These error codes should ne 400's according to the OAuth2 spec, but it seems auth0 uses 403's
   if (!refreshToken) {
     appendLog(ctx, `Invalid refresh token: ${params.refresh_token}`);
-    throw new JSONHTTPException(403, {
+    throw new JSONHTTPException(400, {
       error: "invalid_grant",
       error_description: "Invalid refresh token",
     });
@@ -55,7 +54,7 @@ export async function refreshTokenGrant(
       new Date(refreshToken.idle_expires_at) < new Date())
   ) {
     appendLog(ctx, `Refresh token has expired: ${params.refresh_token}`);
-    throw new JSONHTTPException(403, {
+    throw new JSONHTTPException(400, {
       error: "invalid_grant",
       error_description: "Refresh token has expired",
     });

--- a/packages/authhero/test/routes/auth-api/token.spec.ts
+++ b/packages/authhero/test/routes/auth-api/token.spec.ts
@@ -942,7 +942,7 @@ describe("token", () => {
       expect(refreshToken.idle_expires_at).not.toBe(idle_expires_at);
     });
 
-    it("should return a 403 for a expired refresh token", async () => {
+    it("should return a 400 for a expired refresh token", async () => {
       const { oauthApp, env } = await getTestServer();
       const client = testClient(oauthApp, env);
 
@@ -981,7 +981,7 @@ describe("token", () => {
         { headers: { "tenant-id": "tenantId" } },
       );
 
-      expect(response.status).toBe(403);
+      expect(response.status).toBe(400);
       const body = (await response.json()) as ErrorResponse;
       expect(body).toEqual({
         error: "invalid_grant",
@@ -989,7 +989,7 @@ describe("token", () => {
       });
     });
 
-    it("should return a 403 for a idle expired refresh token", async () => {
+    it("should return a 400 for a idle expired refresh token", async () => {
       const { oauthApp, env } = await getTestServer();
       const client = testClient(oauthApp, env);
 
@@ -1028,7 +1028,7 @@ describe("token", () => {
         { headers: { "tenant-id": "tenantId" } },
       );
 
-      expect(response.status).toBe(403);
+      expect(response.status).toBe(400);
       const body = (await response.json()) as ErrorResponse;
       expect(body).toEqual({
         error: "invalid_grant",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refresh token errors now return HTTP 400 status code to align with OAuth 2.0 RFC 6749 standards.

* **Documentation**
  * Clarified refresh token error handling behavior compared to other providers.
  * Added guidance on token issuance audience requirements with implementation examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->