### PR TITLE
Add custom claims to service tokens

### DIFF
--- a/.changeset/witty-beers-attend.md
+++ b/.changeset/witty-beers-attend.md
@@ -1,0 +1,6 @@
+---
+"authhero": minor
+"@authhero/docs": minor
+---
+
+Add custom claims to service tokens

--- a/apps/docs/auth0-comparison/hooks.md
+++ b/apps/docs/auth0-comparison/hooks.md
@@ -613,8 +613,9 @@ The token API is available in all hooks via `api.token.createServiceToken()`:
 
 ```typescript
 api.token.createServiceToken({
-  scope: string;           // The scope(s) for the token (space-separated)
-  expiresInSeconds?: number; // Optional expiration time (default: 3600 = 1 hour)
+  scope: string;                            // The scope(s) for the token (space-separated)
+  expiresInSeconds?: number;                // Optional expiration time (default: 3600 = 1 hour)
+  customClaims?: Record<string, unknown>;   // Optional custom claims to include in the token
 }): Promise<string>
 ```
 
@@ -624,6 +625,34 @@ The service token is a JWT signed with your AuthHero instance's private key and 
 - **scope**: The requested scope(s)
 - **tenant_id**: Your tenant ID
 - **exp**: Expiration timestamp
+- Any additional **custom claims** you pass via `customClaims`
+
+> **Note:** Reserved JWT claims (`sub`, `iss`, `aud`, `exp`, `nbf`, `iat`, `jti`) cannot be overwritten via `customClaims` — an error will be thrown if attempted.
+
+#### Custom Claims Example
+
+```typescript
+onExecutePostLogin: async (event, api) => {
+  const token = await api.token.createServiceToken({
+    scope: "sync:users",
+    expiresInSeconds: 300,
+    customClaims: {
+      "https://my-app.com/user_id": event.user.user_id,
+      "https://my-app.com/connection": event.connection?.name,
+      action: "post-login-sync",
+    },
+  });
+
+  await fetch("https://api.example.com/sync", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ user: event.user }),
+  });
+},
+```
 
 #### Security Considerations
 

--- a/apps/docs/guides/hooks.md
+++ b/apps/docs/guides/hooks.md
@@ -762,7 +762,8 @@ Validates if an email can be used for signup.
   token: {
     createServiceToken: (params: {
       scope: string,
-      expiresInSeconds?: number
+      expiresInSeconds?: number,
+      customClaims?: Record<string, unknown>
     }) => Promise<string>
   }
 }
@@ -1029,7 +1030,11 @@ Available in all hooks:
 ```typescript
 api.token.createServiceToken({
   scope: 'read:users write:users',
-  expiresInSeconds: 300
+  expiresInSeconds: 300,
+  customClaims: {                        // Optional custom claims
+    'https://my-app.com/role': 'admin',
+    tenant_type: 'enterprise'
+  }
 }): Promise<string>
 ```
 

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -41,9 +41,23 @@ import { createServiceToken } from "../helpers/service-token";
 import { redactUrlForLogging } from "../utils/url";
 import { OnExecuteCredentialsExchangeAPI } from "../types/Hooks";
 
+/**
+ * Minimal client properties actually used by createAuthTokens.
+ * This avoids requiring a full EnrichedClient when only a few fields are needed
+ * (e.g. service tokens).
+ */
+export interface AuthTokenClient {
+  client_id: string;
+  tenant: {
+    audience: string;
+    allow_organization_name_in_authentication_api?: boolean;
+  };
+  auth0_conformant?: boolean;
+}
+
 export interface CreateAuthTokensParams {
   authParams: AuthParams;
-  client: EnrichedClient;
+  client: AuthTokenClient;
   loginSession?: LoginSession;
   user?: User;
   session_id?: string;
@@ -57,6 +71,8 @@ export interface CreateAuthTokensParams {
   impersonatingUser?: User; // The original user who is impersonating
   // OIDC Core 2.1: auth_time is required when max_age is used in authorization request
   auth_time?: number; // Unix timestamp of when the user was authenticated
+  /** Custom claims to add to the access token payload (cannot override reserved claims) */
+  customClaims?: Record<string, unknown>;
 }
 
 const RESERVED_CLAIMS = ["sub", "iss", "aud", "exp", "nbf", "iat", "jti"];
@@ -96,12 +112,14 @@ function buildCredentialsExchangeApi(
       createServiceToken: async (params: {
         scope: string;
         expiresInSeconds?: number;
+        customClaims?: Record<string, unknown>;
       }) => {
         const tokenResponse = await createServiceToken(
           ctx,
           ctx.var.tenant_id,
           params.scope,
           params.expiresInSeconds,
+          params.customClaims,
         );
         return tokenResponse.access_token;
       },
@@ -170,7 +188,18 @@ export async function createAuthTokens(
         ? organization.name.toLowerCase()
         : undefined,
     permissions,
+    // Spread custom claims last so they can add new fields but not override reserved ones above
+    ...params.customClaims,
   };
+
+  // Validate that custom claims don't override reserved JWT claims
+  if (params.customClaims) {
+    for (const claim of RESERVED_CLAIMS) {
+      if (claim in params.customClaims) {
+        throw new Error(`Cannot overwrite reserved claim '${claim}'`);
+      }
+    }
+  }
 
   // Parse scopes to determine which claims to include in id_token
   // Following OIDC Core spec section 5.4 for standard claims
@@ -246,7 +275,7 @@ export async function createAuthTokens(
     await ctx.env.hooks.onExecuteCredentialsExchange(
       {
         ctx,
-        client,
+        client: client as EnrichedClient,
         user,
         request: {
           ip: ctx.var.ip || "",
@@ -1193,7 +1222,10 @@ export async function createFrontChannelAuthResponse(
 // Wrapper to trigger OnExecutePostLogin before issuing tokens or codes
 export async function completeLogin(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
-  params: CreateAuthTokensParams & { responseType?: AuthorizationResponseType },
+  params: Omit<CreateAuthTokensParams, "client"> & {
+    client: EnrichedClient;
+    responseType?: AuthorizationResponseType;
+  },
 ): Promise<TokenResponse | { code: string; state?: string } | Response> {
   let { user } = params;
   const responseType = params.responseType || AuthorizationResponseType.TOKEN;

--- a/packages/authhero/src/helpers/service-token.ts
+++ b/packages/authhero/src/helpers/service-token.ts
@@ -2,7 +2,6 @@ import { Context } from "hono";
 import {
   AuthorizationResponseType,
 } from "@authhero/adapter-interfaces";
-import { EnrichedClient } from "./client";
 import { Bindings, Variables } from "../types";
 import { createAuthTokens } from "../authentication-flows/common";
 
@@ -13,39 +12,18 @@ export async function createServiceToken(
   tenant_id: string,
   scope: string,
   expiresInSeconds?: number,
+  customClaims?: Record<string, unknown>,
 ) {
   const tenant = await ctx.env.data.tenants.get(tenant_id);
   if (!tenant) {
     throw new Error(`Tenant not found: ${tenant_id}`);
   }
 
-  // Create a mock EnrichedClient for service tokens
-  // Using hardcoded AUTH_SERVICE_CLIENT_ID to prevent spoofing
-  const mockClient: EnrichedClient = {
+  const mockClient = {
     client_id: AUTH_SERVICE_CLIENT_ID,
     tenant,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-    name: "Auth Service",
-    global: false,
-    is_first_party: true, // Mark as first party
-    oidc_conformant: false,
     auth0_conformant: true,
-    sso: false,
-    sso_disabled: false,
-    cross_origin_authentication: false,
-    custom_login_page_on: false,
-    require_pushed_authorization_requests: false,
-    require_proof_of_possession: false,
-    client_metadata: {
-      disable_sign_ups: "false",
-      email_validation: "disabled",
-    },
-    // Legacy fields extracted from metadata
-    disable_sign_ups: false,
-    email_validation: "disabled",
-    connections: [],
-  } as EnrichedClient;
+  };
 
   const tokenResponse = await createAuthTokens(ctx, {
     client: mockClient,
@@ -54,6 +32,7 @@ export async function createServiceToken(
       response_type: AuthorizationResponseType.TOKEN,
       scope,
     },
+    customClaims,
   });
 
   return {

--- a/packages/authhero/src/hooks/index.ts
+++ b/packages/authhero/src/hooks/index.ts
@@ -38,12 +38,14 @@ function createTokenAPI(
     createServiceToken: async (params: {
       scope: string;
       expiresInSeconds?: number;
+      customClaims?: Record<string, unknown>;
     }) => {
       const tokenResponse = await createServiceToken(
         ctx,
         tenant_id,
         params.scope,
         params.expiresInSeconds,
+        params.customClaims,
       );
       return tokenResponse.access_token;
     },

--- a/packages/authhero/src/types/Hooks.ts
+++ b/packages/authhero/src/types/Hooks.ts
@@ -172,6 +172,7 @@ export type TokenAPI = {
   createServiceToken: (params: {
     scope: string;
     expiresInSeconds?: number;
+    customClaims?: Record<string, unknown>;
   }) => Promise<string>;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom claims in service tokens, enabling you to attach additional claims to issued tokens.
  * Reserved JWT claims (sub, iss, aud, exp, nbf, iat, jti) cannot be overwritten and will throw an error if attempted.

* **Documentation**
  * Updated documentation with examples and usage patterns for the custom claims capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->