### PR TITLE
Only show selected connections for client

### DIFF
--- a/.changeset/fiery-towns-kneel.md
+++ b/.changeset/fiery-towns-kneel.md
@@ -1,0 +1,7 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+"@authhero/kysely-adapter": minor
+---
+
+Only show the selected connections for a client

--- a/packages/adapter-interfaces/src/types/ResourceServer.ts
+++ b/packages/adapter-interfaces/src/types/ResourceServer.ts
@@ -35,10 +35,7 @@ export const resourceServerInsertSchema = z.object({
   verificationKey: z.string().optional(),
   options: resourceServerOptionsSchema.optional(),
   is_system: z.boolean().optional(),
-  metadata: z.record(z.any()).optional().openapi({
-    description:
-      "Metadata associated with the resource server. Can be used to control sync behavior in multi-tenancy scenarios.",
-  }),
+  metadata: z.record(z.any()).optional(),
 });
 export type ResourceServerInsert = z.input<typeof resourceServerInsertSchema>;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed client connection display to only show configured connections for each application.
  * Added automatic fallback to organization-wide connections when client-specific connections are not defined.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->