### PR TITLE
Show connection name in react-admin

### DIFF
--- a/.changeset/wicked-pears-type.md
+++ b/.changeset/wicked-pears-type.md
@@ -1,0 +1,5 @@
+---
+"@authhero/react-admin": minor
+---
+
+Show connection name in react-admin

--- a/apps/react-admin/src/components/connections/edit.tsx
+++ b/apps/react-admin/src/components/connections/edit.tsx
@@ -119,6 +119,15 @@ function ConnectionTabbedFrom() {
             </>
           )}
 
+          {record?.strategy === "oidc" && (
+            <TextInput
+              source="name"
+              label="Name"
+              helperText="Unique identifier name for the connection"
+              fullWidth
+            />
+          )}
+
           {["oauth2", "oidc"].includes(record?.strategy) && (
             <>
               <SelectInput


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Name field for OIDC connections in the react-admin interface. Users can now assign and manage unique identifier names for each OIDC connection configuration, enabling better organization and clearer distinction between multiple authentication connections in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->