### PR TITLE
Ignore Claude Code worktree directories

### DIFF
--- a/.changeset/drop-integration-type-allowlist.md
+++ b/.changeset/drop-integration-type-allowlist.md
@@ -1,0 +1,6 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+---
+
+Drop `dcr_allowed_integration_types` tenant flag and per-tenant allowlist check on `/connect/start`. `integration_type` is now an optional free-form label — `enable_dynamic_client_registration` alone gates the connect flow. Existing callers that pass `integration_type` continue to work; the value still flows into the IAT constraints and consent screen when supplied.

--- a/.changeset/huge-owls-clean.md
+++ b/.changeset/huge-owls-clean.md
@@ -1,0 +1,6 @@
+---
+"@authhero/react-admin": minor
+"@authhero/docs": minor
+---
+
+Add sync resource server toggle

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ apps/docs/.vitepress/dist
 # Claude Code
 .claude/settings.json
 .claude/settings.local.json
+.claude/worktrees/

--- a/apps/docs/architecture/multi-tenancy.md
+++ b/apps/docs/architecture/multi-tenancy.md
@@ -27,7 +27,7 @@ For B2B SaaS applications where your customers need isolated environments, the `
 - **Per-tenant databases** — Each customer can have their own isolated database
 - **Subdomain routing** — Automatic `customer.auth.example.com` → tenant resolution
 - **Settings inheritance** — Child tenants inherit configuration from the control plane
-- **Entity sync** — Resource servers, roles, and connections can be synced from the control plane to child tenants
+- **Entity sync** — Resource servers, roles, and connections can be synced from the control plane to child tenants. Individual entities can opt out by setting `metadata: { sync: false }` (see [Control Plane — Opting Out of Sync](/customization/multi-tenancy/control-plane#opting-out-of-sync))
 - **Token-based access** — JWT tokens with `org_id` claims for organization context
 
 ### Organizations

--- a/apps/docs/architecture/multi-tenancy.md
+++ b/apps/docs/architecture/multi-tenancy.md
@@ -27,7 +27,7 @@ For B2B SaaS applications where your customers need isolated environments, the `
 - **Per-tenant databases** — Each customer can have their own isolated database
 - **Subdomain routing** — Automatic `customer.auth.example.com` → tenant resolution
 - **Settings inheritance** — Child tenants inherit configuration from the control plane
-- **Entity sync** — Resource servers, roles, and connections can be synced from the control plane to child tenants. Individual entities can opt out by setting `metadata: { sync: false }` (see [Control Plane — Opting Out of Sync](/customization/multi-tenancy/control-plane#opting-out-of-sync))
+- **Entity sync** — Only resource servers and roles are synced from the control plane to child tenants. Individual entities can opt out by setting `metadata: { sync: false }` (see [Control Plane — Opting Out of Sync](/customization/multi-tenancy/control-plane#opting-out-of-sync))
 - **Token-based access** — JWT tokens with `org_id` claims for organization context
 
 ### Organizations

--- a/apps/docs/customization/hono-variables.md
+++ b/apps/docs/customization/hono-variables.md
@@ -15,9 +15,9 @@ Variables in AuthHero are stored in the Hono context (`ctx.var`) and provide a t
 
 ### Core Variables
 
-| Variable        | Type      | Description                                 | Set By                 |
-| --------------- | --------- | ------------------------------------------- | ---------------------- |
-| `tenant_id`     | `string`  | The current tenant identifier               | `tenantMiddleware`     |
+| Variable        | Type      | Description                                                                                                            | Set By                 |
+| --------------- | --------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `tenant_id`     | `string`  | The current tenant identifier. Resolution order is documented in [Tenant Resolution Chain](/customization/multi-tenancy/subdomain-routing#tenant-resolution-chain). | `tenantMiddleware`     |
 | `ip`            | `string`  | Client IP address (from `x-real-ip` header) | `clientInfoMiddleware` |
 | `client_id`     | `string?` | OAuth client identifier                     | Various auth flows     |
 | `user_id`       | `string?` | Current user identifier                     | Auth middleware        |

--- a/apps/docs/customization/multi-tenancy/control-plane.md
+++ b/apps/docs/customization/multi-tenancy/control-plane.md
@@ -145,6 +145,42 @@ await adapters.rolePermissions.assign("main", adminRoleId, [
 // Permissions are synced to the same role on all child tenants
 ```
 
+### Opting Out of Sync
+
+To keep a resource server or role on the control plane only — without
+propagating it to child tenants — set `metadata.sync` to `false`:
+
+```typescript
+// Control-plane-only API; never synced to child tenants
+await adapters.resourceServers.create("main", {
+  name: "Internal Ops API",
+  identifier: "https://ops.internal.example.com",
+  metadata: { sync: false },
+});
+```
+
+The default sync filter checks `metadata.sync !== false` before mirroring
+to child tenants, and it applies in both directions:
+
+- New or updated entities on the control plane are not pushed out.
+- Newly created child tenants do not receive the entity at provisioning time.
+
+The same flag works for roles. For more elaborate rules, supply custom
+filters when constructing the hooks; they compose with the `metadata.sync`
+check rather than replacing it (an entity must pass both to be synced):
+
+```typescript
+const { entityHooks, tenantHooks } = createSyncHooks({
+  controlPlaneTenantId: "main",
+  getChildTenantIds,
+  getAdapters,
+  getControlPlaneAdapters,
+  filters: {
+    resourceServers: (rs) => !rs.identifier.startsWith("https://internal."),
+  },
+});
+```
+
 ### Configuration
 
 Enable entity synchronization when setting up multi-tenancy:

--- a/apps/docs/customization/multi-tenancy/subdomain-routing.md
+++ b/apps/docs/customization/multi-tenancy/subdomain-routing.md
@@ -17,6 +17,24 @@ Subdomain routing allows you to:
 - Customize subdomain resolution logic
 - Support custom domains per tenant
 
+## Tenant Resolution Chain
+
+Subdomain routing is one signal in a broader chain. The core `tenantMiddleware` (in `packages/authhero`) populates `ctx.var.tenant_id` from the first signal that matches, in this order:
+
+| Order | Signal | Typical use |
+| --- | --- | --- |
+| 1 | Authenticated `user.tenant_id` claim | Session/JWT-bearing requests |
+| 2 | `tenant-id` request header | Server-to-server / management API calls |
+| 3 | Custom domain matching `x-forwarded-host` | Proxied requests (Cloudflare, ALB) |
+| 4 | Custom domain matching `host` | Direct requests with per-tenant domains |
+| 5 | Subdomain whose first label is a tenant id | `acme.auth.example.com` → tenant `acme` |
+| 6 | `tenant_id` query parameter | Enrollment tickets, integration callbacks (e.g. [`/connect/start`](/standards/connect-start#tenant-resolution)) |
+| 7 | Single-tenant auto-detection | Only triggers when exactly one tenant exists in the database |
+
+The first match wins — later rules don't run. When `@authhero/multi-tenancy` is installed, its subdomain middleware supplements step 5 with organization-based lookup (e.g. mapping `acme` to a sub-tenant via the organization registry on the control plane), as detailed in the rest of this page.
+
+If none of the rules match, `tenant_id` remains unset and routes that require a tenant respond with `404` or `400`.
+
 ## Basic Configuration
 
 ### Organization-Based Routing

--- a/apps/docs/standards/connect-start.md
+++ b/apps/docs/standards/connect-start.md
@@ -21,15 +21,15 @@ For the canonical Sesamy-CMS use case ("a WordPress publisher connects their sit
 ## Flow
 
 ```
-Browser → GET /connect/start?integration_type=wordpress
-                            &domain=publisher.com
+Browser → GET /connect/start?domain=publisher.com
                             &return_to=https://publisher.com/wp-admin/...
                             &state=<csrf>
-                            &scope=...        ← optional
+                            &integration_type=wordpress  ← optional label
+                            &scope=...                   ← optional
 AuthHero → 302 /u2/connect/start?state=<login_session_id>
             (universal-login + Stencil widget renders the consent screen)
 User     → confirms
-AuthHero → mint IAT bound to {sub: user, domain, integration_type, scope}
+AuthHero → mint IAT bound to {sub: user, domain, integration_type?, scope?}
          → 302 return_to?authhero_iat=<token>&state=<csrf>
 CMS      → POST /oidc/register
              Authorization: Bearer <iat>
@@ -70,11 +70,24 @@ Set on the `return_to` redirect only when the IAT was minted on a tenant *differ
 
 | Parameter | Required | Description |
 | --- | --- | --- |
-| `integration_type` | yes | A caller-defined identifier. Tenant must allowlist it via `flags.dcr_allowed_integration_types`. |
+| `integration_type` | no | Optional caller-defined label (e.g. `wordpress`, `ghost`). Surfaced on the consent screen and pre-bound to the IAT/client metadata. Free-form — there is no per-tenant allowlist. |
 | `domain` | yes | Logical "thing being connected." May be a bare host[:port] (implicit `https://`) or a fully-qualified origin (`http://127.0.0.1:8888` for local dev). `return_to`'s origin must match. |
-| `return_to` | yes | Where the browser is redirected after consent (success or cancel). Origin must match `domain`. |
+| `return_to` | yes | Where the browser is redirected after consent (success or cancel). Origin must match `domain`. URL-encode the value if it contains its own query string. |
 | `state` | yes | Caller-supplied CSRF token. Round-tripped on the redirect unchanged. |
 | `scope` | no | Space-separated scope list, pre-bound to the IAT. |
+| `tenant_id` | no | Explicit tenant override. Used only when host-based resolution doesn't already pick a tenant — see [Tenant resolution](#tenant-resolution). |
+
+## Tenant resolution
+
+`/connect/start` uses AuthHero's standard [tenant-resolution chain](/customization/multi-tenancy/subdomain-routing#tenant-resolution-chain). The request must resolve to either the control-plane tenant (which triggers the workspace picker) or directly to a child tenant (which skips the picker).
+
+The most relevant rules for this endpoint, in priority order:
+
+1. Custom domain registered on the `host` / `x-forwarded-host` header (e.g. `auth.acme.com` → tenant `acme`).
+2. Subdomain matching a tenant id (e.g. `acme.auth.example.com` → tenant `acme`).
+3. Explicit `tenant_id` query parameter — the fallback used when neither of the above matches.
+
+If you're calling the default AuthHero URL (no per-tenant custom domain, no tenant subdomain), append `&tenant_id=<control-plane-id>` so the request resolves to the control plane and the workspace picker is shown. Integrators that already address a child tenant directly via custom domain or subdomain don't need to pass it.
 
 ## Tenant configuration
 
@@ -84,13 +97,12 @@ Enable on the tenant:
 {
   "flags": {
     "enable_dynamic_client_registration": true,
-    "dcr_allowed_integration_types": ["wordpress", "ghost", "drupal"],
     "allow_http_return_to": ["http://dev.publisher.test:8080"]
   }
 }
 ```
 
-If `dcr_allowed_integration_types` is empty/unset, `/connect/start` returns 404 — the consent flow is disabled for the tenant.
+`enable_dynamic_client_registration` is the only required flag. If it is unset, `/connect/start` returns 404 — the consent flow is disabled for the tenant.
 
 `allow_http_return_to` is a per-tenant allowlist of fully-qualified `http://` origins (scheme + host + port, no path) that may appear as `domain` / `return_to` despite not being loopback. Defaults to `[]`. Loopback origins (`localhost`, `127.0.0.1`, `[::1]`) are accepted regardless of this list.
 
@@ -101,9 +113,9 @@ When the user confirms, the issued IAT carries these constraints (enforced serve
 ```json
 {
   "domain": "publisher.com",
-  "integration_type": "wordpress",
+  "integration_type": "wordpress", // only if integration_type was supplied
   "grant_types": ["client_credentials"],
-  "scope": "..."          // only if scope was supplied
+  "scope": "..."                    // only if scope was supplied
 }
 ```
 

--- a/apps/docs/standards/connect-start.md
+++ b/apps/docs/standards/connect-start.md
@@ -136,7 +136,6 @@ If the registration request supplies any of those fields with a different value,
   1. The host is loopback — `localhost`, `127.0.0.1`, or `[::1]` (any port). Aligned with [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3).
   2. The exact origin (scheme + host + port) appears in the tenant's `allow_http_return_to` list.
 - `0.0.0.0` is always rejected (resolves differently across stacks). `localhost.<anything>` is rejected (suffixes are not pattern-matched). Trailing dots and case variations are normalized before comparison.
-- `integration_type` must appear in the per-tenant allowlist.
 - IAT is exposed as a query param on `return_to`. Single-use + 5-min TTL bound the exposure window. The receiving server should consume it immediately and not retain it.
 - When `domain` resolves to a loopback host or matches the tenant allowlist, the consent screen shows a "Local development" badge so users can spot a phishing attempt that claims a `localhost` callback they didn't initiate.
 - Cancel never mints a token.

--- a/apps/react-admin/src/components/resource-servers/edit.tsx
+++ b/apps/react-admin/src/components/resource-servers/edit.tsx
@@ -2,7 +2,8 @@ import {
   Edit,
   TextInput,
   BooleanInput,
-  TextField,
+  DateField,
+  Labeled,
   TabbedForm,
   required,
   NumberInput,
@@ -350,6 +351,17 @@ function ResourceServerForm() {
           />
         </Stack>
 
+        <Stack spacing={2} sx={{ mt: 2 }}>
+          <BooleanInput
+            source="metadata.sync"
+            label="Sync to child tenants"
+            helperText="When disabled, this resource server stays on the control plane and is not propagated to child tenants."
+            format={(value) => value !== false}
+            parse={(checked) => checked}
+            disabled={isSystem}
+          />
+        </Stack>
+
         <Stack spacing={2} direction="row" sx={{ mt: 2 }}>
           <TextInput
             source="signing_alg"
@@ -373,8 +385,12 @@ function ResourceServerForm() {
         </Stack>
 
         <Stack spacing={2} direction="row" sx={{ mt: 4 }}>
-          <TextField source="created_at" />
-          <TextField source="updated_at" />
+          <Labeled label="Created At">
+            <DateField source="created_at" showTime={true} />
+          </Labeled>
+          <Labeled label="Updated At">
+            <DateField source="updated_at" showTime={true} />
+          </Labeled>
         </Stack>
       </TabbedForm.Tab>
 

--- a/packages/adapter-interfaces/src/types/Tenant.ts
+++ b/packages/adapter-interfaces/src/types/Tenant.ts
@@ -66,10 +66,6 @@ export const tenantInsertSchema = z.object({
       // access tokens and a per-tenant grant-type allowlist.
       dcr_require_initial_access_token: z.boolean().optional(),
       dcr_allowed_grant_types: z.array(z.string()).optional(),
-      // Allowlist of `integration_type` values accepted by the
-      // `/connect/start` consent-mediated IAT flow. Empty/undefined disables
-      // the flow.
-      dcr_allowed_integration_types: z.array(z.string()).optional(),
       // Per-tenant allowlist of fully-qualified http origins (scheme + host
       // + port, no path) that may be used as `return_to` / `domain` on
       // `/connect/start` despite not being loopback. Off by default.

--- a/packages/authhero/src/routes/auth-api/connect-start.ts
+++ b/packages/authhero/src/routes/auth-api/connect-start.ts
@@ -7,8 +7,9 @@ import { validateConnectOrigin } from "../../helpers/dcr/validate-connect-origin
 const UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS = 60 * 30; // 30 min
 
 const connectStartQuerySchema = z.object({
-  integration_type: z.string().min(1).openapi({
-    description: "Caller-defined integration identifier; allowlisted per tenant",
+  integration_type: z.string().min(1).optional().openapi({
+    description:
+      "Optional caller-defined integration label. Surfaced on the consent screen and stored on the resulting client's IAT constraints. No validation beyond non-empty string.",
   }),
   domain: z.string().min(1).openapi({
     description: "The domain that will host the integration (origin must match return_to)",
@@ -68,20 +69,6 @@ export const connectStartRoutes = new OpenAPIHono<{
 
     const { integration_type, domain, return_to, state, scope } =
       ctx.req.valid("query");
-
-    const allowedTypes = tenant.flags?.dcr_allowed_integration_types;
-    if (!allowedTypes || allowedTypes.length === 0) {
-      throw new JSONHTTPException(404, {
-        error: "invalid_request",
-        error_description: "Connect flow is not enabled for this tenant",
-      });
-    }
-    if (!allowedTypes.includes(integration_type)) {
-      throw new JSONHTTPException(400, {
-        error: "invalid_request",
-        error_description: `integration_type "${integration_type}" is not allowed`,
-      });
-    }
 
     const allowHttp = tenant.flags?.allow_http_return_to ?? [];
     // `domain` accepts either a bare host[:port] (legacy, implicit https) or a

--- a/packages/authhero/src/routes/universal-login/screens/connect-consent.ts
+++ b/packages/authhero/src/routes/universal-login/screens/connect-consent.ts
@@ -21,7 +21,7 @@ import { logMessage } from "../../../helpers/logging";
 import { LogTypes } from "@authhero/adapter-interfaces";
 
 interface ConnectConsentData {
-  integration_type: string;
+  integration_type?: string;
   domain: string;
   return_to: string;
   scope?: string;
@@ -56,7 +56,8 @@ function readConnectData(stateDataJson?: string): ConnectConsentData | null {
     if (
       c &&
       typeof c === "object" &&
-      typeof c.integration_type === "string" &&
+      (c.integration_type === undefined ||
+        typeof c.integration_type === "string") &&
       typeof c.domain === "string" &&
       typeof c.return_to === "string" &&
       typeof c.caller_state === "string"
@@ -190,7 +191,7 @@ export async function connectConsentScreen(
       config: {
         content: `
           <div style="display:flex;flex-direction:column;gap:12px;padding:16px;border:1px solid #e5e7eb;border-radius:8px;background:#f9fafb">
-            <div style="font-size:14px;color:#6b7280">${escapeHtml(connect.integration_type)}</div>
+            ${connect.integration_type ? `<div style="font-size:14px;color:#6b7280">${escapeHtml(connect.integration_type)}</div>` : ""}
             <div style="font-size:18px;font-weight:600;color:#111827">${escapeHtml(connect.domain)}${localDevBadge}</div>
             <div style="font-size:14px;color:#374151">wants to connect to your ${escapeHtml(tenant.friendly_name)} account as <span style="font-weight:500">${escapeHtml(user.email || user.name || user.user_id)}</span>.</div>
             ${workspaceLine}
@@ -322,9 +323,11 @@ async function handleConnectConsentSubmit(
   // Mint an IAT bound to the consenting user.
   const constraints: Record<string, unknown> = {
     domain: connect.domain,
-    integration_type: connect.integration_type,
     grant_types: ["client_credentials"],
   };
+  if (connect.integration_type) {
+    constraints.integration_type = connect.integration_type;
+  }
   if (connect.scope) {
     constraints.scope = connect.scope;
   }

--- a/packages/authhero/src/routes/universal-login/screens/connect-tenant-select.ts
+++ b/packages/authhero/src/routes/universal-login/screens/connect-tenant-select.ts
@@ -22,7 +22,7 @@ import { escapeHtml } from "../sanitization-utils";
 import { fetchAll } from "../../../utils/fetchAll";
 
 interface ConnectConsentData {
-  integration_type: string;
+  integration_type?: string;
   domain: string;
   return_to: string;
   scope?: string;
@@ -44,7 +44,8 @@ function readConnectData(stateDataJson?: string): ConnectConsentData | null {
     if (
       c &&
       typeof c === "object" &&
-      typeof c.integration_type === "string" &&
+      (c.integration_type === undefined ||
+        typeof c.integration_type === "string") &&
       typeof c.domain === "string" &&
       typeof c.return_to === "string" &&
       typeof c.caller_state === "string"

--- a/packages/authhero/test/routes/auth-api/connect-start.spec.ts
+++ b/packages/authhero/test/routes/auth-api/connect-start.spec.ts
@@ -3,15 +3,11 @@ import { getTestServer } from "../../helpers/test-server";
 import { hashRegistrationToken } from "../../../src/helpers/dcr/mint-token";
 import type { Bindings } from "../../../src/types";
 
-async function enableConnectFlow(
-  env: Bindings,
-  integration_types: string[] = ["wordpress"],
-) {
+async function enableConnectFlow(env: Bindings) {
   await env.data.tenants.update("tenantId", {
     flags: {
       enable_dynamic_client_registration: true,
       dcr_require_initial_access_token: true,
-      dcr_allowed_integration_types: integration_types,
     },
   });
 }
@@ -34,28 +30,28 @@ describe("GET /connect/start", () => {
     expect(response.status).toBe(404);
   });
 
-  it("returns 404 when no integration types are allowlisted", async () => {
+  it("accepts request without integration_type (optional)", async () => {
     const { oauthApp, env } = await getTestServer();
-    await env.data.tenants.update("tenantId", {
-      flags: { enable_dynamic_client_registration: true },
-    });
+    await enableConnectFlow(env);
+    const qs = new URLSearchParams({
+      domain: "publisher.com",
+      return_to: "https://publisher.com/wp-admin/connect-callback",
+      state: "csrf-abc",
+    }).toString();
     const response = await oauthApp.request(
-      `/connect/start?${VALID_QS}`,
+      `/connect/start?${qs}`,
       { method: "GET", headers: { "tenant-id": "tenantId" } },
       env,
     );
-    expect(response.status).toBe(404);
-  });
-
-  it("rejects integration_type not in tenant allowlist", async () => {
-    const { oauthApp, env } = await getTestServer();
-    await enableConnectFlow(env, ["ghost"]);
-    const response = await oauthApp.request(
-      `/connect/start?${VALID_QS}`,
-      { method: "GET", headers: { "tenant-id": "tenantId" } },
-      env,
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    const stateId = new URL(location!, "http://localhost").searchParams.get(
+      "state",
     );
-    expect(response.status).toBe(400);
+    const session = await env.data.loginSessions.get("tenantId", stateId!);
+    const data = JSON.parse(session!.state_data!);
+    expect(data.connect.integration_type).toBeUndefined();
+    expect(data.connect.domain).toBe("publisher.com");
   });
 
   it("rejects when return_to origin doesn't match domain", async () => {
@@ -125,7 +121,6 @@ describe("GET /connect/start", () => {
     await env.data.tenants.update("tenantId", {
       flags: {
         enable_dynamic_client_registration: true,
-        dcr_allowed_integration_types: ["wordpress"],
         allow_http_return_to: ["http://dev.example.test:3000"],
       },
     });
@@ -190,7 +185,6 @@ describe("GET /connect/start", () => {
     await env.data.tenants.update("tenantId", {
       flags: {
         enable_dynamic_client_registration: true,
-        dcr_allowed_integration_types: ["wordpress"],
         allow_http_return_to: ["http://0.0.0.0:8888"],
       },
     });

--- a/packages/authhero/test/routes/universal-login/connect-consent.spec.ts
+++ b/packages/authhero/test/routes/universal-login/connect-consent.spec.ts
@@ -21,7 +21,6 @@ async function enableConnectFlow(env: Bindings) {
     flags: {
       enable_dynamic_client_registration: true,
       dcr_require_initial_access_token: true,
-      dcr_allowed_integration_types: ["wordpress"],
     },
   });
 }
@@ -356,7 +355,6 @@ describe("/u2/connect/start — control-plane mode (multi-tenancy)", () => {
       flags: {
         enable_dynamic_client_registration: true,
         dcr_require_initial_access_token: true,
-        dcr_allowed_integration_types: ["wordpress"],
       },
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sync toggle on resource server settings to control mirroring to child tenants; system entities remain protected.

* **Documentation**
  * Added docs for opting entities out of sync, tenant resolution order (including subdomain behavior), tenant-picker guidance, and updated /connect/start guidance.

* **Behavior Changes**
  * /connect/start now treats integration_type as optional and no longer enforces a per-tenant allowlist; existing integration_type values are still accepted.

* **Chores**
  * Release metadata, packaging updates, gitignore and submodule bookkeeping, and test adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->