### PR TITLE
Remove self-healing

### DIFF
--- a/.changeset/stop-self-healing-post-registration.md
+++ b/.changeset/stop-self-healing-post-registration.md
@@ -1,0 +1,11 @@
+---
+"authhero": minor
+---
+
+Fix duplicate `post-user-registration` outbox events on a user's first login.
+
+`postUserLoginHook` previously re-enqueued a `post-user-registration` event on every successful login whose `registration_completed_at` was still null, as a "self-healing" recovery for dead-lettered events. The check couldn't distinguish "event is still pending in the outbox" from "event was lost" — so every first-time login produced a second duplicate event while the original was still waiting to drain. In tenants with a pre-user-registration hook that mutates the user (e.g. setting `app_metadata.strategy`), the two enqueues even captured different user payloads, confirming the same bug.
+
+Self-healing is removed from the login path. Delivery reliability for `post-user-registration` now belongs solely to the outbox (retry + dead-letter). Recovery of dead-lettered events is an explicit admin/cron responsibility and should no longer be tangled into the login path.
+
+Also fixes the race-loser branch in `linkUsersHook`: `instanceof HTTPException` silently fails when the adapter is bundled (class identity differs across module boundaries), so the existing race-catch never actually fired in production. Switched to a duck-typed `status === 409` check and surfaced the race-loser as a 409 from `createUserHooks`, which `getOrCreateUserByProvider` now catches and recovers so the losing login still completes without re-firing post-registration hooks.

--- a/.changeset/wacky-cats-wash.md
+++ b/.changeset/wacky-cats-wash.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Fix link user race

--- a/packages/authhero/src/errors/is-unique-constraint-error.ts
+++ b/packages/authhero/src/errors/is-unique-constraint-error.ts
@@ -1,0 +1,14 @@
+/**
+ * Check whether an error is a unique-constraint violation (HTTP 409).
+ *
+ * Uses a duck-typed status check rather than `instanceof HTTPException`
+ * because HTTPException instances may not share a class identity across
+ * bundled adapter packages (minification can rename the class).
+ */
+export function isUniqueConstraintError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { status?: unknown }).status === 409
+  );
+}

--- a/packages/authhero/src/helpers/users.ts
+++ b/packages/authhero/src/helpers/users.ts
@@ -221,6 +221,8 @@ export async function getOrCreateUserByProvider(
     provider,
   });
 
+  let wasCreated = false;
+
   if (!user) {
     const userData = {
       user_id: `${provider}|${userId || userIdGenerate()}`,
@@ -245,10 +247,34 @@ export async function getOrCreateUserByProvider(
       profileData: JSON.stringify(profileData),
     };
 
-    user = await ctx.env.data.users.create(client.tenant.id, userData);
+    try {
+      user = await ctx.env.data.users.create(client.tenant.id, userData);
+      wasCreated = true;
+    } catch (err) {
+      // Concurrent social callback already created this user. Read back the
+      // winner's row and fall through to the existing-user branch so the
+      // login completes for both racers. createUserHooks threw before its
+      // post-registration hooks ran, so the winner's flow emits the single
+      // post-user-registration event.
+      if ((err as { status?: unknown })?.status !== 409) {
+        throw err;
+      }
+      const existing = await getPrimaryUserByProvider({
+        userAdapter: ctx.env.data.users,
+        tenant_id: client.tenant.id,
+        username,
+        provider,
+      });
+      if (!existing) {
+        throw err;
+      }
+      user = existing;
+    }
 
     ctx.set("user_id", user.user_id);
-  } else if (effectiveMode === "on_each_login") {
+  }
+
+  if (!wasCreated && effectiveMode === "on_each_login") {
     const updates: Record<string, unknown> = {
       ...rootAttrs,
       profileData: JSON.stringify(profileData),

--- a/packages/authhero/src/hooks/link-users.ts
+++ b/packages/authhero/src/hooks/link-users.ts
@@ -1,6 +1,7 @@
 import { DataAdapters, User } from "@authhero/adapter-interfaces";
 import { getPrimaryUserByEmail } from "../helpers/users";
 import { JSONHTTPException } from "../errors/json-http-exception";
+import { isUniqueConstraintError } from "../errors/is-unique-constraint-error";
 
 export interface LinkUsersResult {
   user: User;
@@ -74,10 +75,7 @@ export function linkUsersHook(data: DataAdapters) {
     } catch (err) {
       // Race condition: another request created the same user simultaneously.
       // The transaction was rolled back, so look up the winner's user and return it.
-      // Duck-type the status check — HTTPException instances may not share a
-      // class identity across bundled adapter packages (minification can
-      // rename the class, breaking `instanceof`).
-      if ((err as { status?: unknown })?.status === 409) {
+      if (isUniqueConstraintError(err)) {
         const existingUser = await findExistingUser(data, tenant_id, user);
         if (existingUser) {
           return { user: existingUser, created: false };

--- a/packages/authhero/src/hooks/link-users.ts
+++ b/packages/authhero/src/hooks/link-users.ts
@@ -1,12 +1,22 @@
 import { DataAdapters, User } from "@authhero/adapter-interfaces";
 import { getPrimaryUserByEmail } from "../helpers/users";
 import { JSONHTTPException } from "../errors/json-http-exception";
-import { HTTPException } from "hono/http-exception";
+
+export interface LinkUsersResult {
+  user: User;
+  // False when a concurrent request already created the same user and we
+  // returned the winner's row; callers use this to suppress duplicate
+  // post-user-registration side effects.
+  created: boolean;
+}
 
 export function linkUsersHook(data: DataAdapters) {
-  return async (tenant_id: string, user: User): Promise<User> => {
+  return async (
+    tenant_id: string,
+    user: User,
+  ): Promise<LinkUsersResult> => {
     try {
-      return await data.transaction(async (trxData) => {
+      const committed = await data.transaction(async (trxData) => {
         // If linked_to is not already set (e.g., from pre-user-registration hook),
         // check for email-based auto-linking
         // Normalize email to lowercase for case-insensitive matching
@@ -60,13 +70,17 @@ export function linkUsersHook(data: DataAdapters) {
         // No linking - return the created user
         return createdUser;
       });
+      return { user: committed, created: true };
     } catch (err) {
       // Race condition: another request created the same user simultaneously.
       // The transaction was rolled back, so look up the winner's user and return it.
-      if (err instanceof HTTPException && err.status === 409) {
+      // Duck-type the status check — HTTPException instances may not share a
+      // class identity across bundled adapter packages (minification can
+      // rename the class, breaking `instanceof`).
+      if ((err as { status?: unknown })?.status === 409) {
         const existingUser = await findExistingUser(data, tenant_id, user);
         if (existingUser) {
-          return existingUser;
+          return { user: existingUser, created: false };
         }
       }
       throw err;

--- a/packages/authhero/src/hooks/post-user-login.ts
+++ b/packages/authhero/src/hooks/post-user-login.ts
@@ -10,7 +10,6 @@ import {
 import { Bindings, Variables } from "../types";
 import { EnrichedClient } from "../helpers/client";
 import { logMessage } from "../helpers/logging";
-import { enqueuePostHookEvent } from "../helpers/hook-events";
 import { stripInternalUserFields } from "../helpers/hook-user-payload";
 import { startLoginSessionHook } from "../authentication-flows/common";
 import { isFormHook, handleFormHook } from "./formhooks";
@@ -203,10 +202,12 @@ async function buildEnhancedEventObject(
  * Checks for post-user-login hooks (form, page, template, code, or webhook)
  * and handles them in that order. Also:
  *  - logs the successful login,
- *  - increments the user's `login_count`,
- *  - re-enqueues the post-user-registration event if the user's
- *    `registration_completed_at` is still null (self-healing recovery for
- *    dead-lettered or lost post-registration events).
+ *  - increments the user's `login_count`.
+ *
+ * Delivery reliability for `post-user-registration` is the outbox's concern
+ * (retry + dead-letter), not the login path's. Recovery of dead-lettered
+ * events is a separate admin/cron responsibility so a user's first login
+ * can't double-enqueue while the original event is still pending.
  *
  * Returns either the (possibly updated) user or a `Response` when a hook
  * redirects, takes over the login, or renders a form.
@@ -243,14 +244,6 @@ export async function postUserLoginHook(
     audience: params?.authParams?.audience,
     scope: params?.authParams?.scope,
   });
-
-  // Self-healing: if the user was registered but the post-user-registration
-  // hook chain never reached completion (dead-lettered, lost on crash, etc.),
-  // re-enqueue it now so customer-authored post-registration logic eventually
-  // runs. Requires the destinations + the action code to be idempotent.
-  if (!(user as User).registration_completed_at) {
-    enqueuePostHookEvent(ctx, tenant_id, "post-user-registration", user);
-  }
 
   // Update the user's last login info
   await data.users.update(tenant_id, user.user_id, {

--- a/packages/authhero/src/hooks/pre-defined/ensure-username.ts
+++ b/packages/authhero/src/hooks/pre-defined/ensure-username.ts
@@ -1,15 +1,8 @@
-import { HTTPException } from "hono/http-exception";
 import { OnExecutePostLogin } from "../../types/Hooks";
 import { userIdGenerate } from "../../utils/user-id";
 import { USERNAME_PASSWORD_PROVIDER } from "../../constants";
 import { Strategy } from "@authhero/adapter-interfaces";
-
-/**
- * Check whether an error is a unique-constraint violation (HTTP 409).
- */
-function isUniqueConstraintError(err: unknown): boolean {
-  return err instanceof HTTPException && err.status === 409;
-}
+import { isUniqueConstraintError } from "../../errors/is-unique-constraint-error";
 
 export interface EnsureUsernameOptions {
   /**

--- a/packages/authhero/src/hooks/user-registration.ts
+++ b/packages/authhero/src/hooks/user-registration.ts
@@ -145,7 +145,19 @@ export function createUserHooks(
     }
 
     // Check for existing user with the same email and if so link the users
-    let result = await linkUsersHook(data)(tenant_id, user);
+    const linkResult = await linkUsersHook(data)(tenant_id, user);
+
+    // Race-loser: another concurrent create committed the row first.
+    // Throw 409 so management-API clients see a duplicate error; auth flows
+    // that want to recover (social callback) catch this in
+    // getOrCreateUserByProvider and read back the winner's user.
+    // Throwing here also skips post-registration hooks, preventing duplicate
+    // outbox events for a single real registration.
+    if (!linkResult.created) {
+      throw new JSONHTTPException(409, { message: "User already exists" });
+    }
+
+    const result = linkResult.user;
 
     // Post-registration hooks run after the commit transaction inside
     // linkUsersHook has closed. They must not be invoked while holding a

--- a/packages/authhero/test/hooks/account-linking.spec.ts
+++ b/packages/authhero/test/hooks/account-linking.spec.ts
@@ -219,8 +219,8 @@ describe("account-linking-hook", () => {
     });
 
     // Should return the Google user (not linked)
-    expect(result.user_id).toBe("google-oauth2|unverified-google-user");
-    expect(result.linked_to).toBeUndefined();
+    expect(result.user.user_id).toBe("google-oauth2|unverified-google-user");
+    expect(result.user.linked_to).toBeUndefined();
 
     // Verify both users exist separately
     const allUsers = await env.data.users.list("tenantId", {
@@ -271,8 +271,8 @@ describe("account-linking-hook", () => {
     });
 
     // Should return the new user (not linked to tenantId user)
-    expect(result.user_id).toBe("google-oauth2|tenant-b-user");
-    expect(result.linked_to).toBeUndefined();
+    expect(result.user.user_id).toBe("google-oauth2|tenant-b-user");
+    expect(result.user.linked_to).toBeUndefined();
   });
 
   it("should handle case-insensitive email matching", async () => {
@@ -305,10 +305,10 @@ describe("account-linking-hook", () => {
     });
 
     // Should return the primary user (linked via case-insensitive match)
-    expect(result.user_id).toBe(
+    expect(result.user.user_id).toBe(
       `${USERNAME_PASSWORD_PROVIDER}|case-test-primary`,
     );
-    expect(result.identities).toHaveLength(2);
+    expect(result.user.identities).toHaveLength(2);
 
     // Verify the secondary user is linked to primary
     const secondaryUser = await env.data.users.get(
@@ -360,8 +360,8 @@ describe("account-linking-hook", () => {
     });
 
     // Should return the PRIMARY user, not the secondary
-    expect(result.user_id).toBe(`${USERNAME_PASSWORD_PROVIDER}|chain-primary`);
-    expect(result.identities).toHaveLength(3);
+    expect(result.user.user_id).toBe(`${USERNAME_PASSWORD_PROVIDER}|chain-primary`);
+    expect(result.user.identities).toHaveLength(3);
 
     // Verify the third user is linked to primary
     const thirdUser = await env.data.users.get(
@@ -401,8 +401,8 @@ describe("account-linking-hook", () => {
     });
 
     // Should return the new user (not linked)
-    expect(result.user_id).toBe("sms|no-email-user");
-    expect(result.linked_to).toBeUndefined();
+    expect(result.user.user_id).toBe("sms|no-email-user");
+    expect(result.user.linked_to).toBeUndefined();
   });
 
   it("should use setLinkedTo from hook when provided", async () => {
@@ -435,8 +435,8 @@ describe("account-linking-hook", () => {
     });
 
     // Should return primary user even though emails don't match
-    expect(result.user_id).toBe(`${USERNAME_PASSWORD_PROVIDER}|hook-primary`);
-    expect(result.identities).toHaveLength(2);
+    expect(result.user.user_id).toBe(`${USERNAME_PASSWORD_PROVIDER}|hook-primary`);
+    expect(result.user.identities).toHaveLength(2);
   });
 
   it("should prioritize setLinkedTo over email-based linking", async () => {
@@ -477,9 +477,9 @@ describe("account-linking-hook", () => {
     });
 
     // Should link to the manually specified user, NOT the email-matched user
-    expect(result.user_id).toBe(
+    expect(result.user.user_id).toBe(
       `${USERNAME_PASSWORD_PROVIDER}|priority-manual-target`,
     );
-    expect(result.identities).toHaveLength(2);
+    expect(result.user.identities).toHaveLength(2);
   });
 });

--- a/packages/authhero/test/hooks/on-post-user-registration.spec.ts
+++ b/packages/authhero/test/hooks/on-post-user-registration.spec.ts
@@ -4,6 +4,7 @@ import { HookEvent } from "../../src/types/Hooks";
 import { testClient } from "hono/testing";
 import { getAdminToken } from "../helpers/token";
 import { Strategy } from "@authhero/adapter-interfaces";
+import { addDataHooks } from "../../src/hooks";
 
 describe("on-post-user-registration-hook", () => {
   it("should trigger an event", async () => {
@@ -44,5 +45,65 @@ describe("on-post-user-registration-hook", () => {
     // The hook should fire once when the user is created
     expect(events.length).toBe(1);
     expect(events[0]?.user.email).toBe("foo2@example.com");
+  });
+
+  it("should fire only once when two creates race for the same user_id", async () => {
+    const events: HookEvent[] = [];
+
+    const hooks = {
+      onExecutePostUserRegistration: async (event: HookEvent) => {
+        events.push(event);
+      },
+    };
+
+    const { env } = await getTestServer({ hooks });
+
+    const mockCtx: any = {
+      req: {
+        method: "POST",
+        url: "http://test",
+        path: "/test",
+        header: () => undefined,
+        query: () => undefined,
+        queries: () => ({}),
+      },
+      // applyConfigMiddleware normally merges hooks into ctx.env during a
+      // real request; inject it directly since this test bypasses the app.
+      env: { ...env, hooks },
+      var: {
+        ip: "127.0.0.1",
+        useragent: "test-agent",
+        auth0_client: undefined,
+        body: undefined,
+        client_id: "clientId",
+        tenant_id: "tenantId",
+      },
+      set: () => {},
+    };
+
+    const dataWithHooks = addDataHooks(mockCtx, env.data);
+
+    const userPayload = {
+      user_id: "vipps|shared-sub",
+      email: "racer@example.com",
+      email_verified: true,
+      provider: "vipps",
+      connection: "vipps",
+      is_social: true,
+    };
+
+    // Race-winner: the first create inserts the row and should fire the hook.
+    await dataWithHooks.users.create("tenantId", userPayload);
+
+    // Race-loser: a concurrent request with the same user_id. createUserHooks
+    // must surface this as 409 so strict management-API callers error out; the
+    // social-callback caller catches the 409 in getOrCreateUserByProvider.
+    await expect(
+      dataWithHooks.users.create("tenantId", userPayload),
+    ).rejects.toMatchObject({ status: 409 });
+
+    // Crucially, the race-loser must not re-fire the post-registration hook —
+    // that was the production bug producing duplicate outbox events.
+    expect(events.length).toBe(1);
   });
 });

--- a/packages/authhero/test/hooks/on-post-user-registration.spec.ts
+++ b/packages/authhero/test/hooks/on-post-user-registration.spec.ts
@@ -92,15 +92,23 @@ describe("on-post-user-registration-hook", () => {
       is_social: true,
     };
 
-    // Race-winner: the first create inserts the row and should fire the hook.
-    await dataWithHooks.users.create("tenantId", userPayload);
-
-    // Race-loser: a concurrent request with the same user_id. createUserHooks
-    // must surface this as 409 so strict management-API callers error out; the
-    // social-callback caller catches the 409 in getOrCreateUserByProvider.
-    await expect(
+    // Kick off both creates without awaiting so they truly race through
+    // createUserHooks concurrently. Exactly one should win the insert; the
+    // other must surface 409 (strict management-API callers error out; the
+    // social-callback caller catches the 409 in getOrCreateUserByProvider).
+    const results = await Promise.allSettled([
       dataWithHooks.users.create("tenantId", userPayload),
-    ).rejects.toMatchObject({ status: 409 });
+      dataWithHooks.users.create("tenantId", userPayload),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter(
+      (r): r is PromiseRejectedResult => r.status === "rejected",
+    );
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.reason).toMatchObject({ status: 409 });
 
     // Crucially, the race-loser must not re-fire the post-registration hook —
     // that was the production bug producing duplicate outbox events.

--- a/packages/authhero/test/hooks/outbox-self-healing.spec.ts
+++ b/packages/authhero/test/hooks/outbox-self-healing.spec.ts
@@ -2,13 +2,11 @@ import { describe, it, expect, afterEach } from "vitest";
 import { getTestServer } from "../helpers/test-server";
 import { Strategy } from "@authhero/adapter-interfaces";
 import { testClient } from "hono/testing";
-import { getAdminToken } from "../helpers/token";
 import http from "node:http";
 import { drainOutbox } from "../../src/helpers/outbox-relay";
 import { LogsDestination } from "../../src/helpers/outbox-destinations/logs";
 import { WebhookDestination } from "../../src/helpers/outbox-destinations/webhooks";
 import { RegistrationFinalizerDestination } from "../../src/helpers/outbox-destinations/registration-finalizer";
-import { USERNAME_PASSWORD_PROVIDER } from "../../src/constants";
 
 function createWebhookServer(
   handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
@@ -26,7 +24,7 @@ function createWebhookServer(
   });
 }
 
-describe("outbox self-healing pipeline", () => {
+describe("post-user-registration is only enqueued on creation", () => {
   let closeServer: (() => Promise<void>) | undefined;
 
   afterEach(async () => {
@@ -36,8 +34,14 @@ describe("outbox self-healing pipeline", () => {
     }
   });
 
-  it("signup with failing webhook → dead-letter → login re-enqueue → success → no-op", async () => {
-    // --- controllable webhook server ---
+  it("login does not re-enqueue post-user-registration, even after dead-letter", async () => {
+    // Delivery reliability for post-user-registration is owned by the outbox
+    // (retry + dead-letter). The login path must NOT re-enqueue on behalf of
+    // a failed registration — that would double-fire the hook on every first
+    // login while the original event is still pending in the outbox, and it
+    // conflates "pending delivery" with "lost delivery". Recovery of
+    // dead-lettered events is an explicit admin/cron concern.
+
     let webhookMode: "fail" | "succeed" = "fail";
     const webhookCalls: any[] = [];
 
@@ -61,14 +65,12 @@ describe("outbox self-healing pipeline", () => {
     });
     closeServer = close;
 
-    // --- test server with outbox enabled ---
-    const { env, oauthApp, managementApp } = await getTestServer({
+    const { env, oauthApp } = await getTestServer({
       mockEmail: true,
       outbox: true,
     });
     const oauthClient = testClient(oauthApp, env);
 
-    // Register a post-user-registration webhook hook
     await env.data.hooks.create("tenantId", {
       url,
       trigger_id: "post-user-registration",
@@ -76,11 +78,11 @@ describe("outbox self-healing pipeline", () => {
       synchronous: false,
     });
 
-    // --- 1. Signup (webhook will fail) ---
+    // Signup — webhook fails on delivery.
     const signupResponse = await oauthClient.dbconnections.signup.$post(
       {
         json: {
-          email: "self-heal@example.com",
+          email: "no-self-heal@example.com",
           password: "Test12345!",
           connection: Strategy.USERNAME_PASSWORD,
           client_id: "clientId",
@@ -93,25 +95,10 @@ describe("outbox self-healing pipeline", () => {
       },
     );
     expect(signupResponse.status).toBe(200);
-    const signupBody = (await signupResponse.json()) as { _id: string };
-    const userId = signupBody._id;
 
-    // Webhook was called but failed
-    const regCall = webhookCalls.find(
-      (c) => c.trigger_id === "post-user-registration",
-    );
-    expect(regCall).toBeDefined();
-
-    // User should NOT have registration_completed_at yet
-    const user1 = await env.data.users.get("tenantId", userId);
-    expect(user1).toBeTruthy();
-    expect(user1!.registration_completed_at).toBeFalsy();
-
-    // --- 2. Drain outbox → dead-letter (maxRetries=1) ---
-    // Wait for retry_at to pass (the backoff is 1s for retry_count=0 → 2s for retry_count=1)
+    // Drive the outbox to dead-letter (maxRetries=1).
     await new Promise((r) => setTimeout(r, 2200));
 
-    // Build destinations for draining
     const destinations = [
       new LogsDestination(env.data.logs),
       new WebhookDestination(env.data.hooks, async () => "dummy-token"),
@@ -120,19 +107,14 @@ describe("outbox self-healing pipeline", () => {
 
     await drainOutbox(env.data.outbox!, destinations, { maxRetries: 1 });
 
-    // Event should now be dead-lettered
     const failed = await env.data.outbox!.listFailed("tenantId");
-    expect(failed.events.length).toBeGreaterThanOrEqual(1);
     const deadEvent = failed.events.find(
       (e) => e.event_type === "hook.post-user-registration",
     );
     expect(deadEvent).toBeDefined();
 
-    // User still not finalized
-    const user2 = await env.data.users.get("tenantId", userId);
-    expect(user2!.registration_completed_at).toBeFalsy();
-
-    // --- 3. Switch webhook to succeed, login ---
+    // Login — even with the webhook now responsive, the login path must not
+    // re-enqueue. Re-driving the dead-lettered event is outside this flow.
     webhookMode = "succeed";
     webhookCalls.length = 0;
 
@@ -142,42 +124,11 @@ describe("outbox self-healing pipeline", () => {
         credential_type: "http://auth0.com/oauth/grant-type/password-realm",
         realm: Strategy.USERNAME_PASSWORD,
         password: "Test12345!",
-        username: "self-heal@example.com",
+        username: "no-self-heal@example.com",
       },
     });
     expect(loginResponse.status).toBe(200);
 
-    // The postUserLoginHook should have re-enqueued the post-user-registration
-    // event (because registration_completed_at was null). The per-request
-    // outbox processing (flushed by flushBackgroundPromises in test mode)
-    // should have delivered it successfully, and RegistrationFinalizerDestination
-    // should have set registration_completed_at.
-
-    // --- 4. Assert registration completed ---
-    const user3 = await env.data.users.get("tenantId", userId);
-    expect(user3!.registration_completed_at).toBeTruthy();
-
-    // Webhook was called successfully
-    const successCall = webhookCalls.find(
-      (c) => c.trigger_id === "post-user-registration",
-    );
-    expect(successCall).toBeDefined();
-
-    // --- 5. Login again → no-op (no re-enqueue) ---
-    webhookCalls.length = 0;
-
-    const login2Response = await oauthClient.co.authenticate.$post({
-      json: {
-        client_id: "clientId",
-        credential_type: "http://auth0.com/oauth/grant-type/password-realm",
-        realm: Strategy.USERNAME_PASSWORD,
-        password: "Test12345!",
-        username: "self-heal@example.com",
-      },
-    });
-    expect(login2Response.status).toBe(200);
-
-    // No post-user-registration webhook should fire this time
     const noopCall = webhookCalls.find(
       (c) => c.trigger_id === "post-user-registration",
     );

--- a/packages/authhero/test/hooks/outbox-self-healing.spec.ts
+++ b/packages/authhero/test/hooks/outbox-self-healing.spec.ts
@@ -129,6 +129,12 @@ describe("post-user-registration is only enqueued on creation", () => {
     });
     expect(loginResponse.status).toBe(200);
 
+    // Drain the outbox so any event that the login path might have
+    // re-enqueued is actually delivered — without this, a regression that
+    // re-enqueues on login would sit pending and silently pass the
+    // assertion below.
+    await drainOutbox(env.data.outbox!, destinations, { maxRetries: 1 });
+
     const noopCall = webhookCalls.find(
       (c) => c.trigger_id === "post-user-registration",
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate post-registration webhook events during first login and concurrent account creations
  * Improved detection and handling of user-linking races so the losing concurrent request completes without re-firing registration hooks

* **Tests**
  * Updated tests to match new result shape and added concurrency tests to ensure single post-registration delivery
<!-- end of auto-generated comment: release notes by coderabbit.ai -->