### PR TITLE
rfc 7591 phase 5

### DIFF
--- a/.changeset/dcr-connect-start.md
+++ b/.changeset/dcr-connect-start.md
@@ -1,11 +1,20 @@
 ---
 "authhero": minor
 "@authhero/adapter-interfaces": patch
+"@authhero/kysely-adapter": patch
 ---
 
-Add Phase 4 of RFC 7591/7592 Dynamic Client Registration: the consent-mediated `/connect/start` browser flow and a Management API endpoint for minting Initial Access Tokens.
+Add Phases 4 and 5 of RFC 7591/7592 Dynamic Client Registration.
+
+**Phase 4 — consent-mediated DCR**
 
 - New top-level `GET /connect/start?integration_type=...&domain=...&return_to=...&state=...&scope=...` route validates the request, creates a login session, and 302s to `/u2/connect/start`. The Stencil widget renders a consent screen there; on confirm AuthHero mints an IAT bound to the consenting user (with `domain`, `integration_type`, `scope`, and `grant_types: ["client_credentials"]` as pre-bound constraints) and redirects to `return_to?authhero_iat=<token>&state=<state>`. Cancel returns `authhero_error=cancelled`.
 - New `POST /api/v2/client-registration-tokens` (scope `create:client_registration_tokens` or `auth:write`) for non-browser IAT issuance. Body: `{ sub?, constraints?, expires_in_seconds?, single_use? }` — defaults to 5-minute TTL and single-use.
 - New tenant flag `dcr_allowed_integration_types: string[]` allowlists the `integration_type` values accepted by `/connect/start`.
 - New management scope `create:client_registration_tokens` added to `MANAGEMENT_API_SCOPES`.
+
+**Phase 5 — owner scoping & soft-delete enforcement**
+
+- New `GET /api/v2/users/{user_id}/connected-clients` Management API endpoint returns clients owned by a user (created via IAT-gated DCR). Response is a slim projection — no secrets, no internal config — and excludes soft-deleted clients.
+- `getEnrichedClient` now treats clients with `client_metadata.status === "deleted"` as not found. After RFC 7592 `DELETE /oidc/register/{client_id}`, subsequent `/oauth/token`, `/authorize`, and resume requests for that `client_id` are rejected.
+- The kysely `clients.list` adapter now supports lucene-style `field:"value"` exact-match filtering on `owner_user_id` and `registration_type`.

--- a/.changeset/deep-radios-relax.md
+++ b/.changeset/deep-radios-relax.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Add rfc 7638 support

--- a/.changeset/rfc-7638-jwk-thumbprint-kid.md
+++ b/.changeset/rfc-7638-jwk-thumbprint-kid.md
@@ -1,0 +1,11 @@
+---
+"authhero": minor
+---
+
+Derive signing-key `kid` from the RFC 7638 JWK Thumbprint.
+
+`createX509Certificate` now sets the `kid` (and the existing `fingerprint` field) to the SHA-256 base64url thumbprint of the public JWK, computed per RFC 7638 (only the required members for the kty, in lexicographic order, no whitespace). This produces a deterministic, self-verifying key identifier that any client can recompute from the published JWKS.
+
+Existing keys keep their original `kid` (a hex-encoded certificate serial number) — `kid` is stored on each row, so previously issued tokens continue to verify. Only newly created keys use the thumbprint format. Operators can normalise via `POST /api/v2/keys/signing/rotate`.
+
+A new exported `computeJWKThumbprint(jwk)` helper is available for any caller that needs to compute the thumbprint of an arbitrary JWK.

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -316,6 +316,10 @@ gtag('config', 'G-DNZWG3PF2L');`,
               items: [
                 { text: "RFC 7517 — JWK", link: "/standards/rfc-7517" },
                 { text: "RFC 7519 — JWT", link: "/standards/rfc-7519" },
+                {
+                  text: "RFC 7638 — JWK Thumbprint",
+                  link: "/standards/rfc-7638",
+                },
               ],
             },
             {

--- a/apps/docs/standards/index.md
+++ b/apps/docs/standards/index.md
@@ -29,6 +29,7 @@ AuthHero is built on open identity standards. This section tracks every spec Aut
 | -------- | ------ |
 | [RFC 7517 — JSON Web Key (JWK)](/standards/rfc-7517) | Full |
 | [RFC 7519 — JSON Web Token (JWT)](/standards/rfc-7519) | Full |
+| [RFC 7638 — JWK Thumbprint](/standards/rfc-7638) | Full |
 
 ## OpenID Connect
 

--- a/apps/docs/standards/rfc-7517.md
+++ b/apps/docs/standards/rfc-7517.md
@@ -14,7 +14,7 @@ RFC 7517 defines the JSON representation of cryptographic keys and the JWK Set f
 
 - **JWK Set endpoint** — `GET /.well-known/jwks.json` returns all active signing keys for the tenant.
 - **Key types** — RSA, EC, and symmetric (`oct`) keys can be represented.
-- **Standard JWK parameters** — `kty`, `kid`, `use`, `alg`, `n`, `e`, `x`, `y`, `crv` are populated as appropriate.
+- **Standard JWK parameters** — `kty`, `kid`, `use`, `alg`, `n`, `e`, `x`, `y`, `crv` are populated as appropriate. New keys derive `kid` from the [RFC 7638 JWK Thumbprint](/standards/rfc-7638).
 - **Key rotation** — multiple keys can be published simultaneously so that old tokens remain verifiable while new tokens are signed with a new key.
 - **Cache headers** — JWKS responses include appropriate `Cache-Control` headers so downstream resource servers can cache public keys.
 

--- a/apps/docs/standards/rfc-7592.md
+++ b/apps/docs/standards/rfc-7592.md
@@ -14,12 +14,26 @@ RFC 7592 extends [RFC 7591](/standards/rfc-7591) with endpoints for a client to 
 
 - **Read** — `GET /oidc/register/{client_id}` returns the current client metadata.
 - **Update** — `PUT /oidc/register/{client_id}` replaces the client metadata document, subject to any constraints carried over from the original Initial Access Token.
-- **Delete** — `DELETE /oidc/register/{client_id}` soft-deletes the client.
+- **Delete** — `DELETE /oidc/register/{client_id}` soft-deletes the client. Subsequent token requests at `/oauth/token` for that `client_id` are rejected as if the client did not exist; the registration record is preserved for audit.
 - **RAT authentication** — every management request must present the Registration Access Token returned at registration time as `Authorization: Bearer <rat>`.
 - **IAT constraint immutability** — fields that were constrained by the original IAT (allowed grant types, redirect URI patterns, scopes) cannot be widened on update.
 - **Error responses** — missing or invalid RATs yield `401` / `403` with the standard RFC 7592 error bodies.
 
+## End-user "connected apps"
+
+Clients created via [IAT-gated DCR](/standards/connect-start) carry an `owner_user_id` referencing the consenting user. This powers a self-service "connected apps" listing:
+
+```
+GET /api/v2/users/{user_id}/connected-clients
+Authorization: Bearer <mgmt-api-token with read:clients|read:users|auth:read>
+```
+
+The response is a slim projection of each client (no secrets, no internal config) — `client_id`, `name`, `logo_uri`, `registration_type`, `registration_metadata` (e.g. `domain`, `integration_type`), and timestamps. Soft-deleted clients are excluded so the listing always reflects live, revocable connections.
+
+A revocation flow is just `DELETE /oidc/register/{client_id}` from the user's UI (proxying through your application server, which holds the RAT).
+
 ## Related AuthHero documentation
 
 - [RFC 7591 — Dynamic Client Registration](/standards/rfc-7591)
+- [Connect Start (consent flow)](/standards/connect-start)
 - [Applications](/entities/configuration/applications)

--- a/apps/docs/standards/rfc-7638.md
+++ b/apps/docs/standards/rfc-7638.md
@@ -1,0 +1,33 @@
+---
+title: RFC 7638 — JWK Thumbprint
+description: AuthHero's implementation of the JSON Web Key (JWK) Thumbprint specification (RFC 7638), used to derive stable key identifiers.
+---
+
+# RFC 7638 — JWK Thumbprint
+
+**Spec:** [datatracker.ietf.org/doc/html/rfc7638](https://datatracker.ietf.org/doc/html/rfc7638)
+**Status:** Full
+
+RFC 7638 defines a deterministic way to derive a fingerprint from the public-key material in a JWK. The thumbprint is computed by:
+
+1. Selecting only the required members for the key type (`kty`, plus the type-specific public parameters — e.g. `e`, `n` for RSA; `crv`, `x`, `y` for EC).
+2. Serializing those members as JSON in lexicographic order with no whitespace.
+3. Hashing the serialization with SHA-256.
+4. Encoding the digest as base64url without padding.
+
+Because the thumbprint depends only on the key material, two parties given the same public key will always derive the same value.
+
+## How AuthHero uses it
+
+- **`kid` for signing keys** — when a new signing certificate is generated (via key rotation, tenant seed, or first-time setup), AuthHero sets the JWK `kid` to the RFC 7638 thumbprint of the public key. The same value is published in `/.well-known/jwks.json` and embedded in the `kid` header of every signed JWT.
+- **Stable across cert reissue** — because the `kid` is derived from the key, reissuing a certificate that wraps the same public key produces the same `kid`. Clients caching the JWKS do not need to re-fetch.
+- **Self-verifying** — any client can recompute the thumbprint from the published JWK and confirm it matches the `kid`.
+
+## Backwards compatibility
+
+Signing keys created before RFC 7638 was adopted retain their original `kid` (a hex-encoded certificate serial number). The `kid` is stored on each key row, so existing tokens continue to verify against existing JWKS entries — only newly created keys use the thumbprint format. Operators who want every key to use the new format can rotate via `POST /api/v2/keys/signing/rotate`.
+
+## Related standards
+
+- [RFC 7517 — JSON Web Key (JWK)](/standards/rfc-7517) — defines the JWK structure and the `kid` parameter.
+- [RFC 7519 — JSON Web Token (JWT)](/standards/rfc-7519) — `kid` in the JWT header tells verifiers which JWKS entry to use.

--- a/packages/authhero/src/helpers/client.ts
+++ b/packages/authhero/src/helpers/client.ts
@@ -74,6 +74,11 @@ export async function getEnrichedClient(
   if (!finalClient) {
     throw new JSONHTTPException(403, { message: "Client not found" });
   }
+  // Treat soft-deleted clients (DCR DELETE /oidc/register/:id) as if they
+  // were removed entirely — no token issuance, no /authorize, no resume.
+  if (finalClient.client_metadata?.status === "deleted") {
+    throw new JSONHTTPException(403, { message: "Client not found" });
+  }
   if (!tenant) {
     throw new JSONHTTPException(404, { message: "Tenant not found" });
   }

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -65,6 +65,23 @@ const userOrganizationsWithTotalsSchema = totalsSchema.extend({
   organizations: z.array(organizationSchema),
 });
 
+// Slim projection of a Client suitable for end-user "connected apps" UIs.
+// Excludes secrets and internal config; surfaces enough for revocation
+// and display.
+const connectedClientSchema = z.object({
+  client_id: z.string(),
+  name: z.string(),
+  logo_uri: z.string().optional(),
+  registration_type: z.enum(["manual", "open_dcr", "iat_dcr"]).optional(),
+  registration_metadata: z.record(z.any()).optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+const connectedClientsWithTotalsSchema = totalsSchema.extend({
+  connected_clients: z.array(connectedClientSchema),
+});
+
 export const userRoutes = new OpenAPIHono<{
   Bindings: Bindings;
   Variables: Variables;
@@ -808,6 +825,78 @@ export const userRoutes = new OpenAPIHono<{
       });
 
       return ctx.json([auth0UserResponseSchema.parse(user)]);
+    },
+  )
+  // --------------------------------
+  // GET /users/:user_id/connected-clients
+  //
+  // Returns clients that this user owns — i.e. clients created via the
+  // RFC 7591 IAT-gated Dynamic Client Registration flow where the IAT was
+  // bound to this user (`owner_user_id = user_id`). Excludes soft-deleted
+  // clients (DELETE /oidc/register/:id), so this is a live "connected apps"
+  // listing safe for end-user UIs.
+  // --------------------------------
+  .openapi(
+    createRoute({
+      tags: ["users"],
+      method: "get",
+      path: "/{user_id}/connected-clients",
+      request: {
+        query: querySchema,
+        headers: z.object({
+          "tenant-id": z.string().optional(),
+        }),
+        params: z.object({
+          user_id: z.string(),
+        }),
+      },
+      security: [
+        {
+          Bearer: ["read:clients", "read:users", "auth:read"],
+        },
+      ],
+      responses: {
+        200: {
+          content: {
+            "application/json": {
+              schema: z.union([
+                z.array(connectedClientSchema),
+                connectedClientsWithTotalsSchema,
+              ]),
+            },
+          },
+          description:
+            "List of clients connected to this user (created via IAT-gated DCR).",
+        },
+      },
+    }),
+    async (ctx) => {
+      const { user_id } = ctx.req.valid("param");
+      const { include_totals, page, per_page } = ctx.req.valid("query");
+
+      const result = await ctx.env.data.clients.list(ctx.var.tenant_id, {
+        page,
+        per_page,
+        include_totals,
+        q: `owner_user_id:"${user_id}"`,
+      });
+
+      // Filter out soft-deleted clients and project to the slim shape so
+      // we never leak secrets or internal config to the connected-apps UI.
+      const connectedClients = result.clients
+        .filter((client) => client.client_metadata?.status !== "deleted")
+        .map((client) => connectedClientSchema.parse(client));
+
+      if (!include_totals) {
+        return ctx.json(connectedClients);
+      }
+
+      return ctx.json({
+        connected_clients: connectedClients,
+        start: result.totals?.start ?? 0,
+        limit: result.totals?.limit ?? 0,
+        length: connectedClients.length,
+      });
     },
   ) // --------------------------------
   // GET /users/:user_id/sessions

--- a/packages/authhero/src/utils/encryption.ts
+++ b/packages/authhero/src/utils/encryption.ts
@@ -1,8 +1,15 @@
 import { nanoid } from "nanoid";
 import * as x509 from "@peculiar/x509";
-import { encodeHex, base64 } from "oslo/encoding";
+import { encodeHex, base64, base64url } from "oslo/encoding";
 import { sha256 } from "oslo/crypto";
 import { SigningKey } from "@authhero/adapter-interfaces";
+
+const RFC7638_REQUIRED_MEMBERS: Record<string, string[]> = {
+  RSA: ["e", "kty", "n"],
+  EC: ["crv", "kty", "x", "y"],
+  oct: ["k", "kty"],
+  OKP: ["crv", "kty", "x"],
+};
 
 export interface CreateX509CertificateParams {
   name: string;
@@ -43,12 +50,12 @@ export async function createX509Certificate(
   const privateKey = await crypto.subtle.exportKey("pkcs8", keys.privateKey!);
 
   const pemCert = cert.toString("pem");
-  const fingerprint = await getJWKFingerprint(cert);
+  const fingerprint = await getJWKThumbprint(cert);
   const thumbprint = encodeHex(await cert.getThumbprint());
   const pkcs7 = convertPKCS7ToPem("PRIVATE", privateKey);
 
   return {
-    kid: cert.serialNumber,
+    kid: fingerprint,
     cert: pemCert,
     thumbprint,
     fingerprint,
@@ -81,16 +88,38 @@ export async function toJWKS(key: CryptoKey): Promise<JsonWebKey> {
   return await crypto.subtle.exportKey("jwk", key);
 }
 
-export async function getJWKFingerprint(cert: x509.X509Certificate) {
+export async function getJWKThumbprint(
+  cert: x509.X509Certificate,
+): Promise<string> {
   const publicKey = await cert.publicKey.export();
   const jwkKey = await crypto.subtle.exportKey("jwk", publicKey);
+  return computeJWKThumbprint(jwkKey);
+}
 
-  // Create a canonical JSON representation
-  const canonicalJWK = JSON.stringify(jwkKey, Object.keys(jwkKey).sort());
+// RFC 7638 §3: SHA-256 of a canonical JSON serialization that contains
+// only the required public-key members for the kty, in lexicographic
+// order, with no whitespace, encoded as base64url without padding.
+export async function computeJWKThumbprint(jwk: JsonWebKey): Promise<string> {
+  if (!jwk.kty) {
+    throw new Error("JWK is missing required 'kty' member");
+  }
+  const required = RFC7638_REQUIRED_MEMBERS[jwk.kty];
+  if (!required) {
+    throw new Error(`Unsupported JWK kty for thumbprint: ${jwk.kty}`);
+  }
 
-  // Convert the string to an ArrayBuffer using TextEncoder
-  const encoder = new TextEncoder();
-  const data = encoder.encode(canonicalJWK);
+  const canonical: Record<string, string> = {};
+  for (const member of required) {
+    const value = (jwk as Record<string, unknown>)[member];
+    if (typeof value !== "string" || value.length === 0) {
+      throw new Error(
+        `JWK is missing required member '${member}' for kty=${jwk.kty}`,
+      );
+    }
+    canonical[member] = value;
+  }
 
-  return encodeHex(await sha256(data));
+  const json = JSON.stringify(canonical);
+  const digest = await sha256(new TextEncoder().encode(json));
+  return base64url.encode(new Uint8Array(digest), { includePadding: false });
 }

--- a/packages/authhero/test/routes/auth-api/dcr-phase5.spec.ts
+++ b/packages/authhero/test/routes/auth-api/dcr-phase5.spec.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import { testClient } from "hono/testing";
+import { getTestServer } from "../../helpers/test-server";
+import { mintRegistrationToken } from "../../../src/helpers/dcr/mint-token";
+import { getAdminToken } from "../../helpers/token";
+import type { Bindings } from "../../../src/types";
+
+async function enableDcr(env: Bindings) {
+  await env.data.tenants.update("tenantId", {
+    flags: {
+      enable_dynamic_client_registration: true,
+      dcr_require_initial_access_token: true,
+    },
+  });
+}
+
+async function mintIatRecord(
+  env: Bindings,
+  opts: { sub?: string; constraints?: Record<string, unknown> } = {},
+) {
+  const token = await mintRegistrationToken();
+  await env.data.clientRegistrationTokens.create("tenantId", {
+    id: token.id,
+    token_hash: token.token_hash,
+    type: "iat",
+    sub: opts.sub,
+    constraints: opts.constraints,
+    single_use: true,
+    expires_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+  });
+  return token.token;
+}
+
+async function registerClient(
+  env: Bindings,
+  oauthApp: any,
+  iat: string,
+  body: Record<string, unknown>,
+) {
+  const response = await oauthApp.request(
+    "/oidc/register",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "tenant-id": "tenantId",
+        authorization: `Bearer ${iat}`,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+  expect(response.status).toBe(201);
+  return response.json();
+}
+
+describe("Phase 5 — soft-delete enforcement at /oauth/token", () => {
+  it("after RFC 7592 DELETE, client_credentials token request returns invalid_client", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await enableDcr(env);
+
+    const iat = await mintIatRecord(env, {
+      sub: "email|user-1",
+      constraints: { grant_types: ["client_credentials"] },
+    });
+
+    const created = await registerClient(env, oauthApp, iat, {
+      client_name: "App to be deleted",
+      grant_types: ["client_credentials"],
+      token_endpoint_auth_method: "client_secret_basic",
+    });
+
+    // Sanity check — the freshly registered client can mint tokens.
+    const ok = await testClient(oauthApp, env).oauth.token.$post(
+      // @ts-expect-error testClient typing
+      {
+        form: {
+          grant_type: "client_credentials",
+          client_id: created.client_id,
+          client_secret: created.client_secret,
+          audience: "https://example.com",
+        },
+      },
+      { headers: { "tenant-id": "tenantId" } },
+    );
+    expect(ok.status).toBe(200);
+
+    // RFC 7592 DELETE — soft-deletes the client.
+    const del = await oauthApp.request(
+      `/oidc/register/${created.client_id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${created.registration_access_token}`,
+        },
+      },
+      env,
+    );
+    expect(del.status).toBe(204);
+
+    // Subsequent token request must fail — getEnrichedClient blocks lookup.
+    const denied = await testClient(oauthApp, env).oauth.token.$post(
+      // @ts-expect-error testClient typing
+      {
+        form: {
+          grant_type: "client_credentials",
+          client_id: created.client_id,
+          client_secret: created.client_secret,
+          audience: "https://example.com",
+        },
+      },
+      { headers: { "tenant-id": "tenantId" } },
+    );
+    expect(denied.status).not.toBe(200);
+  });
+});
+
+describe("Phase 5 — GET /api/v2/users/:user_id/connected-clients", () => {
+  it("returns clients owned by the user, excludes other users' clients and soft-deleted clients", async () => {
+    const { oauthApp, managementApp, env } = await getTestServer();
+    await enableDcr(env);
+
+    const iatA1 = await mintIatRecord(env, { sub: "email|user-A" });
+    const iatA2 = await mintIatRecord(env, { sub: "email|user-A" });
+    const iatB = await mintIatRecord(env, { sub: "email|user-B" });
+
+    const a1 = await registerClient(env, oauthApp, iatA1, {
+      client_name: "User A — App 1",
+      redirect_uris: ["https://a-publisher.com/cb"],
+    });
+    const a2 = await registerClient(env, oauthApp, iatA2, {
+      client_name: "User A — App 2",
+      redirect_uris: ["https://a-other.com/cb"],
+    });
+    await registerClient(env, oauthApp, iatB, {
+      client_name: "User B — App",
+      redirect_uris: ["https://b.com/cb"],
+    });
+
+    // Soft-delete one of A's clients — it should not appear.
+    const del = await oauthApp.request(
+      `/oidc/register/${a2.client_id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${a2.registration_access_token}`,
+        },
+      },
+      env,
+    );
+    expect(del.status).toBe(204);
+
+    const adminToken = await getAdminToken();
+    const response = await managementApp.request(
+      "/users/email%7Cuser-A/connected-clients",
+      {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${adminToken}`,
+          "tenant-id": "tenantId",
+        },
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Array<{
+      client_id: string;
+      name: string;
+      registration_type?: string;
+    }>;
+    expect(body).toHaveLength(1);
+    expect(body[0]!.client_id).toBe(a1.client_id);
+    expect(body[0]!.name).toBe("User A — App 1");
+    expect(body[0]!.registration_type).toBe("iat_dcr");
+    // Confirm slim shape — secret never leaks.
+    expect(body[0] as Record<string, unknown>).not.toHaveProperty(
+      "client_secret",
+    );
+  });
+
+  it("returns empty array when user has no connected clients", async () => {
+    const { managementApp, env } = await getTestServer();
+    const adminToken = await getAdminToken();
+    const response = await managementApp.request(
+      "/users/email%7Cnobody/connected-clients",
+      {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${adminToken}`,
+          "tenant-id": "tenantId",
+        },
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual([]);
+  });
+
+  it("rejects request without read:clients/read:users/auth:read scope", async () => {
+    const { managementApp, env } = await getTestServer();
+    const { createToken } = await import("../../helpers/token");
+    const limited = await createToken({ permissions: ["delete:users"] });
+    const response = await managementApp.request(
+      "/users/email%7Cuser-A/connected-clients",
+      {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${limited}`,
+          "tenant-id": "tenantId",
+        },
+      },
+      env,
+    );
+    expect(response.status).toBe(403);
+  });
+});

--- a/packages/kysely/src/clients/list.ts
+++ b/packages/kysely/src/clients/list.ts
@@ -13,14 +13,37 @@ export function list(db: Kysely<Database>) {
       .selectFrom("clients")
       .where("clients.tenant_id", "=", tenantId);
 
-    // Apply search filter if q is provided
+    // Lucene-style `field:"value"` matches do exact equality on the named
+    // column. Right now only `owner_user_id` and `registration_type` are
+    // surfaced — both are first-class columns added for RFC 7591 DCR.
+    // Anything else falls back to the legacy substring search across
+    // `name` + `client_id`.
+    const exactMatchableFields = new Set([
+      "owner_user_id",
+      "registration_type",
+    ]);
     if (params?.q) {
-      query = query.where((eb) =>
-        eb.or([
-          eb("name", "like", `%${params.q}%`),
-          eb("client_id", "like", `%${params.q}%`),
-        ]),
+      const trimmed = params.q.trim();
+      const exactMatch = trimmed.match(
+        /^([a-zA-Z_][a-zA-Z0-9_]*):"?([^"]*)"?$/,
       );
+      if (
+        exactMatch &&
+        exactMatchableFields.has(exactMatch[1]!) &&
+        exactMatch[2]
+      ) {
+        const fieldName = exactMatch[1] as
+          | "owner_user_id"
+          | "registration_type";
+        query = query.where(fieldName, "=", exactMatch[2]!);
+      } else {
+        query = query.where((eb) =>
+          eb.or([
+            eb("name", "like", `%${params.q}%`),
+            eb("client_id", "like", `%${params.q}%`),
+          ]),
+        );
+      }
     }
 
     // Apply sorting
@@ -67,12 +90,27 @@ export function list(db: Kysely<Database>) {
         .where("clients.tenant_id", "=", tenantId);
 
       if (params?.q) {
-        countQuery = countQuery.where((eb) =>
-          eb.or([
-            eb("name", "like", `%${params.q}%`),
-            eb("client_id", "like", `%${params.q}%`),
-          ]),
+        const trimmed = params.q.trim();
+        const exactMatch = trimmed.match(
+          /^([a-zA-Z_][a-zA-Z0-9_]*):"?([^"]*)"?$/,
         );
+        if (
+          exactMatch &&
+          exactMatchableFields.has(exactMatch[1]!) &&
+          exactMatch[2]
+        ) {
+          const fieldName = exactMatch[1] as
+            | "owner_user_id"
+            | "registration_type";
+          countQuery = countQuery.where(fieldName, "=", exactMatch[2]!);
+        } else {
+          countQuery = countQuery.where((eb) =>
+            eb.or([
+              eb("name", "like", `%${params.q}%`),
+              eb("client_id", "like", `%${params.q}%`),
+            ]),
+          );
+        }
       }
 
       const countResult = await countQuery.executeTakeFirst();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * RFC 7638 JWK Thumbprint support now available—automatically derives `kid` values for new signing keys
  * New endpoint enabling users to list and manage their connected OAuth clients
  * New helper function to compute RFC 7638 thumbprints for arbitrary JWKs

* **Bug Fixes**
  * Soft-deleted clients now properly rejected in OAuth token and authorization flows

* **Documentation**
  * RFC 7638 (JWK Thumbprint) documentation added
  * RFC 7592 and RFC 7517 documentation updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->