### PR TITLE
Add cors for screens endpoints

### DIFF
--- a/.changeset/some-teeth-rhyme.md
+++ b/.changeset/some-teeth-rhyme.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Add cors for the screens endpoints

--- a/packages/authhero/src/routes/universal-login/u2-index.ts
+++ b/packages/authhero/src/routes/universal-login/u2-index.ts
@@ -16,6 +16,7 @@
  */
 
 import { OpenAPIHono } from "@hono/zod-openapi";
+import { cors } from "hono/cors";
 import { AuthHeroConfig, Bindings, Variables } from "../../types";
 import { addDataHooks } from "../../hooks";
 import { addTimingLogs } from "../../helpers/server-timing";
@@ -55,6 +56,17 @@ export default function createU2App(config: AuthHeroConfig) {
     }
     return c.text("Unexpected error", 500);
   });
+
+  // CORS middleware for screen API - allow requests from any origin
+  app.use(
+    "/screen/*",
+    cors({
+      origin: "*",
+      allowHeaders: ["Content-Type", "Tenant-Id"],
+      allowMethods: ["GET", "POST", "OPTIONS"],
+      maxAge: 600,
+    }),
+  );
 
   // Data adapter middleware
   app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Screen API endpoints now support cross-origin requests, allowing applications and services running on different domains to securely access screen functionality. This enhancement significantly improves overall API accessibility and enables seamless integration with external applications across diverse environments. Flexible header configuration provides additional control and customization over request handling and access parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->