### PR TITLE
Implement disable-sso

### DIFF
--- a/.changeset/ripe-horses-lose.md
+++ b/.changeset/ripe-horses-lose.md
@@ -1,0 +1,9 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+"@authhero/react-admin": minor
+"@authhero/drizzle": minor
+"@authhero/kysely-adapter": minor
+---
+
+Implement disable-sso

--- a/apps/react-admin/src/components/clients/edit.tsx
+++ b/apps/react-admin/src/components/clients/edit.tsx
@@ -1393,6 +1393,11 @@ export function ClientEdit() {
             label="First Party Application"
             helperText="First party applications are trusted applications that don't require user consent for standard scopes."
           />
+          <BooleanInput
+            source="sso_disabled"
+            label="SSO Disabled"
+            helperText="When enabled, this client will not reuse existing SSO sessions. Users must authenticate every time, even if they have an active session from another client."
+          />
         </TabbedForm.Tab>
         <TabbedForm.Tab label="Raw JSON">
           <FunctionField

--- a/packages/adapter-interfaces/src/types/Client.ts
+++ b/packages/adapter-interfaces/src/types/Client.ts
@@ -124,9 +124,9 @@ export const clientInsertSchema = z.object({
     description:
       "Applies only to SSO clients and determines whether Auth0 will handle Single Sign On (true) or whether the Identity Provider will (false).",
   }),
-  sso_disabled: z.boolean().default(true).openapi({
+  sso_disabled: z.boolean().default(false).openapi({
     description:
-      "Whether Single Sign On is disabled (true) or enabled (true). Defaults to true.",
+      "Whether Single Sign On is disabled for this client. When true, existing SSO sessions will not be reused and users must authenticate every time.",
   }),
   cross_origin_authentication: z.boolean().default(false).openapi({
     description:

--- a/packages/authhero/src/routes/auth-api/account.ts
+++ b/packages/authhero/src/routes/auth-api/account.ts
@@ -114,7 +114,12 @@ export const accountRoutes = new OpenAPIHono<{
       const session = authCookie
         ? await env.data.sessions.get(client.tenant.id, authCookie)
         : undefined;
-      const validSession = session && !session.revoked_at ? session : undefined;
+      let validSession = session && !session.revoked_at ? session : undefined;
+
+      // If SSO is disabled for this client, ignore any existing session
+      if (client.sso_disabled) {
+        validSession = undefined;
+      }
 
       const url = new URL(ctx.req.url);
       if (ctx.var.custom_domain) {

--- a/packages/authhero/src/routes/auth-api/authorize.ts
+++ b/packages/authhero/src/routes/auth-api/authorize.ts
@@ -306,6 +306,11 @@ export const authorizeRoutes = new OpenAPIHono<{
         }
       }
 
+      // If SSO is disabled for this client, ignore any existing session
+      if (client.sso_disabled) {
+        validSession = undefined;
+      }
+
       // Silent authentication with iframe
       if (prompt == "none") {
         if (!sanitizedRedirectUri || !state || !response_type) {

--- a/packages/authhero/test/routes/auth-api/authorize.spec.ts
+++ b/packages/authhero/test/routes/auth-api/authorize.spec.ts
@@ -917,4 +917,193 @@ describe("authorize", () => {
       expect(login?.authParams.state).toBe("query-state");
     });
   });
+
+  describe("sso_disabled", () => {
+    it("should return login_required for prompt=none when sso_disabled is true despite valid session", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const oauthClient = testClient(oauthApp, env);
+
+      // Update the client to have sso_disabled=true
+      await env.data.clients.update("tenantId", "clientId", {
+        sso_disabled: true,
+      });
+
+      const loginSession = await env.data.loginSessions.create("tenantId", {
+        expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+        csrf_token: "csrfToken",
+        authParams: {
+          client_id: "clientId",
+          username: "foo@example.com",
+          redirect_uri: "https://example.com/callback",
+        },
+      });
+
+      await env.data.sessions.create("tenantId", {
+        id: "ssoDisabledSessionId",
+        user_id: "email|userId",
+        clients: ["clientId"],
+        idle_expires_at: new Date(Date.now() + 1000).toISOString(),
+        login_session_id: loginSession.id,
+        device: {
+          last_ip: "",
+          initial_ip: "",
+          last_user_agent: "",
+          initial_user_agent: "",
+          initial_asn: "",
+          last_asn: "",
+        },
+      });
+
+      const response = await oauthClient.authorize.$get(
+        {
+          query: {
+            client_id: "clientId",
+            redirect_uri: "https://example.com/callback",
+            state: "state",
+            nonce: "nonce",
+            code_challenge: "codeChallenge",
+            code_challenge_method: CodeChallengeMethod.S256,
+            scope: "openid email profile",
+            prompt: "none",
+            response_mode: AuthorizationResponseMode.WEB_MESSAGE,
+            response_type: AuthorizationResponseType.CODE,
+          },
+        },
+        {
+          headers: {
+            origin: "https://example.com",
+            cookie: "tenantId-auth-token=ssoDisabledSessionId",
+          },
+        },
+      );
+
+      expect(response.status).toEqual(200);
+      const body = await response.text();
+      expect(body).toContain("login_required");
+    });
+
+    it("should redirect to login when sso_disabled is true despite valid session", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const oauthClient = testClient(oauthApp, env);
+
+      // Update the client to have sso_disabled=true
+      await env.data.clients.update("tenantId", "clientId", {
+        sso_disabled: true,
+      });
+
+      const loginSession = await env.data.loginSessions.create("tenantId", {
+        expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+        csrf_token: "csrfToken",
+        authParams: {
+          client_id: "clientId",
+          username: "foo@example.com",
+          redirect_uri: "https://example.com/callback",
+        },
+      });
+
+      await env.data.sessions.create("tenantId", {
+        id: "ssoDisabledSessionId2",
+        user_id: "email|userId",
+        clients: ["clientId"],
+        idle_expires_at: new Date(Date.now() + 1000).toISOString(),
+        login_session_id: loginSession.id,
+        device: {
+          last_ip: "",
+          initial_ip: "",
+          last_user_agent: "",
+          initial_user_agent: "",
+          initial_asn: "",
+          last_asn: "",
+        },
+      });
+
+      const response = await oauthClient.authorize.$get(
+        {
+          query: {
+            client_id: "clientId",
+            redirect_uri: "https://example.com/callback",
+            state: "state",
+            nonce: "nonce",
+            scope: "openid email profile",
+            response_type: AuthorizationResponseType.CODE,
+          },
+        },
+        {
+          headers: {
+            origin: "https://example.com",
+            cookie: "tenantId-auth-token=ssoDisabledSessionId2",
+          },
+        },
+      );
+
+      // Should redirect to login, not to check-account
+      expect(response.status).toEqual(302);
+      const location = response.headers.get("location");
+      expect(location).toContain("/u/login/identifier");
+      expect(location).not.toContain("/check-account");
+    });
+
+    it("should reuse session for prompt=none when sso_disabled is false", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const oauthClient = testClient(oauthApp, env);
+
+      // Default test client has sso_disabled=false, but set explicitly for clarity
+      await env.data.clients.update("tenantId", "clientId", {
+        sso_disabled: false,
+      });
+
+      const loginSession = await env.data.loginSessions.create("tenantId", {
+        expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+        csrf_token: "csrfToken",
+        authParams: {
+          client_id: "clientId",
+          username: "foo@example.com",
+          redirect_uri: "https://example.com/callback",
+        },
+      });
+
+      await env.data.sessions.create("tenantId", {
+        id: "ssoEnabledSessionId",
+        user_id: "email|userId",
+        clients: ["clientId"],
+        idle_expires_at: new Date(Date.now() + 1000).toISOString(),
+        login_session_id: loginSession.id,
+        device: {
+          last_ip: "",
+          initial_ip: "",
+          last_user_agent: "",
+          initial_user_agent: "",
+          initial_asn: "",
+          last_asn: "",
+        },
+      });
+
+      const response = await oauthClient.authorize.$get(
+        {
+          query: {
+            client_id: "clientId",
+            redirect_uri: "https://example.com/callback",
+            state: "state",
+            nonce: "nonce",
+            code_challenge: "codeChallenge",
+            code_challenge_method: CodeChallengeMethod.S256,
+            scope: "openid email profile",
+            prompt: "none",
+            response_mode: AuthorizationResponseMode.WEB_MESSAGE,
+            response_type: AuthorizationResponseType.CODE,
+          },
+        },
+        {
+          headers: {
+            origin: "https://example.com",
+            cookie: "tenantId-auth-token=ssoEnabledSessionId",
+          },
+        },
+      );
+
+      expect(response.status).toEqual(200);
+      const body = await response.text();
+      expect(body).toContain('"code":"');
+    });
+  });
 });

--- a/packages/authhero/test/routes/management-api/clients.spec.ts
+++ b/packages/authhero/test/routes/management-api/clients.spec.ts
@@ -48,7 +48,7 @@ describe("clients", () => {
       require_proof_of_possession: false,
       require_pushed_authorization_requests: false,
       sso: false,
-      sso_disabled: true,
+      sso_disabled: false,
       callbacks: [],
       allowed_logout_urls: [],
       allowed_origins: [],

--- a/packages/drizzle/src/adapters/clients.ts
+++ b/packages/drizzle/src/adapters/clients.ts
@@ -136,7 +136,7 @@ export function createClientsAdapter(db: DrizzleDb): ClientsAdapter {
       // Common overrides
       client.oidc_conformant = params.oidc_conformant ?? true;
       client.auth0_conformant = params.auth0_conformant ?? true;
-      client.sso_disabled = params.sso_disabled ?? true;
+      client.sso_disabled = params.sso_disabled ?? false;
 
       // Set array/object defaults
       for (const field of JSON_ARRAY_FIELDS) {

--- a/packages/kysely/src/clients/create.ts
+++ b/packages/kysely/src/clients/create.ts
@@ -15,7 +15,7 @@ export function create(db: Kysely<Database>) {
       oidc_conformant: params.oidc_conformant ?? true,
       auth0_conformant: params.auth0_conformant ?? true,
       sso: params.sso ?? false,
-      sso_disabled: params.sso_disabled ?? true,
+      sso_disabled: params.sso_disabled ?? false,
       cross_origin_authentication: params.cross_origin_authentication ?? false,
       custom_login_page_on: params.custom_login_page_on ?? false,
       require_pushed_authorization_requests:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSO disable toggle in client configuration settings, enabling administrators to require fresh authentication for every login instead of reusing valid sessions.

* **Changes**
  * Single sign-on (SSO) is now enabled by default for all new clients, providing a seamless experience where user sessions are automatically reused unless administrators explicitly disable the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->