### PR TITLE
Migrate to controle plane

### DIFF
--- a/.changeset/sour-ravens-shout.md
+++ b/.changeset/sour-ravens-shout.md
@@ -1,0 +1,9 @@
+---
+"@authhero/multi-tenancy": minor
+"authhero": minor
+"@authhero/react-admin": minor
+"@authhero/kysely-adapter": minor
+"@authhero/docs": minor
+---
+
+Change from main to control plane

--- a/apps/docs/packages/multi-tenancy/control-plane.md
+++ b/apps/docs/packages/multi-tenancy/control-plane.md
@@ -1,0 +1,525 @@
+# Control Plane Architecture
+
+The multi-tenancy package uses a **control plane** architecture where a central tenant manages and provisions all other tenants in the system.
+
+## Overview
+
+The control plane acts as the management layer for your entire multi-tenant system:
+
+- **Centralized Management**: All tenant management operations happen on the control plane
+- **Entity Synchronization**: Resource servers and roles from the control plane are synced to child tenants
+- **Organization Mapping**: Organizations on the control plane map to individual child tenants
+- **Access Control**: Controls who can access which tenants via organization membership
+
+## Control Plane vs Child Tenants
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        CONTROL PLANE (main)                              │
+│                                                                          │
+│  Organizations                   System Entities                        │
+│  ┌──────────────┐               ┌──────────────────┐                   │
+│  │ org: "acme"  │               │ Resource Servers │                   │
+│  │ users:       │               │  - Management API│                   │
+│  │  - alice     │               │  - My API        │                   │
+│  │  - bob       │               │                  │                   │
+│  └──────────────┘               │ Roles            │                   │
+│                                 │  - Admin         │                   │
+│  ┌──────────────┐               │  - User          │                   │
+│  │ org:"widgets"│               │  - Viewer        │                   │
+│  │ users:       │               └──────────────────┘                   │
+│  │  - charlie   │                                                       │
+│  └──────────────┘                                                       │
+│                                                                          │
+└──────────────────┬─────────────────────────────────┬─────────────────────┘
+                   │ Synced Entities                 │
+                   ▼                                 ▼
+        ┌──────────────────┐              ┌──────────────────┐
+        │ TENANT: acme     │              │ TENANT: widgets  │
+        │                  │              │                  │
+        │ Organizations    │              │ Organizations    │
+        │  - Sales Dept    │              │  - Engineering   │
+        │  - Marketing     │              │  - Product       │
+        │                  │              │                  │
+        │ Resource Servers │              │ Resource Servers │
+        │  - Management API│ (synced)     │  - Management API│ (synced)
+        │  - My API        │ (synced)     │  - My API        │ (synced)
+        │                  │              │                  │
+        │ Roles            │              │ Roles            │
+        │  - Admin         │ (synced)     │  - Admin         │ (synced)
+        │  - User          │ (synced)     │  - User          │ (synced)
+        │  - Viewer        │ (synced)     │  - Viewer        │ (synced)
+        │                  │              │                  │
+        │ Users            │              │ Users            │
+        │  - end-user-1    │              │  - end-user-2    │
+        │  - end-user-2    │              │  - end-user-3    │
+        └──────────────────┘              └──────────────────┘
+```
+
+### Key Differences
+
+| Aspect | Control Plane | Child Tenants |
+|--------|--------------|---------------|
+| **Purpose** | Manages all tenants | Isolated customer environments |
+| **Organizations** | Map to child tenants | Internal business units |
+| **Users on Orgs** | Tenant administrators | Not used for tenant access |
+| **Resource Servers** | Synced to all tenants | Synced from control plane |
+| **Roles** | Synced to all tenants | Synced from control plane |
+| **End Users** | System administrators | Customer end users |
+
+## Entity Synchronization
+
+When you create or update entities on the control plane, they are automatically synchronized to all child tenants.
+
+### Synced Entities
+
+#### 1. Resource Servers
+
+Resource servers created on the control plane are automatically synced to all child tenants with the `is_system: true` flag.
+
+```typescript
+// Create a resource server on control plane
+await adapters.resourceServers.create("main", {
+  name: "My API",
+  identifier: "https://api.example.com",
+  scopes: [
+    { value: "read:data", description: "Read data" },
+    { value: "write:data", description: "Write data" },
+  ],
+});
+
+// Automatically synced to all child tenants:
+// - tenant: acme
+// - tenant: widgets
+// - tenant: demo
+// All with is_system: true
+```
+
+**Key Points:**
+- Marked as `is_system: true` on child tenants
+- Cannot be modified on child tenants
+- Updates on control plane are synced to all tenants
+- Deletions on control plane remove from all tenants
+
+#### 2. Roles
+
+Roles created on the control plane are automatically synced to all child tenants.
+
+```typescript
+// Create a role on control plane
+await adapters.roles.create("main", {
+  name: "Admin",
+  description: "Administrator role",
+});
+
+// Automatically synced to all child tenants with is_system: true
+```
+
+**Key Points:**
+- Marked as `is_system: true` on child tenants
+- Cannot be modified on child tenants
+- Role permissions are also synced
+- Updates and deletions are propagated
+
+#### 3. Role Permissions
+
+When roles are synced, their permissions are also synchronized.
+
+```typescript
+// Assign permissions on control plane
+await adapters.rolePermissions.assign("main", adminRoleId, [
+  {
+    role_id: adminRoleId,
+    resource_server_identifier: "https://api.example.com",
+    permission_name: "read:data",
+  },
+]);
+
+// Permissions are synced to the same role on all child tenants
+```
+
+### Configuration
+
+Enable entity synchronization when setting up multi-tenancy:
+
+```typescript
+import {
+  setupMultiTenancy,
+  createTenantResourceServerSyncHooks,
+  createTenantRoleSyncHooks,
+} from "@authhero/multi-tenancy";
+
+// Create sync hooks
+const resourceServerSync = createTenantResourceServerSyncHooks({
+  controlPlaneTenantId: "main",
+  getControlPlaneAdapters: async () => mainAdapters,
+  getAdapters: async (tenantId) => getTenantAdapters(tenantId),
+});
+
+const roleSync = createTenantRoleSyncHooks({
+  controlPlaneTenantId: "main",
+  getControlPlaneAdapters: async () => mainAdapters,
+  getAdapters: async (tenantId) => getTenantAdapters(tenantId),
+  syncPermissions: true, // Also sync role permissions
+});
+
+// Setup multi-tenancy with sync hooks
+const multiTenancy = setupMultiTenancy({
+  accessControl: {
+    controlPlaneTenantId: "main",
+  },
+  hooks: {
+    resourceServers: resourceServerSync,
+    roles: roleSync,
+  },
+});
+```
+
+### Protected Entities Middleware
+
+System entities synced from the control plane are protected from modification on child tenants:
+
+```typescript
+import { createProtectSyncedMiddleware } from "@authhero/multi-tenancy";
+
+// Apply middleware to management API
+app.use("/api/v2/*", createProtectSyncedMiddleware());
+
+// Now attempts to modify synced entities will return 403
+// PATCH /api/v2/resource-servers/:id (where is_system: true)
+// Response: 403 "This resource server is a system resource and cannot be modified"
+```
+
+## Organizations: Control Plane vs Child Tenants
+
+Organizations serve different purposes depending on where they exist:
+
+### Organizations on Control Plane
+
+Organizations on the control plane represent **child tenants**:
+
+```typescript
+// Create a new tenant
+await fetch("/management/tenants", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    id: "acme",
+    friendly_name: "Acme Corporation",
+  }),
+});
+
+// This automatically creates:
+// 1. Tenant with id "acme"
+// 2. Organization on control plane with name "acme"
+```
+
+**Key characteristics:**
+- Organization name = tenant ID
+- Membership controls tenant administrator access
+- Used for access control to tenant management APIs
+
+**Example use case:**
+```typescript
+// Alice is added to the "acme" organization on control plane
+// This grants her access to manage the acme tenant via:
+// - Token with org_name: "acme" or organization_id: "acme"
+// - Can call management APIs for acme tenant
+```
+
+### Organizations on Child Tenants
+
+Organizations on child tenants represent **internal business units** within that tenant:
+
+```typescript
+// On the "acme" tenant, create departments
+await adapters.organizations.create("acme", {
+  name: "sales-dept",
+  display_name: "Sales Department",
+});
+
+await adapters.organizations.create("acme", {
+  name: "engineering",
+  display_name: "Engineering Department",
+});
+```
+
+**Key characteristics:**
+- Represent departments, teams, or business units
+- Used for B2B customer organization management
+- Not used for tenant access control
+- End users belong to these organizations
+
+**Example use case:**
+```typescript
+// Acme Corporation has two departments:
+// 1. Sales Department - has access to CRM features
+// 2. Engineering - has access to technical resources
+// End users get tokens with org_id for their department
+```
+
+## API Access Methods
+
+There are three ways to call tenant-scoped APIs:
+
+### 1. Organization Token (Recommended)
+
+Request a token with an organization claim via silent authentication:
+
+```typescript
+// Get token for "acme" tenant
+const token = await auth.getTokenSilently({
+  authorizationParams: {
+    organization: "acme",
+  },
+});
+
+// Call any API for acme tenant
+const response = await fetch("https://api.example.com/api/v2/users", {
+  headers: {
+    Authorization: `Bearer ${token}`,
+  },
+});
+
+// Token contains org_name: "acme" or organization_id: "org_xxx"
+// Middleware automatically routes to acme tenant
+```
+
+**How it works:**
+- Token includes `org_name: "acme"` (if `allow_organization_name_in_authentication_api` is enabled)
+- Or `organization_id: "org_xxx"` where org.name = "acme"
+- Access control middleware validates organization membership on control plane
+- Request is automatically scoped to the acme tenant
+
+**Best for:**
+- Production applications
+- Frontend/mobile apps
+- Standard OAuth2/OIDC flows
+
+### 2. Control Plane Token + Tenant Header
+
+Use a control plane token with an explicit tenant ID header:
+
+```typescript
+// Get control plane token (no organization)
+const token = await auth.getTokenSilently();
+
+// Call API with tenant header
+const response = await fetch("https://api.example.com/api/v2/users", {
+  headers: {
+    Authorization: `Bearer ${token}`,
+    "X-Tenant-ID": "acme", // or "tenant-id": "acme"
+  },
+});
+```
+
+**How it works:**
+- Token is for control plane (no org_id)
+- Tenant header explicitly specifies target tenant
+- Access control validates user has access to specified tenant
+- Request is scoped to the tenant from header
+
+**Best for:**
+- Administrative scripts
+- Backend services
+- Migration tools
+- Testing scenarios
+
+### 3. Tenant-Specific Token
+
+Request a token directly from a tenant's authorization endpoint:
+
+```typescript
+// Login directly to acme tenant
+const token = await fetch("https://acme.auth.example.com/oauth/token", {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body: new URLSearchParams({
+    grant_type: "password",
+    username: "user@acme.com",
+    password: "password",
+    client_id: "client_id",
+    scope: "openid profile",
+  }),
+});
+
+// Use token for acme tenant
+const response = await fetch("https://acme.auth.example.com/api/v2/users", {
+  headers: {
+    Authorization: `Bearer ${token.access_token}`,
+  },
+});
+```
+
+**How it works:**
+- Subdomain routing determines tenant (acme.auth.example.com → acme)
+- Token is issued specifically for acme tenant
+- No organization claim needed
+- Request is automatically scoped via subdomain
+
+**Best for:**
+- Subdomain-based deployments
+- Tenant-specific domains
+- White-label scenarios
+- Isolated tenant access
+
+### Comparison Table
+
+| Method | Token Type | Tenant Selection | Use Case |
+|--------|-----------|------------------|----------|
+| **Organization Token** | Control plane with org claim | Via `org_name`/`organization_id` | Production apps, standard OAuth flow |
+| **Token + Header** | Control plane | Via `X-Tenant-ID` header | Admin tools, backend services |
+| **Tenant Token** | Tenant-specific | Via subdomain | White-label, isolated deployments |
+
+## Access Control Flow
+
+### Accessing Control Plane
+
+```typescript
+// User alice has no organization claim
+const token = {
+  sub: "alice",
+  // No org_id or org_name
+};
+
+// ✅ Can access control plane
+GET /management/tenants
+Authorization: Bearer <token>
+
+// ✅ Can list all tenants alice has access to
+// (based on organization memberships on control plane)
+```
+
+### Accessing Child Tenant
+
+```typescript
+// User alice is member of "acme" organization on control plane
+const token = {
+  sub: "alice",
+  org_name: "acme", // or organization_id: "org_xxx"
+};
+
+// ✅ Can access acme tenant
+GET /api/v2/users
+Authorization: Bearer <token>
+
+// ❌ Cannot access widgets tenant
+GET /api/v2/users
+Authorization: Bearer <token>
+X-Tenant-ID: widgets
+// Response: 403 Forbidden
+```
+
+## Example: Complete Multi-Tenant Setup
+
+```typescript
+import { init } from "@authhero/authhero";
+import { getAdapters } from "./adapters";
+
+const app = await init({
+  multiTenancy: {
+    // Define control plane
+    accessControl: {
+      controlPlaneTenantId: "main",
+      requireOrganizationMatch: true,
+      defaultPermissions: ["tenant:admin"],
+    },
+
+    // Enable subdomain routing
+    subdomainRouting: {
+      baseDomain: "auth.example.com",
+      reservedSubdomains: ["www", "api", "admin"],
+    },
+
+    // Sync entities from control plane
+    entitySync: {
+      resourceServers: true,
+      roles: true,
+      permissions: true,
+    },
+
+    // Database isolation per tenant
+    databaseIsolation: {
+      createDatabase: async (tenantId) => {
+        // Create D1 database or Turso instance
+        const db = await createTenantDatabase(tenantId);
+        return getAdapters(db);
+      },
+      deleteDatabase: async (tenantId) => {
+        await deleteTenantDatabase(tenantId);
+      },
+    },
+  },
+
+  // Your other config
+  issuer: "https://auth.example.com/",
+  getAdapters: () => getAdapters(mainDb),
+});
+```
+
+## Best Practices
+
+### 1. Use org_name for Tenant Access
+
+Enable `allow_organization_name_in_authentication_api` on your applications:
+
+```typescript
+await adapters.clients.update("main", clientId, {
+  allow_organization_name_in_authentication_api: true,
+});
+```
+
+This ensures tokens contain `org_name` which directly maps to tenant IDs, avoiding the need to lookup organization IDs.
+
+### 2. Protect System Entities
+
+Always use the protect synced middleware:
+
+```typescript
+import { createProtectSyncedMiddleware } from "@authhero/multi-tenancy";
+
+app.use("/api/v2/*", createProtectSyncedMiddleware());
+```
+
+### 3. Centralize Entity Management
+
+Create all shared resource servers and roles on the control plane:
+
+```typescript
+// ✅ Create on control plane - syncs to all tenants
+await createResourceServer("main", config);
+
+// ❌ Don't create individually on each tenant
+// await createResourceServer("acme", config);
+// await createResourceServer("widgets", config);
+```
+
+### 4. Separate Admin and End Users
+
+- **Control plane users**: Tenant administrators, manage via organizations
+- **Child tenant users**: End customers, authenticate to their specific tenant
+
+### 5. Use Tenant Headers for Admin Operations
+
+For administrative scripts and backend services, use the control plane token with tenant headers rather than switching organizations:
+
+```typescript
+// ✅ Simple admin script
+const adminToken = await getControlPlaneToken();
+
+for (const tenant of tenants) {
+  await fetch(`/api/v2/users`, {
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "X-Tenant-ID": tenant.id,
+    },
+  });
+}
+```
+
+## Next Steps
+
+- [Tenant Lifecycle](./tenant-lifecycle.md) - Learn about creating and managing tenants
+- [Database Isolation](./database-isolation.md) - Set up per-tenant databases
+- [Settings Inheritance](./settings-inheritance.md) - Inherit configuration from control plane
+- [API Reference](./api-reference.md) - Complete API documentation

--- a/apps/docs/packages/multi-tenancy/index.md
+++ b/apps/docs/packages/multi-tenancy/index.md
@@ -6,11 +6,12 @@ Multi-tenancy support for AuthHero with organization-based access control, per-t
 
 This package provides a complete multi-tenancy solution for AuthHero-based authentication systems. It enables you to:
 
-- **Manage multiple tenants** from a single "main" tenant
+- **Manage multiple tenants** from a central control plane
 - **Control access** using organization-based tokens
 - **Isolate data** with per-tenant databases (D1, Turso, or custom)
 - **Route requests** via subdomains
-- **Inherit settings** from the main tenant to child tenants
+- **Sync entities** from control plane to child tenants
+- **Inherit settings** from the control plane to child tenants
 
 ## Installation
 
@@ -29,7 +30,7 @@ import { setupMultiTenancy } from "@authhero/multi-tenancy";
 // Setup multi-tenancy
 const multiTenancy = setupMultiTenancy({
   accessControl: {
-    mainTenantId: "main",
+    controlPlaneTenantId: "main",
     defaultPermissions: ["tenant:admin"],
   },
 });
@@ -49,30 +50,32 @@ app.route(
 
 ## Documentation
 
+- [Control Plane Architecture](./control-plane.md) - Control plane concept, entity sync, and API access methods
 - [Architecture](./architecture.md) - Organization-tenant model and token-based access
 - [Database Isolation](./database-isolation.md) - Per-tenant databases with D1, Turso, or custom
 - [Tenant Lifecycle](./tenant-lifecycle.md) - Creating, managing, and deleting tenants
-- [Settings Inheritance](./settings-inheritance.md) - Inherit configuration from main tenant
+- [Settings Inheritance](./settings-inheritance.md) - Inherit configuration from control plane
 - [Subdomain Routing](./subdomain-routing.md) - Route requests based on subdomains
 - [API Reference](./api-reference.md) - Complete API documentation
 - [Migration Guide](./migration.md) - Moving from single to multi-tenant
 
 ## Key Concepts
 
-### Organization-Tenant Model
+### Control Plane Architecture
 
-The multi-tenancy system uses organizations on a "main" tenant to represent and control access to child tenants:
+The multi-tenancy system uses a **control plane** architecture where a central tenant manages all other tenants:
 
-- **Main Tenant**: The management tenant that controls all other tenants
-- **Organizations**: Each organization on the main tenant maps to a child tenant
+- **Control Plane**: The central management tenant that controls all other tenants
+- **Organizations**: Each organization on the control plane maps to a child tenant
 - **Child Tenants**: Independent tenants with their own users, applications, and configuration
+- **Entity Synchronization**: Resource servers and roles from the control plane are synced to all child tenants
 
 ### Token-Based Access Control
 
-Access to tenants is controlled via the `org_id` claim in JWT tokens:
+Access to tenants is controlled via the `org_name` or `organization_id` claim in JWT tokens:
 
-- **No `org_id`**: Access to main tenant only
-- **With `org_id`**: Access to the tenant matching the organization ID
+- **No org claim**: Access to control plane only
+- **With org claim**: Access to the tenant matching the organization
 
 ### Silent Authentication Flow
 

--- a/packages/multi-tenancy/src/hooks/access-control.ts
+++ b/packages/multi-tenancy/src/hooks/access-control.ts
@@ -8,7 +8,7 @@ import {
  * Creates hooks for organization-based tenant access control.
  *
  * This implements the following access model:
- * - Main tenant: Accessible without an organization claim
+ * - Control plane: Accessible without an organization claim
  * - Child tenants: Require an organization claim matching the tenant ID
  *   - org_name (organization name) takes precedence and should match tenant ID
  *   - org_id (organization ID) is checked as fallback
@@ -19,16 +19,16 @@ import {
 export function createAccessControlHooks(
   config: AccessControlConfig,
 ): Pick<MultiTenancyHooks, "onTenantAccessValidation"> {
-  const { mainTenantId, requireOrganizationMatch = true } = config;
+  const { controlPlaneTenantId, requireOrganizationMatch = true } = config;
 
   return {
     async onTenantAccessValidation(
       ctx: MultiTenancyContext,
       targetTenantId: string,
     ): Promise<boolean> {
-      // Main tenant access - no organization required
-      if (targetTenantId === mainTenantId) {
-        // For main tenant, we allow access without org claim
+      // Control plane access - no organization required
+      if (targetTenantId === controlPlaneTenantId) {
+        // For the control plane, we allow access without org claim
         // The user just needs to be authenticated
         return true;
       }
@@ -64,17 +64,17 @@ export function createAccessControlHooks(
  * @param organizationId - The organization ID from the token (may be undefined)
  * @param orgName - The organization name from the token (may be undefined, takes precedence)
  * @param targetTenantId - The tenant ID being accessed
- * @param mainTenantId - The main/management tenant ID
+ * @param controlPlaneTenantId - The control plane/management tenant ID
  * @returns true if access is allowed
  */
 export function validateTenantAccess(
   organizationId: string | undefined,
   targetTenantId: string,
-  mainTenantId: string,
+  controlPlaneTenantId: string,
   orgName?: string,
 ): boolean {
-  // Main tenant is always accessible (for management operations)
-  if (targetTenantId === mainTenantId) {
+  // Control plane is always accessible (for management operations)
+  if (targetTenantId === controlPlaneTenantId) {
     return true;
   }
 

--- a/packages/multi-tenancy/src/middleware/protect-synced.ts
+++ b/packages/multi-tenancy/src/middleware/protect-synced.ts
@@ -56,7 +56,7 @@ function parseEntityFromPath(path: string): EntityInfo | null {
 }
 
 /**
- * Check if an entity is a system entity from the main tenant
+ * Check if an entity is a system entity from the control plane
  *
  * @param adapters - Data adapters
  * @param tenantId - The tenant ID
@@ -110,10 +110,10 @@ function getEntityTypeName(type: SystemEntityType): string {
  * Creates middleware to protect system resources from modification.
  *
  * This middleware intercepts write operations (PATCH, PUT, DELETE) on
- * entities that are marked as system entities from the main tenant and returns a 403
+ * entities that are marked as system entities from the control plane and returns a 403
  * error if modification is attempted.
  *
- * System resources can only be modified in the main tenant, and changes
+ * System resources can only be modified in the control plane, and changes
  * will be propagated to child tenants automatically.
  *
  * @returns Hono middleware handler
@@ -154,7 +154,7 @@ export function createProtectSyncedMiddleware(): MiddlewareHandler<{
     const isSystem = await isSystemEntity(ctx.env.data, tenantId, entityInfo);
     if (isSystem) {
       throw new HTTPException(403, {
-        message: `This ${getEntityTypeName(entityInfo.type)} is a system resource and cannot be modified. Make changes in the main tenant instead.`,
+        message: `This ${getEntityTypeName(entityInfo.type)} is a system resource and cannot be modified. Make changes in the control plane instead.`,
       });
     }
 

--- a/packages/multi-tenancy/src/plugin.ts
+++ b/packages/multi-tenancy/src/plugin.ts
@@ -65,7 +65,7 @@ export interface AuthHeroPlugin {
  *   plugins: [
  *     createMultiTenancyPlugin({
  *       accessControl: {
- *         mainTenantId: "main",
+ *         controlPlaneTenantId: "main",
  *         defaultPermissions: ["tenant:admin"],
  *       },
  *       subdomainRouting: {
@@ -103,7 +103,7 @@ export function createMultiTenancyPlugin(
       console.log("Multi-tenancy plugin registered");
       if (config.accessControl) {
         console.log(
-          `  - Access control enabled (main tenant: ${config.accessControl.mainTenantId})`,
+          `  - Access control enabled (control plane: ${config.accessControl.controlPlaneTenantId})`,
         );
       }
       if (config.subdomainRouting) {

--- a/packages/multi-tenancy/src/routes/tenants-openapi.ts
+++ b/packages/multi-tenancy/src/routes/tenants-openapi.ts
@@ -76,13 +76,13 @@ export function createTenantsOpenAPIRouter(
 
       // If access control is enabled, filter tenants based on user's organization memberships
       if (config.accessControl && user?.sub) {
-        const mainTenantId = config.accessControl.mainTenantId;
+        const controlPlaneTenantId = config.accessControl.controlPlaneTenantId;
 
-        // Get all organizations the user belongs to on the main tenant
+        // Get all organizations the user belongs to on the control plane
         const userOrgs = await fetchAll<{ id: string; name: string }>(
           (params) =>
             ctx.env.data.userOrganizations.listUserOrganizations(
-              mainTenantId,
+              controlPlaneTenantId,
               user.sub,
               params,
             ),
@@ -93,9 +93,9 @@ export function createTenantsOpenAPIRouter(
         // (organization name is set to tenant ID when creating tenant organizations)
         const accessibleTenantIds = userOrgs.map((org) => org.name);
 
-        // Always include the main tenant if the user is authenticated
-        if (!accessibleTenantIds.includes(mainTenantId)) {
-          accessibleTenantIds.push(mainTenantId);
+        // Always include the control plane if the user is authenticated
+        if (!accessibleTenantIds.includes(controlPlaneTenantId)) {
+          accessibleTenantIds.push(controlPlaneTenantId);
         }
 
         // Get all tenants and filter to only those the user has access to
@@ -182,10 +182,10 @@ export function createTenantsOpenAPIRouter(
       // Validate access via organization membership
       if (config.accessControl) {
         const user = ctx.var.user;
-        const mainTenantId = config.accessControl.mainTenantId;
+        const controlPlaneTenantId = config.accessControl.controlPlaneTenantId;
 
-        // Main tenant is accessible to any authenticated user
-        if (id !== mainTenantId) {
+        // Control plane is accessible to any authenticated user
+        if (id !== controlPlaneTenantId) {
           if (!user?.sub) {
             throw new HTTPException(401, {
               message: "Authentication required",
@@ -196,7 +196,7 @@ export function createTenantsOpenAPIRouter(
           const userOrgs = await fetchAll<{ id: string; name: string }>(
             (params) =>
               ctx.env.data.userOrganizations.listUserOrganizations(
-                mainTenantId,
+                controlPlaneTenantId,
                 user.sub,
                 params,
               ),
@@ -342,7 +342,7 @@ export function createTenantsOpenAPIRouter(
       // Validate access via organization membership
       if (config.accessControl) {
         const user = ctx.var.user;
-        const mainTenantId = config.accessControl.mainTenantId;
+        const controlPlaneTenantId = config.accessControl.controlPlaneTenantId;
 
         if (!user?.sub) {
           throw new HTTPException(401, {
@@ -350,13 +350,13 @@ export function createTenantsOpenAPIRouter(
           });
         }
 
-        // Main tenant can only be updated by users who have access to it
+        // Control plane can only be updated by users who have access to it
         // For child tenants, check organization membership
-        if (id !== mainTenantId) {
+        if (id !== controlPlaneTenantId) {
           const userOrgs = await fetchAll<{ id: string; name: string }>(
             (params) =>
               ctx.env.data.userOrganizations.listUserOrganizations(
-                mainTenantId,
+                controlPlaneTenantId,
                 user.sub,
                 params,
               ),
@@ -441,7 +441,7 @@ export function createTenantsOpenAPIRouter(
           description: "Tenant deleted",
         },
         403: {
-          description: "Access denied or cannot delete main tenant",
+          description: "Access denied or cannot delete the control plane",
         },
         404: {
           description: "Tenant not found",
@@ -451,10 +451,10 @@ export function createTenantsOpenAPIRouter(
     async (ctx) => {
       const { id } = ctx.req.valid("param");
 
-      // Validate access and prevent deleting main tenant
+      // Validate access and prevent deleting the control plane
       if (config.accessControl) {
         const user = ctx.var.user;
-        const mainTenantId = config.accessControl.mainTenantId;
+        const controlPlaneTenantId = config.accessControl.controlPlaneTenantId;
 
         if (!user?.sub) {
           throw new HTTPException(401, {
@@ -462,10 +462,10 @@ export function createTenantsOpenAPIRouter(
           });
         }
 
-        // Cannot delete the main tenant
-        if (id === mainTenantId) {
+        // Cannot delete the control plane
+        if (id === controlPlaneTenantId) {
           throw new HTTPException(403, {
-            message: "Cannot delete the main tenant",
+            message: "Cannot delete the control plane",
           });
         }
 
@@ -473,7 +473,7 @@ export function createTenantsOpenAPIRouter(
         const userOrgs = await fetchAll<{ id: string; name: string }>(
           (params) =>
             ctx.env.data.userOrganizations.listUserOrganizations(
-              mainTenantId,
+              controlPlaneTenantId,
               user.sub,
               params,
             ),

--- a/packages/multi-tenancy/src/types.ts
+++ b/packages/multi-tenancy/src/types.ts
@@ -36,36 +36,36 @@ export type MultiTenancyContext = Context<{
  * Configuration for organization-based tenant access control.
  *
  * This enables a model where:
- * - A "main" tenant manages all other tenants
- * - Organizations on the main tenant correspond to child tenants
+ * - A "control plane" tenant manages all other tenants
+ * - Organizations on the control plane correspond to child tenants
  * - Tokens with an org claim can access the matching tenant
- * - Tokens without an org claim can only access the main tenant
+ * - Tokens without an org claim can only access the control plane
  */
 export interface AccessControlConfig {
   /**
-   * The main/management tenant ID.
-   * This is the "master" tenant that manages all other tenants.
+   * The control plane tenant ID.
+   * This is the tenant that manages all other tenants.
    * Tokens without an organization claim can access this tenant.
    */
-  mainTenantId: string;
+  controlPlaneTenantId: string;
 
   /**
    * If true, tokens must have an organization claim matching the target tenant ID
-   * (except for main tenant access where no org is required).
+   * (except for control plane access where no org is required).
    * @default true
    */
   requireOrganizationMatch?: boolean;
 
   /**
    * Permissions to automatically grant when creating an organization
-   * for a new tenant on the main tenant.
+   * for a new tenant on the control plane.
    * @example ["tenant:admin", "tenant:read", "tenant:write"]
    */
   defaultPermissions?: string[];
 
   /**
    * Roles to automatically assign to the organization when created.
-   * These roles should exist on the main tenant.
+   * These roles should exist on the control plane.
    */
   defaultRoles?: string[];
 
@@ -151,19 +151,19 @@ export interface DatabaseIsolationConfig {
 /**
  * Configuration for tenant settings inheritance.
  *
- * This enables child tenants to inherit default settings from the main tenant,
+ * This enables child tenants to inherit default settings from the control plane,
  * reducing configuration overhead and ensuring consistency.
  */
 export interface SettingsInheritanceConfig {
   /**
-   * If true, new tenants will inherit settings from the main tenant
+   * If true, new tenants will inherit settings from the control plane
    * as their default configuration.
    * @default true
    */
-  inheritFromMain?: boolean;
+  inheritFromControlPlane?: boolean;
 
   /**
-   * Specific settings keys to inherit from the main tenant.
+   * Specific settings keys to inherit from the control plane.
    * If not provided, all settings are inherited.
    */
   inheritedKeys?: (keyof Tenant)[];
@@ -178,7 +178,7 @@ export interface SettingsInheritanceConfig {
    * Custom function to transform inherited settings before applying.
    */
   transformSettings?: (
-    mainTenantSettings: Partial<Tenant>,
+    controlPlaneSettings: Partial<Tenant>,
     newTenantId: string,
   ) => Partial<Tenant>;
 }
@@ -187,7 +187,7 @@ export interface SettingsInheritanceConfig {
  * Configuration for subdomain-based tenant routing.
  *
  * This enables using subdomains to route requests to different tenants,
- * where the subdomain matches an organization ID on the main tenant.
+ * where the subdomain matches an organization ID on the control plane.
  */
 export interface SubdomainRoutingConfig {
   /**
@@ -198,7 +198,7 @@ export interface SubdomainRoutingConfig {
 
   /**
    * If true, use organizations to resolve subdomains to tenants.
-   * The subdomain will be matched against organization IDs on the main tenant.
+   * The subdomain will be matched against organization IDs on the control plane.
    * @default true
    */
   useOrganizations?: boolean;
@@ -223,13 +223,13 @@ export interface SubdomainRoutingConfig {
  *
  * - **accessControl**: Organization-based tenant access validation
  * - **databaseIsolation**: Per-tenant database instances
- * - **settingsInheritance**: Inherit settings from main tenant
+ * - **settingsInheritance**: Inherit settings from control plane
  * - **subdomainRouting**: Route requests via subdomains
  */
 export interface MultiTenancyConfig {
   /**
    * Organization-based access control configuration.
-   * Links organizations on the main tenant to tenant access.
+   * Links organizations on the control plane to tenant access.
    */
   accessControl?: AccessControlConfig;
 
@@ -275,7 +275,7 @@ export interface TenantHookContext {
  * ```typescript
  * const tenantHooks: TenantEntityHooks = {
  *   afterCreate: async (ctx, tenant) => {
- *     // Copy resource servers from main tenant
+ *     // Copy resource servers from the control plane
  *     await syncResourceServersToNewTenant(ctx, tenant);
  *   },
  *   beforeDelete: async (ctx, tenantId) => {

--- a/packages/multi-tenancy/test/multi-tenancy.test.ts
+++ b/packages/multi-tenancy/test/multi-tenancy.test.ts
@@ -32,16 +32,16 @@ describe("Multi-Tenancy", () => {
     // Create env object (simulating Cloudflare Workers environment)
     env = { data: adapters };
 
-    // Create main tenant
+    // Create control plane tenant
     await adapters.tenants.create({
       id: "main",
-      friendly_name: "Main Tenant",
+      friendly_name: "Control Plane",
       audience: "https://example.com",
       sender_email: "admin@example.com",
-      sender_name: "Main Tenant",
+      sender_name: "Control Plane",
     });
 
-    // Create a test user on the main tenant
+    // Create a test user on the control plane
     await adapters.users.create("main", {
       user_id: testUserId,
       email: "test@example.com",
@@ -55,7 +55,7 @@ describe("Multi-Tenancy", () => {
     // Setup multi-tenancy with access control for organization creation
     const multiTenancy = setupMultiTenancy({
       accessControl: {
-        mainTenantId: "main",
+        controlPlaneTenantId: "main",
         requireOrganizationMatch: false, // Disable strict organization matching for tests
         defaultPermissions: ["tenant:admin"],
       },
@@ -120,7 +120,7 @@ describe("Multi-Tenancy", () => {
     expect(acmeTenant).toBeDefined();
     expect(acmeTenant?.friendly_name).toBe("Acme Corporation");
 
-    // Verify organization was created on main tenant
+    // Verify organization was created on control plane
     const orgs = await adapters.organizations.list("main");
     const acmeOrg = orgs.organizations.find((org) => org.name === "acme");
     expect(acmeOrg).toBeDefined();
@@ -364,7 +364,7 @@ describe("Multi-Tenancy", () => {
 
     expect(response.status).toBe(201);
 
-    // Verify organization was created on main tenant
+    // Verify organization was created on control plane
     const orgs = await adapters.organizations.list("main");
     const orgTestOrg = orgs.organizations.find(
       (org) => org.name === "org-test",

--- a/packages/multi-tenancy/test/provisioning.test.ts
+++ b/packages/multi-tenancy/test/provisioning.test.ts
@@ -35,16 +35,16 @@ describe("Tenant Provisioning with User Organization Membership", () => {
     // Create env object (simulating Cloudflare Workers environment)
     env = { data: adapters };
 
-    // Create main tenant
+    // Create control plane tenant
     await adapters.tenants.create({
       id: "main",
-      friendly_name: "Main Tenant",
+      friendly_name: "Control Plane",
       audience: "https://example.com",
       sender_email: "admin@example.com",
-      sender_name: "Main Tenant",
+      sender_name: "Control Plane",
     });
 
-    // Create the Management API resource server on the main tenant
+    // Create the Management API resource server on the control plane
     await adapters.resourceServers.create("main", {
       name: "Authhero Management API",
       identifier: MANAGEMENT_API_IDENTIFIER,
@@ -56,7 +56,7 @@ describe("Tenant Provisioning with User Organization Membership", () => {
       scopes: MANAGEMENT_API_SCOPES,
     });
 
-    // Create a test user on the main tenant
+    // Create a test user on the control plane
     await adapters.users.create("main", {
       user_id: TEST_USER_ID,
       email: "testuser@example.com",
@@ -68,7 +68,7 @@ describe("Tenant Provisioning with User Organization Membership", () => {
     // Setup multi-tenancy with access control and issuer for admin role creation
     const multiTenancy = setupMultiTenancy({
       accessControl: {
-        mainTenantId: "main",
+        controlPlaneTenantId: "main",
         requireOrganizationMatch: false,
         issuer: TEST_ISSUER,
         adminRoleName: "Tenant Admin",
@@ -128,7 +128,7 @@ describe("Tenant Provisioning with User Organization Membership", () => {
     const data = await response.json();
     expect(data.id).toBe("new-tenant");
 
-    // Verify organization was created on main tenant
+    // Verify organization was created on control plane
     const orgs = await adapters.organizations.list("main");
     const newTenantOrg = orgs.organizations.find(
       (org) => org.name === "new-tenant",
@@ -170,7 +170,7 @@ describe("Tenant Provisioning with User Organization Membership", () => {
 
     expect(response.status).toBe(201);
 
-    // Verify the Tenant Admin role was created on main tenant
+    // Verify the Tenant Admin role was created on control plane
     const roles = await adapters.roles.list("main", {});
     const adminRole = roles.roles.find((r) => r.name === "Tenant Admin");
     expect(adminRole).toBeDefined();
@@ -303,8 +303,12 @@ describe("Tenant Provisioning with User Organization Membership", () => {
 
     // Verify user has the admin role in both organizations
     const orgs = await adapters.organizations.list("main");
-    const tenantOneOrg = orgs.organizations.find((o) => o.name === "tenant-one");
-    const tenantTwoOrg = orgs.organizations.find((o) => o.name === "tenant-two");
+    const tenantOneOrg = orgs.organizations.find(
+      (o) => o.name === "tenant-one",
+    );
+    const tenantTwoOrg = orgs.organizations.find(
+      (o) => o.name === "tenant-two",
+    );
 
     const adminRole = adminRoles[0]!;
 
@@ -384,16 +388,16 @@ describe("Tenant Provisioning without issuer (no admin role)", () => {
     // Create env object
     env = { data: adapters };
 
-    // Create main tenant
+    // Create control plane tenant
     await adapters.tenants.create({
       id: "main",
-      friendly_name: "Main Tenant",
+      friendly_name: "Control Plane",
       audience: "https://example.com",
       sender_email: "admin@example.com",
-      sender_name: "Main Tenant",
+      sender_name: "Control Plane",
     });
 
-    // Create a test user on the main tenant
+    // Create a test user on the control plane
     await adapters.users.create("main", {
       user_id: TEST_USER_ID,
       email: "testuser@example.com",
@@ -405,7 +409,7 @@ describe("Tenant Provisioning without issuer (no admin role)", () => {
     // Setup multi-tenancy WITHOUT issuer (no admin role will be created)
     const multiTenancy = setupMultiTenancy({
       accessControl: {
-        mainTenantId: "main",
+        controlPlaneTenantId: "main",
         requireOrganizationMatch: false,
         // Note: no issuer provided, so no admin role will be created
         addCreatorToOrganization: true,
@@ -508,16 +512,16 @@ describe("Tenant Provisioning with addCreatorToOrganization disabled", () => {
     // Create env object
     env = { data: adapters };
 
-    // Create main tenant
+    // Create control plane tenant
     await adapters.tenants.create({
       id: "main",
-      friendly_name: "Main Tenant",
+      friendly_name: "Control Plane",
       audience: "https://example.com",
       sender_email: "admin@example.com",
-      sender_name: "Main Tenant",
+      sender_name: "Control Plane",
     });
 
-    // Create a test user on the main tenant
+    // Create a test user on the control plane
     await adapters.users.create("main", {
       user_id: TEST_USER_ID,
       email: "testuser@example.com",
@@ -529,7 +533,7 @@ describe("Tenant Provisioning with addCreatorToOrganization disabled", () => {
     // Setup multi-tenancy with addCreatorToOrganization disabled
     const multiTenancy = setupMultiTenancy({
       accessControl: {
-        mainTenantId: "main",
+        controlPlaneTenantId: "main",
         requireOrganizationMatch: false,
         issuer: "https://auth.example.com/",
         addCreatorToOrganization: false, // Explicitly disabled


### PR DESCRIPTION
The main tenant term wasn't very clear. Control plane is more in line with other products and platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Configuration property `mainTenantId` renamed to `controlPlaneTenantId`; update your configuration accordingly.
  * Token claim terminology updated: `org_id` replaced with `org_name` or `organization_id`.

* **Documentation**
  * Added comprehensive control plane architecture documentation.
  * Updated multi-tenancy guides with control plane concepts and setup instructions.
  * Clarified organization management and token validation flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->