### PR TITLE
inherit scopes

### DIFF
--- a/.changeset/quick-foxes-begin.md
+++ b/.changeset/quick-foxes-begin.md
@@ -1,0 +1,5 @@
+---
+"@authhero/multi-tenancy": minor
+---
+
+Inherit scopes instead of syncing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource servers now inherit scopes at runtime from the control plane with automatic fallback resolution.

* **Changes**
  * Scopes are no longer synchronized during resource server operations; instead, they are dynamically inherited at request time from control plane definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->