### PR TITLE
Add deny for pre register event

### DIFF
--- a/.changeset/slow-nails-exist.md
+++ b/.changeset/slow-nails-exist.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Add deny for pre register event

--- a/packages/authhero/src/hooks/index.ts
+++ b/packages/authhero/src/hooks/index.ts
@@ -105,10 +105,22 @@ function createUserHooks(
                 user.linked_to = primaryUserId;
               },
             },
+            access: {
+              deny: (code: string, reason?: string) => {
+                throw new JSONHTTPException(400, {
+                  message: reason
+                    ? `Registration denied: ${code} - ${reason}`
+                    : `Registration denied: ${code}`,
+                });
+              },
+            },
             token: createTokenAPI(ctx, tenant_id),
           },
         );
       } catch (err) {
+        if (err instanceof HTTPException) {
+          throw err;
+        }
         logMessage(ctx, tenant_id, {
           type: LogTypes.FAILED_SIGNUP,
           description: "Pre user registration hook failed",

--- a/packages/authhero/src/types/Hooks.ts
+++ b/packages/authhero/src/types/Hooks.ts
@@ -199,6 +199,9 @@ export type OnExecutePreUserRegistrationAPI = {
     setUserMetadata: (key: string, value: any) => void;
     setLinkedTo: (primaryUserId: string) => void;
   };
+  access: {
+    deny: (code: string, reason?: string) => void;
+  };
   token: TokenAPI;
 };
 

--- a/packages/authhero/test/hooks/on-pre-user-registration.spec.ts
+++ b/packages/authhero/test/hooks/on-pre-user-registration.spec.ts
@@ -115,4 +115,110 @@ describe("on-pre-user-registration-hook", () => {
 
     expect(user?.given_name).toBe("given_name");
   });
+
+  it("should block user creation when deny() is called", async () => {
+    const { env, managementApp } = await getTestServer({
+      hooks: {
+        onExecutePreUserRegistration: async (
+          _: HookEvent,
+          api: OnExecutePreUserRegistrationAPI,
+        ) => {
+          api.access.deny("unauthorized", "Registration not allowed");
+        },
+      },
+    });
+
+    const client = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const response = await client.users.$post(
+      {
+        json: {
+          email: "denied@example.com",
+          connection: Strategy.USERNAME_PASSWORD,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(response.status).toBe(400);
+    const error = (await response.json()) as { message: string };
+    expect(error.message).toContain("Registration denied");
+  });
+
+  it("should continue user creation when hook throws a generic error", async () => {
+    const { env, managementApp } = await getTestServer({
+      hooks: {
+        onExecutePreUserRegistration: async () => {
+          throw new Error("Something went wrong");
+        },
+      },
+    });
+
+    const client = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const response = await client.users.$post(
+      {
+        json: {
+          email: "error-but-continues@example.com",
+          connection: Strategy.USERNAME_PASSWORD,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(response.status).toBe(201);
+  });
+
+  it("should block user creation when deny() is called with code only", async () => {
+    const { env, managementApp } = await getTestServer({
+      hooks: {
+        onExecutePreUserRegistration: async (
+          _: HookEvent,
+          api: OnExecutePreUserRegistrationAPI,
+        ) => {
+          api.access.deny("blocked");
+        },
+      },
+    });
+
+    const client = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const response = await client.users.$post(
+      {
+        json: {
+          email: "blocked@example.com",
+          connection: Strategy.USERNAME_PASSWORD,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(response.status).toBe(400);
+    const error = (await response.json()) as { message: string };
+    expect(error.message).toBe("Registration denied: blocked");
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deny capability to pre-registration hooks, enabling developers to explicitly reject user registrations with customizable error codes and optional reason messages for better control over user onboarding.

* **Tests**
  * Introduced comprehensive test coverage for the new registration denial feature, validating denial behavior with different error codes and proper error message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->