### PR TITLE
Handle conversion of is_system

### DIFF
--- a/.changeset/flat-moons-fold.md
+++ b/.changeset/flat-moons-fold.md
@@ -1,0 +1,5 @@
+---
+"@authhero/kysely-adapter": minor
+---
+
+Handle conversion of is_system

--- a/packages/kysely/src/connections/get.ts
+++ b/packages/kysely/src/connections/get.ts
@@ -1,7 +1,7 @@
 import { Kysely } from "kysely";
-import { removeNullProperties } from "../helpers/remove-nulls";
 import { Connection } from "@authhero/adapter-interfaces";
 import { Database } from "../db";
+import { transformConnection } from "./transform";
 
 export function get(db: Kysely<Database>) {
   return async (
@@ -19,12 +19,6 @@ export function get(db: Kysely<Database>) {
       return null;
     }
 
-    const { is_system, ...rest } = connection;
-
-    return removeNullProperties({
-      ...rest,
-      is_system: is_system ? true : undefined,
-      options: JSON.parse(connection.options),
-    });
+    return transformConnection(connection);
   };
 }

--- a/packages/kysely/src/connections/transform.ts
+++ b/packages/kysely/src/connections/transform.ts
@@ -1,0 +1,31 @@
+import { Connection } from "@authhero/adapter-interfaces";
+import { removeNullProperties } from "../helpers/remove-nulls";
+import { Database } from "../db";
+import { Selectable } from "kysely";
+
+type DbConnection = Selectable<Database["connections"]>;
+
+/**
+ * Transform a raw database connection row to a Connection object.
+ * Handles:
+ * - Converting is_system from number (0/1) to boolean/undefined
+ * - Parsing the JSON options field
+ * - Removing null properties
+ */
+export function transformConnection(dbConnection: DbConnection): Connection {
+  const { is_system, ...rest } = dbConnection;
+  return removeNullProperties({
+    ...rest,
+    is_system: is_system ? true : undefined,
+    options: JSON.parse(dbConnection.options),
+  });
+}
+
+/**
+ * Transform multiple raw database connection rows to Connection objects.
+ */
+export function transformConnections(
+  dbConnections: DbConnection[],
+): Connection[] {
+  return dbConnections.map(transformConnection);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of the `is_system` field to properly convert numeric values to boolean format in connection data retrieval.

* **Tests**
  * Added comprehensive tests to validate that the `is_system` field is correctly normalized across all connection retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->