### PR TITLE
Add control plane client callbacks

### DIFF
--- a/.changeset/jolly-horses-lick.md
+++ b/.changeset/jolly-horses-lick.md
@@ -1,0 +1,5 @@
+---
+"@authhero/multi-tenancy": minor
+---
+
+Add fallback to control plane client

--- a/packages/multi-tenancy/test/settings-inheritance.test.ts
+++ b/packages/multi-tenancy/test/settings-inheritance.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   DataAdapters,
   Connection,
+  Client,
 } from "@authhero/adapter-interfaces";
 
 // Mock data adapters for testing
@@ -91,8 +92,107 @@ const createMockAdapters = (): DataAdapters => ({
       throw new Error("Not implemented");
     },
   },
+  // Mock clients adapter
+  clients: {
+    get: async (tenantId: string, clientId: string): Promise<Client | null> => {
+      const clients: Record<string, Record<string, Client>> = {
+        "control-plane": {
+          "control-plane-client": {
+            client_id: "control-plane-client",
+            name: "Control Plane Client",
+            callbacks: [
+              "http://localhost:3000/callback",
+              "https://dev.example.com/callback",
+            ],
+            web_origins: ["http://localhost:3000", "https://dev.example.com"],
+            allowed_logout_urls: [
+              "http://localhost:3000",
+              "https://dev.example.com",
+            ],
+            allowed_origins: ["http://localhost:3000"],
+            created_at: "2023-01-01T00:00:00Z",
+            updated_at: "2023-01-01T00:00:00Z",
+          },
+          "other-cp-client": {
+            client_id: "other-cp-client",
+            name: "Other Control Plane Client",
+            callbacks: ["https://other-app.example.com/callback"],
+            web_origins: ["https://other-app.example.com"],
+            allowed_logout_urls: ["https://other-app.example.com"],
+            created_at: "2023-01-01T00:00:00Z",
+            updated_at: "2023-01-01T00:00:00Z",
+          },
+        },
+        "tenant-1": {
+          "tenant-client": {
+            client_id: "tenant-client",
+            name: "Tenant Client",
+            callbacks: ["https://tenant.example.com/callback"],
+            web_origins: ["https://tenant.example.com"],
+            allowed_logout_urls: ["https://tenant.example.com"],
+            created_at: "2023-01-01T00:00:00Z",
+            updated_at: "2023-01-01T00:00:00Z",
+          },
+        },
+      };
+      return clients[tenantId]?.[clientId] || null;
+    },
+    getByClientId: async (
+      clientId: string,
+    ): Promise<(Client & { tenant_id: string }) | null> => {
+      const allClients: Record<string, Client & { tenant_id: string }> = {
+        "control-plane-client": {
+          client_id: "control-plane-client",
+          name: "Control Plane Client",
+          callbacks: [
+            "http://localhost:3000/callback",
+            "https://dev.example.com/callback",
+          ],
+          web_origins: ["http://localhost:3000", "https://dev.example.com"],
+          allowed_logout_urls: [
+            "http://localhost:3000",
+            "https://dev.example.com",
+          ],
+          allowed_origins: ["http://localhost:3000"],
+          tenant_id: "control-plane",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T00:00:00Z",
+        },
+        "other-cp-client": {
+          client_id: "other-cp-client",
+          name: "Other Control Plane Client",
+          callbacks: ["https://other-app.example.com/callback"],
+          web_origins: ["https://other-app.example.com"],
+          allowed_logout_urls: ["https://other-app.example.com"],
+          tenant_id: "control-plane",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T00:00:00Z",
+        },
+        "tenant-client": {
+          client_id: "tenant-client",
+          name: "Tenant Client",
+          callbacks: ["https://tenant.example.com/callback"],
+          web_origins: ["https://tenant.example.com"],
+          allowed_logout_urls: ["https://tenant.example.com"],
+          tenant_id: "tenant-1",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T00:00:00Z",
+        },
+      };
+      return allClients[clientId] || null;
+    },
+    list: async () => ({ clients: [], start: 0, limit: 10, length: 0 }),
+    create: async () => {
+      throw new Error("Not implemented");
+    },
+    update: async () => {
+      throw new Error("Not implemented");
+    },
+    remove: async () => {
+      throw new Error("Not implemented");
+    },
+  },
   // Mock other adapters (empty implementations)
-  clients: {} as any,
   clientGrants: {} as any,
   invites: {} as any,
   branding: {} as any,
@@ -327,6 +427,189 @@ describe("Runtime Fallback Adapter (Settings Inheritance)", () => {
       );
       expect(connection).toBeDefined();
       expect(connection!.options?.client_secret).toBe("control-plane-api-key");
+    });
+  });
+
+  describe("clients", () => {
+    it("should merge callbacks from control plane client", async () => {
+      const client = await fallbackAdapter.clients.get(
+        "tenant-1",
+        "tenant-client",
+      );
+
+      expect(client).toBeDefined();
+      expect(client!.callbacks).toEqual([
+        "http://localhost:3000/callback", // from control plane
+        "https://dev.example.com/callback", // from control plane
+        "https://tenant.example.com/callback", // from tenant
+      ]);
+    });
+
+    it("should merge web_origins from control plane client", async () => {
+      const client = await fallbackAdapter.clients.get(
+        "tenant-1",
+        "tenant-client",
+      );
+
+      expect(client).toBeDefined();
+      expect(client!.web_origins).toEqual([
+        "http://localhost:3000", // from control plane
+        "https://dev.example.com", // from control plane
+        "https://tenant.example.com", // from tenant
+      ]);
+    });
+
+    it("should merge allowed_logout_urls from control plane client", async () => {
+      const client = await fallbackAdapter.clients.get(
+        "tenant-1",
+        "tenant-client",
+      );
+
+      expect(client).toBeDefined();
+      expect(client!.allowed_logout_urls).toEqual([
+        "http://localhost:3000", // from control plane
+        "https://dev.example.com", // from control plane
+        "https://tenant.example.com", // from tenant
+      ]);
+    });
+
+    it("should merge allowed_origins from control plane client", async () => {
+      const client = await fallbackAdapter.clients.get(
+        "tenant-1",
+        "tenant-client",
+      );
+
+      expect(client).toBeDefined();
+      expect(client!.allowed_origins).toEqual([
+        "http://localhost:3000", // from control plane (tenant has none)
+      ]);
+    });
+
+    it("should deduplicate URLs when merging", async () => {
+      // Create a mock where tenant has same URL as control plane
+      const tenantWithDuplicateUrls = {
+        ...mockAdapters,
+        clients: {
+          ...mockAdapters.clients,
+          get: async (
+            tenantId: string,
+            clientId: string,
+          ): Promise<Client | null> => {
+            if (tenantId === "tenant-1" && clientId === "tenant-client") {
+              return {
+                client_id: "tenant-client",
+                name: "Tenant Client",
+                callbacks: [
+                  "http://localhost:3000/callback", // same as control plane
+                  "https://tenant.example.com/callback",
+                ],
+                web_origins: ["https://tenant.example.com"],
+                allowed_logout_urls: ["https://tenant.example.com"],
+                created_at: "2023-01-01T00:00:00Z",
+                updated_at: "2023-01-01T00:00:00Z",
+              };
+            }
+            return mockAdapters.clients.get(tenantId, clientId);
+          },
+        },
+      };
+
+      const adapterWithDuplicates = createRuntimeFallbackAdapter(
+        tenantWithDuplicateUrls as DataAdapters,
+        {
+          controlPlaneTenantId: "control-plane",
+          controlPlaneClientId: "control-plane-client",
+        },
+      );
+
+      const client = await adapterWithDuplicates.clients.get(
+        "tenant-1",
+        "tenant-client",
+      );
+
+      expect(client).toBeDefined();
+      // Should have deduplicated the localhost callback
+      expect(client!.callbacks).toEqual([
+        "http://localhost:3000/callback",
+        "https://dev.example.com/callback",
+        "https://tenant.example.com/callback",
+      ]);
+    });
+
+    it("should not merge for control plane client itself", async () => {
+      const client = await fallbackAdapter.clients.get(
+        "control-plane",
+        "control-plane-client",
+      );
+
+      expect(client).toBeDefined();
+      expect(client!.callbacks).toEqual([
+        "http://localhost:3000/callback",
+        "https://dev.example.com/callback",
+      ]);
+    });
+
+    it("should merge URLs for other clients in control plane tenant", async () => {
+      const client = await fallbackAdapter.clients.get(
+        "control-plane",
+        "other-cp-client",
+      );
+
+      expect(client).toBeDefined();
+      // Other clients in control plane tenant should get merged URLs
+      expect(client!.callbacks).toEqual([
+        "http://localhost:3000/callback", // from control plane client
+        "https://dev.example.com/callback", // from control plane client
+        "https://other-app.example.com/callback", // from other-cp-client
+      ]);
+      expect(client!.web_origins).toEqual([
+        "http://localhost:3000", // from control plane client
+        "https://dev.example.com", // from control plane client
+        "https://other-app.example.com", // from other-cp-client
+      ]);
+    });
+
+    it("should return original client when no control plane configured", async () => {
+      const adapterWithoutControlPlane = createRuntimeFallbackAdapter(
+        mockAdapters,
+        {},
+      );
+      const client = await adapterWithoutControlPlane.clients.get(
+        "tenant-1",
+        "tenant-client",
+      );
+
+      expect(client).toBeDefined();
+      expect(client!.callbacks).toEqual([
+        "https://tenant.example.com/callback",
+      ]);
+    });
+
+    it("should work with getByClientId", async () => {
+      const client = await fallbackAdapter.clients.getByClientId(
+        "tenant-client",
+      );
+
+      expect(client).toBeDefined();
+      expect(client!.tenant_id).toBe("tenant-1");
+      expect(client!.callbacks).toEqual([
+        "http://localhost:3000/callback", // from control plane
+        "https://dev.example.com/callback", // from control plane
+        "https://tenant.example.com/callback", // from tenant
+      ]);
+    });
+
+    it("should not merge getByClientId for control plane client itself", async () => {
+      const client = await fallbackAdapter.clients.getByClientId(
+        "control-plane-client",
+      );
+
+      expect(client).toBeDefined();
+      expect(client!.tenant_id).toBe("control-plane");
+      expect(client!.callbacks).toEqual([
+        "http://localhost:3000/callback",
+        "https://dev.example.com/callback",
+      ]);
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback support for control plane client configuration with automatic URL merging for callbacks, web origins, logout URLs, and allowed origins. Client configurations now inherit from the control plane when tenant-specific values are absent, ensuring consistency across your multi-tenant setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->