### PR TITLE
Add vary header for origin

### DIFF
--- a/.changeset/slick-beds-win.md
+++ b/.changeset/slick-beds-win.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Add vary header for origin

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -63,7 +63,7 @@ export default function create(config: AuthHeroConfig) {
       );
       ctx.res.headers.set("Access-Control-Max-Age", "600");
       ctx.res.headers.set("Access-Control-Allow-Credentials", "true");
-      ctx.res.headers.set("Vary", "Origin");
+      ctx.res.headers.append("Vary", "Origin");
     };
 
     // Handle preflight requests
@@ -88,7 +88,7 @@ export default function create(config: AuthHeroConfig) {
           );
           response.headers.set("Access-Control-Max-Age", "600");
           response.headers.set("Access-Control-Allow-Credentials", "true");
-          response.headers.set("Vary", "Origin");
+          response.headers.append("Vary", "Origin");
         };
 
         if (config.allowedOrigins?.includes(origin)) {
@@ -111,15 +111,15 @@ export default function create(config: AuthHeroConfig) {
       }
       // Return 204 without CORS headers if origin not allowed
       // Still set Vary so caches don't serve this to an allowed origin
-      response.headers.set("Vary", "Origin");
+      response.headers.append("Vary", "Origin");
       return response;
     }
 
     // For actual requests, process the request first then set headers
     await next();
 
-    // Always set Vary: Origin so caches differentiate responses by origin
-    ctx.res.headers.set("Vary", "Origin");
+    // Always append Vary: Origin so caches differentiate responses by origin
+    ctx.res.headers.append("Vary", "Origin");
 
     if (origin) {
       // Check static allowedOrigins first

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -63,6 +63,7 @@ export default function create(config: AuthHeroConfig) {
       );
       ctx.res.headers.set("Access-Control-Max-Age", "600");
       ctx.res.headers.set("Access-Control-Allow-Credentials", "true");
+      ctx.res.headers.set("Vary", "Origin");
     };
 
     // Handle preflight requests
@@ -70,9 +71,9 @@ export default function create(config: AuthHeroConfig) {
       const response = new Response(null, { status: 204 });
 
       if (origin) {
-        // For preflight, check static allowedOrigins first
-        if (config.allowedOrigins?.includes(origin)) {
-          response.headers.set("Access-Control-Allow-Origin", origin);
+        // Helper to set preflight CORS headers
+        const setPreflightCors = (allowedOrigin: string) => {
+          response.headers.set("Access-Control-Allow-Origin", allowedOrigin);
           response.headers.set(
             "Access-Control-Allow-Headers",
             "Tenant-Id, Content-Type, Content-Range, Auth0-Client, Authorization, Range, Upgrade-Insecure-Requests",
@@ -87,6 +88,11 @@ export default function create(config: AuthHeroConfig) {
           );
           response.headers.set("Access-Control-Max-Age", "600");
           response.headers.set("Access-Control-Allow-Credentials", "true");
+          response.headers.set("Vary", "Origin");
+        };
+
+        if (config.allowedOrigins?.includes(origin)) {
+          setPreflightCors(origin);
           return response;
         }
 
@@ -98,31 +104,22 @@ export default function create(config: AuthHeroConfig) {
             (client) => client.web_origins || [],
           );
           if (allWebOrigins.includes(origin)) {
-            response.headers.set("Access-Control-Allow-Origin", origin);
-            response.headers.set(
-              "Access-Control-Allow-Headers",
-              "Tenant-Id, Content-Type, Content-Range, Auth0-Client, Authorization, Range, Upgrade-Insecure-Requests",
-            );
-            response.headers.set(
-              "Access-Control-Allow-Methods",
-              "POST, PUT, GET, DELETE, PATCH, OPTIONS",
-            );
-            response.headers.set(
-              "Access-Control-Expose-Headers",
-              "Content-Length, Content-Range",
-            );
-            response.headers.set("Access-Control-Max-Age", "600");
-            response.headers.set("Access-Control-Allow-Credentials", "true");
+            setPreflightCors(origin);
             return response;
           }
         }
       }
       // Return 204 without CORS headers if origin not allowed
+      // Still set Vary so caches don't serve this to an allowed origin
+      response.headers.set("Vary", "Origin");
       return response;
     }
 
     // For actual requests, process the request first then set headers
     await next();
+
+    // Always set Vary: Origin so caches differentiate responses by origin
+    ctx.res.headers.set("Vary", "Origin");
 
     if (origin) {
       // Check static allowedOrigins first

--- a/packages/authhero/test/routes/management-api/cors.spec.ts
+++ b/packages/authhero/test/routes/management-api/cors.spec.ts
@@ -23,7 +23,7 @@ describe("management-api CORS", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
       "https://example.com",
     );
-    expect(response.headers.get("Vary")).toBe("Origin");
+    expect(response.headers.get("Vary")).toContain("Origin");
   });
 
   it("should not set CORS headers for unknown origin but still set Vary", async () => {
@@ -45,7 +45,7 @@ describe("management-api CORS", () => {
     expect(response.status).toBe(204);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
     // Vary: Origin must still be set so caches don't serve this denial to allowed origins
-    expect(response.headers.get("Vary")).toBe("Origin");
+    expect(response.headers.get("Vary")).toContain("Origin");
   });
 
   it("should allow origin after adding it to client web_origins", async () => {
@@ -117,7 +117,7 @@ describe("management-api CORS", () => {
     expect(response.headers.get("Access-Control-Allow-Credentials")).toBe(
       "true",
     );
-    expect(response.headers.get("Vary")).toBe("Origin");
+    expect(response.headers.get("Vary")).toContain("Origin");
   });
 
   it("should allow multiple origins from different clients simultaneously", async () => {
@@ -164,7 +164,7 @@ describe("management-api CORS", () => {
       "https://other-app.example.com",
     );
     // Both must have Vary: Origin for proper cache behavior
-    expect(response1.headers.get("Vary")).toBe("Origin");
-    expect(response2.headers.get("Vary")).toBe("Origin");
+    expect(response1.headers.get("Vary")).toContain("Origin");
+    expect(response2.headers.get("Vary")).toContain("Origin");
   });
 });

--- a/packages/authhero/test/routes/management-api/cors.spec.ts
+++ b/packages/authhero/test/routes/management-api/cors.spec.ts
@@ -23,9 +23,10 @@ describe("management-api CORS", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
       "https://example.com",
     );
+    expect(response.headers.get("Vary")).toBe("Origin");
   });
 
-  it("should not set CORS headers for unknown origin", async () => {
+  it("should not set CORS headers for unknown origin but still set Vary", async () => {
     const { managementApp, env } = await getTestServer();
 
     const response = await managementApp.request(
@@ -43,6 +44,8 @@ describe("management-api CORS", () => {
 
     expect(response.status).toBe(204);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    // Vary: Origin must still be set so caches don't serve this denial to allowed origins
+    expect(response.headers.get("Vary")).toBe("Origin");
   });
 
   it("should allow origin after adding it to client web_origins", async () => {
@@ -114,5 +117,54 @@ describe("management-api CORS", () => {
     expect(response.headers.get("Access-Control-Allow-Credentials")).toBe(
       "true",
     );
+    expect(response.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("should allow multiple origins from different clients simultaneously", async () => {
+    const { managementApp, env } = await getTestServer();
+
+    // Add a second origin to the client
+    await env.data.clients.update("tenantId", "clientId", {
+      web_origins: ["https://example.com", "https://other-app.example.com"],
+    });
+
+    // Request from first origin
+    const response1 = await managementApp.request(
+      "/clients",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://example.com",
+          "tenant-id": "tenantId",
+          "Access-Control-Request-Method": "GET",
+        },
+      },
+      env,
+    );
+
+    // Request from second origin
+    const response2 = await managementApp.request(
+      "/clients",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://other-app.example.com",
+          "tenant-id": "tenantId",
+          "Access-Control-Request-Method": "GET",
+        },
+      },
+      env,
+    );
+
+    // Both should be allowed with their respective origins
+    expect(response1.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://example.com",
+    );
+    expect(response2.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://other-app.example.com",
+    );
+    // Both must have Vary: Origin for proper cache behavior
+    expect(response1.headers.get("Vary")).toBe("Origin");
+    expect(response2.headers.get("Vary")).toBe("Origin");
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure responses include the Vary: Origin header so CORS responses are cached and served correctly per origin.

* **Tests**
  * Expanded and updated CORS tests to verify Vary: Origin on allowed, unknown, and concurrent multi-origin preflight and actual requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->