### PR TITLE
Use custom domains for openid-configuration

### DIFF
--- a/.changeset/thirty-papers-lick.md
+++ b/.changeset/thirty-papers-lick.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Use custom domains for openid-configuration

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -21,6 +21,7 @@ import {
   AUTHORIZATION_CODE_EXPIRES_IN_SECONDS,
   SILENT_AUTH_MAX_AGE_IN_SECONDS,
   TICKET_EXPIRATION_TIME,
+  UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS,
 } from "../constants";
 import { serializeAuthCookie } from "../utils/cookies";
 import { getIssuer } from "../variables";
@@ -574,14 +575,14 @@ export async function authenticateLoginSession(
 
   const currentState = currentLoginSession.state || LoginSessionState.PENDING;
 
-  // Guard against terminal states
+  // Guard against terminal states (EXPIRED is allowed — see createFrontChannelAuthResponse)
   if (
     currentState === LoginSessionState.FAILED ||
-    currentState === LoginSessionState.EXPIRED ||
     currentState === LoginSessionState.COMPLETED
   ) {
-    throw new HTTPException(400, {
-      message: `Cannot authenticate login session in ${currentState} state`,
+    throw new JSONHTTPException(400, {
+      error: "access_denied",
+      error_description: `Cannot authenticate login session in ${currentState} state`,
     });
   }
 
@@ -639,7 +640,13 @@ export async function authenticateLoginSession(
   }
 
   // Transition to AUTHENTICATED state
-  const { state: newState } = transitionLoginSession(currentState, {
+  // If the session was EXPIRED, treat as PENDING for the state machine transition
+  // since the XState machine defines expired as a final state with no outbound transitions
+  const stateForTransition =
+    currentState === LoginSessionState.EXPIRED
+      ? LoginSessionState.PENDING
+      : currentState;
+  const { state: newState } = transitionLoginSession(stateForTransition, {
     type: LoginSessionEventType.AUTHENTICATE,
     userId: user.user_id,
   });
@@ -649,11 +656,20 @@ export async function authenticateLoginSession(
 
   // Update the login session with session_id, user_id, new state, and auth_connection
   // auth_connection is stored early so it survives hook redirects (new HTTP requests)
+  // If recovering from EXPIRED, also extend expires_at so the session doesn't
+  // immediately expire again during subsequent MFA/hook checks
   await ctx.env.data.loginSessions.update(client.tenant.id, loginSession.id, {
     session_id,
     state: newState,
     user_id: user.user_id,
     ...(resolvedConnection ? { auth_connection: resolvedConnection } : {}),
+    ...(currentState === LoginSessionState.EXPIRED
+      ? {
+          expires_at: new Date(
+            Date.now() + UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS * 1000,
+          ).toISOString(),
+        }
+      : {}),
   });
 
   return session_id;
@@ -1130,15 +1146,15 @@ export async function createFrontChannelAuthResponse(
         error_description: `Login session failed: ${currentLoginSession.failure_reason || "unknown reason"}`,
       });
     }
-    if (currentState === LoginSessionState.EXPIRED) {
-      throw new JSONHTTPException(400, {
-        error: "invalid_request",
-        error_description: "Login session has expired",
-      });
-    }
+    // EXPIRED sessions are NOT rejected here — if we got this far, the OAuth
+    // exchange succeeded and we have a valid user. The TTL expiry should only
+    // block new auth attempts, not in-flight completions.
 
-    // If state is PENDING (or any pre-authenticated state), we need to authenticate
-    if (currentState === LoginSessionState.PENDING) {
+    // If state is PENDING or EXPIRED, we need to authenticate
+    if (
+      currentState === LoginSessionState.PENDING ||
+      currentState === LoginSessionState.EXPIRED
+    ) {
       session_id = await authenticateLoginSession(ctx, {
         user,
         client,

--- a/packages/authhero/src/routes/auth-api/callback.ts
+++ b/packages/authhero/src/routes/auth-api/callback.ts
@@ -201,14 +201,17 @@ export const callbackRoutes = new OpenAPIHono<{
               );
               if (loginSession) {
                 let errorMessage = "access_denied";
+                let errorCode = "access_denied";
                 try {
                   const body = JSON.parse(err.message);
-                  errorMessage = body.message || errorMessage;
+                  errorMessage =
+                    body.error_description || body.message || errorMessage;
+                  errorCode = body.error || errorCode;
                 } catch {
                   // If message is not JSON, use it directly
                   errorMessage = err.message || errorMessage;
                 }
-                return returnError(ctx, state, "access_denied", errorMessage);
+                return returnError(ctx, state, errorCode, errorMessage);
               }
             }
           }
@@ -313,14 +316,17 @@ export const callbackRoutes = new OpenAPIHono<{
               );
               if (loginSession) {
                 let errorMessage = "access_denied";
+                let errorCode = "access_denied";
                 try {
                   const body = JSON.parse(err.message);
-                  errorMessage = body.message || errorMessage;
+                  errorMessage =
+                    body.error_description || body.message || errorMessage;
+                  errorCode = body.error || errorCode;
                 } catch {
                   // If message is not JSON, use it directly
                   errorMessage = err.message || errorMessage;
                 }
-                return returnError(ctx, state, "access_denied", errorMessage);
+                return returnError(ctx, state, errorCode, errorMessage);
               }
             }
           }

--- a/packages/authhero/src/routes/auth-api/well-known.ts
+++ b/packages/authhero/src/routes/auth-api/well-known.ts
@@ -41,9 +41,8 @@ export const wellKnownRoutes = new OpenAPIHono<{
           headers: {
             "access-control-allow-origin": "*",
             "access-control-allow-method": "GET",
-            "cache-control": `public, max-age=${JWKS_CACHE_TIMEOUT_IN_SECONDS}, stale-while-revalidate=${
-              JWKS_CACHE_TIMEOUT_IN_SECONDS * 2
-            }, stale-if-error=86400`,
+            "cache-control": `public, max-age=${JWKS_CACHE_TIMEOUT_IN_SECONDS}, stale-while-revalidate=${JWKS_CACHE_TIMEOUT_IN_SECONDS * 2
+              }, stale-if-error=86400`,
           },
         },
       );
@@ -70,16 +69,17 @@ export const wellKnownRoutes = new OpenAPIHono<{
       },
     }),
     async (ctx) => {
+      const customDomain = ctx.var.custom_domain;
       const result = openIDConfigurationSchema.parse({
-        issuer: getIssuer(ctx.env),
-        authorization_endpoint: `${getAuthUrl(ctx.env)}authorize`,
-        token_endpoint: `${getAuthUrl(ctx.env)}oauth/token`,
-        device_authorization_endpoint: `${getAuthUrl(ctx.env)}oauth/device/code`,
-        userinfo_endpoint: `${getAuthUrl(ctx.env)}userinfo`,
-        mfa_challenge_endpoint: `${getAuthUrl(ctx.env)}mfa/challenge`,
-        jwks_uri: `${getAuthUrl(ctx.env)}.well-known/jwks.json`,
-        registration_endpoint: `${getAuthUrl(ctx.env)}oidc/register`,
-        revocation_endpoint: `${getAuthUrl(ctx.env)}oauth/revoke`,
+        issuer: getIssuer(ctx.env, customDomain),
+        authorization_endpoint: `${getAuthUrl(ctx.env, customDomain)}authorize`,
+        token_endpoint: `${getAuthUrl(ctx.env, customDomain)}oauth/token`,
+        device_authorization_endpoint: `${getAuthUrl(ctx.env, customDomain)}oauth/device/code`,
+        userinfo_endpoint: `${getAuthUrl(ctx.env, customDomain)}userinfo`,
+        mfa_challenge_endpoint: `${getAuthUrl(ctx.env, customDomain)}mfa/challenge`,
+        jwks_uri: `${getAuthUrl(ctx.env, customDomain)}.well-known/jwks.json`,
+        registration_endpoint: `${getAuthUrl(ctx.env, customDomain)}oidc/register`,
+        revocation_endpoint: `${getAuthUrl(ctx.env, customDomain)}oauth/revoke`,
         scopes_supported: [
           "openid",
           "profile",
@@ -147,9 +147,8 @@ export const wellKnownRoutes = new OpenAPIHono<{
         headers: {
           "access-control-allow-origin": "*",
           "access-control-allow-method": "GET",
-          "cache-control": `public, max-age=${JWKS_CACHE_TIMEOUT_IN_SECONDS}, stale-while-revalidate=${
-            JWKS_CACHE_TIMEOUT_IN_SECONDS * 2
-          }, stale-if-error=86400`,
+          "cache-control": `public, max-age=${JWKS_CACHE_TIMEOUT_IN_SECONDS}, stale-while-revalidate=${JWKS_CACHE_TIMEOUT_IN_SECONDS * 2
+            }, stale-if-error=86400`,
         },
       });
     },

--- a/packages/authhero/src/variables.ts
+++ b/packages/authhero/src/variables.ts
@@ -11,6 +11,9 @@ export function getUniversalLoginUrl(env: Bindings) {
   return env.UNIVERSAL_LOGIN_URL || `${env.ISSUER}u/`;
 }
 
-export function getAuthUrl(env: Bindings) {
+export function getAuthUrl(env: Bindings, customDomain?: string) {
+  if (customDomain) {
+    return `https://${customDomain}/`;
+  }
   return env.OAUTH_API_URL || env.ISSUER;
 }

--- a/packages/authhero/test/routes/auth-api/callback.spec.ts
+++ b/packages/authhero/test/routes/auth-api/callback.spec.ts
@@ -4,6 +4,7 @@ import { getTestServer } from "../../helpers/test-server";
 import { nanoid } from "nanoid";
 import {
   AuthorizationResponseMode,
+  LoginSessionState,
   Strategy,
 } from "@authhero/adapter-interfaces";
 
@@ -749,5 +750,168 @@ describe("callback", () => {
     // Verify no user operations were performed yet (since we're redirecting)
     const logs = await env.data.logs.list("tenantId");
     expect(logs).toHaveLength(0);
+  });
+
+  it("should complete callback successfully when login session has expired during processing", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    await env.data.connections.create("tenantId", {
+      id: "connectionId",
+      name: "mock-strategy",
+      strategy: "mock-strategy",
+      options: {
+        client_id: "clientId",
+        client_secret: "clientSecret",
+      },
+    });
+
+    const loginSession = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+      },
+    });
+
+    const state = await env.data.codes.create("tenantId", {
+      code_id: nanoid(),
+      code_type: "oauth2_state",
+      login_id: loginSession.id,
+      connection_id: "connectionId",
+      code_verifier: "verifier",
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    });
+
+    // Simulate session expiring during processing
+    await env.data.loginSessions.update("tenantId", loginSession.id, {
+      state: LoginSessionState.EXPIRED,
+    });
+
+    const response = await oauthClient.callback.$get({
+      query: {
+        state: state.code_id,
+        code: "foo@example.com",
+      },
+    });
+
+    // Should still succeed with a redirect containing an authorization code
+    expect(response.status).toEqual(302);
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const redirectUri = new URL(location!);
+    expect(redirectUri.pathname).toEqual("/callback");
+    expect(redirectUri.searchParams.get("code")).toBeTruthy();
+  });
+
+  it("should redirect to login with meaningful error when login session is already completed", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    await env.data.connections.create("tenantId", {
+      id: "connectionId",
+      name: "mock-strategy",
+      strategy: "mock-strategy",
+      options: {
+        client_id: "clientId",
+        client_secret: "clientSecret",
+      },
+    });
+
+    const loginSession = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+      },
+    });
+
+    const state = await env.data.codes.create("tenantId", {
+      code_id: nanoid(),
+      code_type: "oauth2_state",
+      login_id: loginSession.id,
+      connection_id: "connectionId",
+      code_verifier: "verifier",
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    });
+
+    // Simulate a duplicate callback that already completed the session
+    await env.data.loginSessions.update("tenantId", loginSession.id, {
+      state: LoginSessionState.COMPLETED,
+    });
+
+    const response = await oauthClient.callback.$get({
+      query: {
+        state: state.code_id,
+        code: "foo@example.com",
+      },
+    });
+
+    expect(response.status).toEqual(302);
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const redirectUri = new URL(location!);
+    expect(redirectUri.pathname).toEqual("/u/login/identifier");
+    // Should include a meaningful error_description, not just "access_denied"
+    const errorDescription = redirectUri.searchParams.get("error_description");
+    expect(errorDescription).toBeTruthy();
+    expect(errorDescription).not.toEqual("access_denied");
+  });
+
+  it("should redirect to login with failure reason when login session has failed", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    await env.data.connections.create("tenantId", {
+      id: "connectionId",
+      name: "mock-strategy",
+      strategy: "mock-strategy",
+      options: {
+        client_id: "clientId",
+        client_secret: "clientSecret",
+      },
+    });
+
+    const loginSession = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+      },
+    });
+
+    const state = await env.data.codes.create("tenantId", {
+      code_id: nanoid(),
+      code_type: "oauth2_state",
+      login_id: loginSession.id,
+      connection_id: "connectionId",
+      code_verifier: "verifier",
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+    });
+
+    // Simulate session failure with a specific reason
+    await env.data.loginSessions.update("tenantId", loginSession.id, {
+      state: LoginSessionState.FAILED,
+      failure_reason: "User account locked",
+    });
+
+    const response = await oauthClient.callback.$get({
+      query: {
+        state: state.code_id,
+        code: "foo@example.com",
+      },
+    });
+
+    expect(response.status).toEqual(302);
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const redirectUri = new URL(location!);
+    expect(redirectUri.pathname).toEqual("/u/login/identifier");
+    // Should include the failure reason in the error description
+    const errorDescription = redirectUri.searchParams.get("error_description");
+    expect(errorDescription).toContain("User account locked");
   });
 });

--- a/packages/authhero/test/routes/auth-api/well-known.spec.ts
+++ b/packages/authhero/test/routes/auth-api/well-known.spec.ts
@@ -106,4 +106,44 @@ describe("jwks", () => {
     const body = openIDConfigurationSchema.parse(await response.json());
     expect(body.issuer).toBe("http://localhost:3000/");
   });
+
+  it("should return openid-configuration with custom domain URLs when accessed via custom domain", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const client = testClient(oauthApp, env);
+
+    // Create a custom domain for the tenant
+    await env.data.customDomains.create("tenantId", {
+      domain: "login.example.com",
+      custom_domain_id: "custom-domain-id",
+      type: "auth0_managed_certs",
+    });
+
+    const response = await client[".well-known"]["openid-configuration"].$get(
+      {
+        param: {},
+      },
+      {
+        headers: {
+          host: "login.example.com",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = openIDConfigurationSchema.parse(await response.json());
+    expect(body.issuer).toBe("https://login.example.com/");
+    expect(body.authorization_endpoint).toBe(
+      "https://login.example.com/authorize",
+    );
+    expect(body.token_endpoint).toBe(
+      "https://login.example.com/oauth/token",
+    );
+    expect(body.userinfo_endpoint).toBe(
+      "https://login.example.com/userinfo",
+    );
+    expect(body.jwks_uri).toBe(
+      "https://login.example.com/.well-known/jwks.json",
+    );
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenID configuration now supports custom domains with dynamically generated endpoint URLs

* **Bug Fixes**
  * Improved handling of expired authentication sessions; they now attempt recovery instead of immediate rejection
  * Enhanced error responses with more specific error codes and descriptions

* **Tests**
  * Added test coverage for custom domain configuration scenarios and session state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->