### PR TITLE
Add support for set_user_root_attributes

### DIFF
--- a/.changeset/fifty-oranges-hope.md
+++ b/.changeset/fifty-oranges-hope.md
@@ -1,0 +1,7 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+"@authhero/react-admin": minor
+---
+
+Add support for set_user_root_attributes

--- a/apps/react-admin/src/components/connections/edit.tsx
+++ b/apps/react-admin/src/components/connections/edit.tsx
@@ -180,6 +180,20 @@ function ConnectionTabbedFrom() {
             </>
           )}
 
+          {!isDbConnection(record?.strategy) && record?.strategy !== "sms" && (
+            <SelectInput
+              source="options.set_user_root_attributes"
+              label="Set User Root Attributes"
+              helperText="Controls when profile data from this connection updates user attributes"
+              choices={[
+                { id: "on_each_login", name: "On Each Login" },
+                { id: "on_first_login", name: "On First Login" },
+                { id: "never_on_login", name: "Never On Login" },
+              ]}
+              defaultValue="on_each_login"
+            />
+          )}
+
           {isDbConnection(record?.strategy) && (
             <>
               <BooleanInput

--- a/packages/adapter-interfaces/src/types/Connection.ts
+++ b/packages/adapter-interfaces/src/types/Connection.ts
@@ -164,6 +164,10 @@ export const connectionOptionsSchema = z.object({
         .optional(),
     })
     .optional(),
+  // Controls when root user attributes are updated from external IdP
+  set_user_root_attributes: z
+    .enum(["on_each_login", "on_first_login", "never_on_login"])
+    .optional(),
 });
 
 export const connectionInsertSchema = z.object({

--- a/packages/authhero/src/authentication-flows/connection.ts
+++ b/packages/authhero/src/authentication-flows/connection.ts
@@ -193,6 +193,7 @@ export async function connectionCallback(
     profileData,
     isSocial: true,
     ip: ctx.var.ip,
+    set_user_root_attributes: connection.options.set_user_root_attributes,
   });
 
   return createFrontChannelAuthResponse(ctx, {

--- a/packages/authhero/src/helpers/users.ts
+++ b/packages/authhero/src/helpers/users.ts
@@ -134,6 +134,45 @@ export async function getPrimaryUserByProvider({
   return userAdapter.get(tenant_id, user.linked_to);
 }
 
+interface RootAttributes {
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  nickname?: string;
+  picture?: string;
+  email_verified?: boolean;
+  phone_number?: string;
+  phone_verified?: boolean;
+}
+
+function extractRootAttributesFromProfile(
+  profileData: Record<string, unknown>,
+): RootAttributes {
+  const attrs: RootAttributes = {};
+
+  if (typeof profileData.name === "string") attrs.name = profileData.name;
+  if (typeof profileData.given_name === "string")
+    attrs.given_name = profileData.given_name;
+  if (typeof profileData.family_name === "string")
+    attrs.family_name = profileData.family_name;
+  if (typeof profileData.nickname === "string")
+    attrs.nickname = profileData.nickname;
+  if (typeof profileData.picture === "string")
+    attrs.picture = profileData.picture;
+  if (typeof profileData.email_verified === "boolean")
+    attrs.email_verified = profileData.email_verified;
+  if (typeof profileData.phone_number === "string")
+    attrs.phone_number = profileData.phone_number;
+  // Vipps uses "phone_number_verified", OIDC standard uses "phone_verified"
+  if (typeof profileData.phone_number_verified === "boolean") {
+    attrs.phone_verified = profileData.phone_number_verified;
+  } else if (typeof profileData.phone_verified === "boolean") {
+    attrs.phone_verified = profileData.phone_verified;
+  }
+
+  return attrs;
+}
+
 interface GetOrCreateUserByProviderParams {
   client: EnrichedClient;
   username: string;
@@ -143,6 +182,10 @@ interface GetOrCreateUserByProviderParams {
   profileData?: Record<string, unknown>;
   ip?: string;
   isSocial: boolean;
+  set_user_root_attributes?:
+    | "on_each_login"
+    | "on_first_login"
+    | "never_on_login";
 }
 
 /**
@@ -163,7 +206,14 @@ export async function getOrCreateUserByProvider(
     isSocial,
     profileData = {},
     ip = "",
+    set_user_root_attributes,
   } = params;
+
+  const effectiveMode = set_user_root_attributes || "on_each_login";
+  const rootAttrs =
+    effectiveMode !== "never_on_login"
+      ? extractRootAttributesFromProfile(profileData)
+      : {};
 
   let user = await getPrimaryUserByProvider({
     userAdapter: ctx.env.data.users,
@@ -177,14 +227,19 @@ export async function getOrCreateUserByProvider(
       user_id: `${provider}|${userId || userIdGenerate()}`,
       email:
         connection !== "sms" && username.includes("@") ? username : undefined,
-      phone_number: connection === "sms" ? username : undefined,
+      phone_number:
+        connection === "sms" ? username : rootAttrs.phone_number,
       username:
         !username.includes("@") && connection !== "sms" ? username : undefined,
-      name: username,
+      name: rootAttrs.name || username,
+      given_name: rootAttrs.given_name,
+      family_name: rootAttrs.family_name,
+      nickname: rootAttrs.nickname,
+      picture: rootAttrs.picture,
+      phone_verified: rootAttrs.phone_verified,
       provider,
       connection,
-      // Assume all auth providers verify emails for now
-      email_verified: true,
+      email_verified: rootAttrs.email_verified ?? (isSocial ? true : false),
       last_ip: ip,
       is_social: isSocial,
       last_login: new Date().toISOString(),
@@ -194,6 +249,23 @@ export async function getOrCreateUserByProvider(
     user = await getDataAdapter(ctx).users.create(client.tenant.id, userData);
 
     ctx.set("user_id", user.user_id);
+  } else if (effectiveMode === "on_each_login") {
+    const updates: Record<string, unknown> = {
+      ...rootAttrs,
+      profileData: JSON.stringify(profileData),
+    };
+    // Filter out undefined values to avoid overwriting existing data
+    const filteredUpdates = Object.fromEntries(
+      Object.entries(updates).filter(([_, v]) => v !== undefined),
+    );
+    if (Object.keys(filteredUpdates).length > 0) {
+      await getDataAdapter(ctx).users.update(
+        client.tenant.id,
+        user.user_id,
+        filteredUpdates,
+      );
+      user = { ...user, ...filteredUpdates };
+    }
   }
 
   return user;

--- a/packages/authhero/test/helpers/mock-strategy.ts
+++ b/packages/authhero/test/helpers/mock-strategy.ts
@@ -19,6 +19,32 @@ export const mockStrategy: Strategy = {
           sub: "foo",
           email: "foo@example.com",
         };
+      case "vipps-user@example.com":
+        return {
+          sub: "vipps-456",
+          email: "vipps-user@example.com",
+          email_verified: true,
+          given_name: "Test",
+          family_name: "User",
+          name: "Test User",
+          phone_number: "+4712345678",
+          phone_number_verified: true,
+          picture: "https://example.com/avatar.jpg",
+          nickname: "testuser",
+        };
+      case "vipps-user-updated@example.com":
+        return {
+          sub: "vipps-456",
+          email: "vipps-user@example.com",
+          email_verified: true,
+          given_name: "Updated",
+          family_name: "Name",
+          name: "Updated Name",
+          phone_number: "+4799999999",
+          phone_number_verified: true,
+          picture: "https://example.com/new-avatar.jpg",
+          nickname: "updateduser",
+        };
       default:
         return {
           sub: "123",

--- a/packages/authhero/test/routes/auth-api/callback.spec.ts
+++ b/packages/authhero/test/routes/auth-api/callback.spec.ts
@@ -296,6 +296,283 @@ describe("callback", () => {
     expect(user?.identities?.length).toBe(2);
   });
 
+  it("should populate root attributes from social profile on user creation", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    await env.data.connections.create("tenantId", {
+      id: "connectionId",
+      name: "mock-strategy",
+      strategy: "mock-strategy",
+      options: {
+        client_id: "clientId",
+        client_secret: "clientSecret",
+      },
+    });
+
+    const loginSession = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+      },
+    });
+
+    const state = await env.data.codes.create("tenantId", {
+      code_id: nanoid(),
+      code_type: "oauth2_state",
+      login_id: loginSession.id,
+      connection_id: "connectionId",
+      code_verifier: "verifier",
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    });
+
+    const response = await oauthClient.callback.$get({
+      query: {
+        state: state.code_id,
+        code: "vipps-user@example.com",
+      },
+    });
+
+    expect(response.status).toEqual(302);
+
+    const user = await env.data.users.get(
+      "tenantId",
+      "mock-strategy|vipps-456",
+    );
+    expect(user).toBeTruthy();
+    expect(user!.given_name).toEqual("Test");
+    expect(user!.family_name).toEqual("User");
+    expect(user!.name).toEqual("Test User");
+    expect(user!.phone_number).toEqual("+4712345678");
+    expect(user!.phone_verified).toEqual(true);
+    expect(user!.picture).toEqual("https://example.com/avatar.jpg");
+    expect(user!.nickname).toEqual("testuser");
+    expect(user!.email_verified).toEqual(true);
+  });
+
+  it("should update root attributes on each login by default", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    await env.data.connections.create("tenantId", {
+      id: "connectionId",
+      name: "mock-strategy",
+      strategy: "mock-strategy",
+      options: {
+        client_id: "clientId",
+        client_secret: "clientSecret",
+      },
+    });
+
+    // First login - creates user
+    const loginSession1 = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+      },
+    });
+
+    const state1 = await env.data.codes.create("tenantId", {
+      code_id: nanoid(),
+      code_type: "oauth2_state",
+      login_id: loginSession1.id,
+      connection_id: "connectionId",
+      code_verifier: "verifier",
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    });
+
+    await oauthClient.callback.$get({
+      query: {
+        state: state1.code_id,
+        code: "vipps-user@example.com",
+      },
+    });
+
+    // Second login - updates user with different profile data
+    const loginSession2 = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+      },
+    });
+
+    const state2 = await env.data.codes.create("tenantId", {
+      code_id: nanoid(),
+      code_type: "oauth2_state",
+      login_id: loginSession2.id,
+      connection_id: "connectionId",
+      code_verifier: "verifier",
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    });
+
+    await oauthClient.callback.$get({
+      query: {
+        state: state2.code_id,
+        code: "vipps-user-updated@example.com",
+      },
+    });
+
+    const user = await env.data.users.get(
+      "tenantId",
+      "mock-strategy|vipps-456",
+    );
+    expect(user).toBeTruthy();
+    expect(user!.given_name).toEqual("Updated");
+    expect(user!.family_name).toEqual("Name");
+    expect(user!.name).toEqual("Updated Name");
+    expect(user!.phone_number).toEqual("+4799999999");
+    expect(user!.picture).toEqual("https://example.com/new-avatar.jpg");
+    expect(user!.nickname).toEqual("updateduser");
+  });
+
+  it("should not update root attributes on subsequent login when set_user_root_attributes is on_first_login", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    await env.data.connections.create("tenantId", {
+      id: "connectionId",
+      name: "mock-strategy",
+      strategy: "mock-strategy",
+      options: {
+        client_id: "clientId",
+        client_secret: "clientSecret",
+        set_user_root_attributes: "on_first_login",
+      },
+    });
+
+    // First login - creates user with profile data
+    const loginSession1 = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+      },
+    });
+
+    const state1 = await env.data.codes.create("tenantId", {
+      code_id: nanoid(),
+      code_type: "oauth2_state",
+      login_id: loginSession1.id,
+      connection_id: "connectionId",
+      code_verifier: "verifier",
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    });
+
+    await oauthClient.callback.$get({
+      query: {
+        state: state1.code_id,
+        code: "vipps-user@example.com",
+      },
+    });
+
+    // Verify first login populated attributes
+    let user = await env.data.users.get(
+      "tenantId",
+      "mock-strategy|vipps-456",
+    );
+    expect(user!.given_name).toEqual("Test");
+
+    // Second login - should NOT update attributes
+    const loginSession2 = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+      },
+    });
+
+    const state2 = await env.data.codes.create("tenantId", {
+      code_id: nanoid(),
+      code_type: "oauth2_state",
+      login_id: loginSession2.id,
+      connection_id: "connectionId",
+      code_verifier: "verifier",
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    });
+
+    await oauthClient.callback.$get({
+      query: {
+        state: state2.code_id,
+        code: "vipps-user-updated@example.com",
+      },
+    });
+
+    user = await env.data.users.get("tenantId", "mock-strategy|vipps-456");
+    // Should still have original values
+    expect(user!.given_name).toEqual("Test");
+    expect(user!.family_name).toEqual("User");
+    expect(user!.name).toEqual("Test User");
+    expect(user!.phone_number).toEqual("+4712345678");
+  });
+
+  it("should not populate root attributes from profile when set_user_root_attributes is never_on_login", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    await env.data.connections.create("tenantId", {
+      id: "connectionId",
+      name: "mock-strategy",
+      strategy: "mock-strategy",
+      options: {
+        client_id: "clientId",
+        client_secret: "clientSecret",
+        set_user_root_attributes: "never_on_login",
+      },
+    });
+
+    const loginSession = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+      },
+    });
+
+    const state = await env.data.codes.create("tenantId", {
+      code_id: nanoid(),
+      code_type: "oauth2_state",
+      login_id: loginSession.id,
+      connection_id: "connectionId",
+      code_verifier: "verifier",
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    });
+
+    const response = await oauthClient.callback.$get({
+      query: {
+        state: state.code_id,
+        code: "vipps-user@example.com",
+      },
+    });
+
+    expect(response.status).toEqual(302);
+
+    const user = await env.data.users.get(
+      "tenantId",
+      "mock-strategy|vipps-456",
+    );
+    expect(user).toBeTruthy();
+    // Root attributes should NOT be populated from profile
+    expect(user!.given_name).toBeUndefined();
+    expect(user!.family_name).toBeUndefined();
+    expect(user!.phone_number).toBeUndefined();
+    expect(user!.phone_verified).toBeUndefined();
+    expect(user!.picture).toBeUndefined();
+    expect(user!.nickname).toBeUndefined();
+    // Name should fall back to username (email)
+    expect(user!.name).toEqual("vipps-user@example.com");
+    // email_verified defaults to true for social logins even with never_on_login
+    expect(user!.email_verified).toEqual(true);
+  });
+
   it("should redirect to the callback endpoint on the original domain when domain doesn't match the current request", async () => {
     const { oauthApp, env } = await getTestServer();
     const oauthClient = testClient(oauthApp, env);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration option to control when user root attributes are synced from social provider profiles. Choose between syncing on each login, first login only, or never.

* **Tests**
  * Added comprehensive test coverage for user attribute synchronization across various configuration modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->