### PR TITLE
fix trailing slashes for redirect_uri

### DIFF
--- a/.changeset/ready-otters-wash.md
+++ b/.changeset/ready-otters-wash.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Fix trailings slashes in redirect url

--- a/packages/authhero/src/authentication-flows/authorization-code.ts
+++ b/packages/authhero/src/authentication-flows/authorization-code.ts
@@ -146,7 +146,7 @@ export async function authorizationCodeGrantUser(
     }
   }
 
-  // Validate the redirect_uri
+  // Validate the redirect_uri (RFC 6749 requires exact string comparison)
   if (code.redirect_uri && code.redirect_uri !== params.redirect_uri) {
     logMessage(ctx, client.tenant.id, {
       type: LogTypes.FAILED_EXCHANGE_AUTHORIZATION_CODE_FOR_ACCESS_TOKEN,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected redirect URI validation to use exact string comparison per RFC 6749, ensuring trailing slashes are properly handled
  * Simplified redirect URI processing to preserve query parameters exactly as provided

* **Tests**
  * Added test coverage for redirect URI validation with trailing slash behavior and query parameter preservation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->