### PR TITLE
fix refresh on sub path of react-admin

### DIFF
--- a/.changeset/neat-rabbits-march.md
+++ b/.changeset/neat-rabbits-march.md
@@ -1,0 +1,5 @@
+---
+"@authhero/react-admin": minor
+---
+
+Fix refresh of sub path

--- a/apps/react-admin/src/index.tsx
+++ b/apps/react-admin/src/index.tsx
@@ -11,8 +11,9 @@ import { getSelectedDomainFromStorage } from "./utils/domainUtils";
 const envDomain = import.meta.env.VITE_AUTH0_DOMAIN;
 
 function Root() {
+  // Initialize synchronously from storage to prevent flash of DomainSelector on direct navigation
   const [selectedDomain, setSelectedDomain] = useState<string | null>(
-    envDomain || null,
+    envDomain || getSelectedDomainFromStorage() || null,
   );
   const currentPath = location.pathname;
   const isAuthCallback = currentPath === "/auth-callback";
@@ -22,17 +23,6 @@ function Root() {
     currentPath === "/tenants" ||
     currentPath.startsWith("/tenants/create") ||
     currentPath === "/tenants/";
-
-  // Load domain from cookies on component mount (only when no env domain configured)
-  useEffect(() => {
-    if (envDomain) {
-      return;
-    }
-    const savedDomain = getSelectedDomainFromStorage();
-    if (savedDomain) {
-      setSelectedDomain(savedDomain);
-    }
-  }, []);
 
   // Handle auth callback separately without basename
   if (isAuthCallback) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sub path refresh issue where domain selection settings were not being properly restored from saved preferences. The application now correctly initializes these settings on startup, ensuring users experience seamless navigation between different sub paths and maintain their selected preferences without losing state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->