### PR TITLE
Inherit account-linking template from control plane

### DIFF
--- a/.changeset/inherit-control-plane-templates.md
+++ b/.changeset/inherit-control-plane-templates.md
@@ -1,0 +1,16 @@
+---
+"@authhero/adapter-interfaces": patch
+"authhero": patch
+"@authhero/multi-tenancy": patch
+"@authhero/kysely-adapter": patch
+"@authhero/drizzle": patch
+---
+
+Hook metadata bag + control-plane template inheritance.
+
+Adds a free-form `metadata: Record<string, unknown>` field to all hook variants (web, form, template, code), persisted as JSON in kysely + drizzle. Two well-known keys are defined:
+
+- `metadata.inheritable: true` — when set on a hook on the control-plane tenant, the multi-tenancy runtime fallback surfaces that hook on every sub-tenant's `hooks.list` and `hooks.get`. Inherited hooks are read-only from the sub-tenant's perspective: writes go through the base adapter's `tenant_id` WHERE clause and are silent no-ops on cross-tenant rows.
+- Template options. The dispatcher forwards `hook.metadata` to the template function. The `account-linking` template reads `metadata.copy_user_metadata: true` to merge the secondary user's `user_metadata` into the primary's on link (primary wins on key conflicts; `app_metadata` is never copied).
+
+Includes the kysely migration `2026-04-29T10:00:00_hooks_metadata` adding the `metadata` column.

--- a/apps/docs/auth0-comparison/account-linking.md
+++ b/apps/docs/auth0-comparison/account-linking.md
@@ -224,7 +224,23 @@ await data.hooks.create(tenantId, {
 });
 ```
 
-The `metadata` field is a generic property bag on every hook variant. It also reserves `inheritable: true` for the upcoming multi-tenancy sync — control-plane hooks marked inheritable will surface to sub-tenants once that work lands.
+The `metadata` field is a generic property bag on every hook variant.
+
+#### Inheriting templates from the control plane
+
+In a multi-tenant deployment using `@authhero/multi-tenancy`, a single hook on the control-plane tenant can be surfaced to every sub-tenant by setting `metadata.inheritable: true`. The runtime fallback in `withRuntimeFallback` merges those rows into each sub-tenant's `hooks.list` and `hooks.get` results. Inherited hooks are read-only from a sub-tenant's perspective — `hooks.update` / `hooks.remove` calls scoped to the sub-tenant's `tenant_id` cannot touch a row owned by the control plane.
+
+```typescript
+// On the control-plane tenant — applies to every sub-tenant.
+await data.hooks.create(controlPlaneTenantId, {
+  trigger_id: "post-user-registration",
+  template_id: "account-linking",
+  enabled: true,
+  metadata: { inheritable: true, copy_user_metadata: true },
+});
+```
+
+A sub-tenant can still create its own hook for the same trigger; both run.
 
 #### When to use the template vs. the built-in
 

--- a/apps/docs/auth0-comparison/account-linking.md
+++ b/apps/docs/auth0-comparison/account-linking.md
@@ -205,8 +205,26 @@ preDefinedHooks.accountLinking({
   // default: true. Disabling is almost never what you want — it enables
   // account takeover via unverified email on an untrusted connection.
   requireVerifiedEmail: true,
+
+  // default: false. When true, merges the secondary user's user_metadata
+  // into the primary's on link. Existing keys on the primary are NOT
+  // overwritten (primary wins on conflict). app_metadata is never copied.
+  copyUserMetadata: false,
 });
 ```
+
+When the template is enabled per-tenant via `data.hooks.create`, options are read from the hook's `metadata` field:
+
+```typescript
+await data.hooks.create(tenantId, {
+  trigger_id: "post-user-registration",
+  template_id: "account-linking",
+  enabled: true,
+  metadata: { copy_user_metadata: true },
+});
+```
+
+The `metadata` field is a generic property bag on every hook variant. It also reserves `inheritable: true` for the upcoming multi-tenancy sync — control-plane hooks marked inheritable will surface to sub-tenants once that work lands.
 
 #### When to use the template vs. the built-in
 

--- a/apps/docs/features/user-creation-flow.md
+++ b/apps/docs/features/user-creation-flow.md
@@ -90,8 +90,8 @@ Once the pre-registration hook passes, the actual user creation begins through `
 4. Invokes `onExecutePreUserRegistration` (programmatic hook)
 5. Resolves the effective `userLinkingMode` (per-client → service-level)
 6. Commits the user via `commitUserHook` — when the resolved mode allows it, the email→primary lookup runs inside the same transaction; otherwise the lookup is skipped and only the row is committed
-7. Dispatches enabled `post-user-registration` template hooks (e.g. `account-linking`)
-8. Invokes `onExecutePostUserRegistration` (programmatic hook)
+7. Invokes `onExecutePostUserRegistration` (programmatic hook)
+8. Dispatches enabled `post-user-registration` template hooks (e.g. `account-linking`)
 9. Invokes post-user-registration webhooks
 
 ## Complete Hook Execution Order

--- a/packages/adapter-interfaces/src/types/Hook.ts
+++ b/packages/adapter-interfaces/src/types/Hook.ts
@@ -88,6 +88,18 @@ const hookBaseCommonProperties = {
   synchronous: z.boolean().default(false),
   priority: z.number().optional(),
   hook_id: z.string().optional(),
+  /**
+   * Free-form key/value bag for hook properties. Two well-known keys:
+   *
+   * - `inheritable: true` — when set on a hook on the control-plane tenant,
+   *   the multi-tenancy sync surfaces this hook to sub-tenants (Phase 2).
+   * - Template-specific options. Templates read their config here, e.g.
+   *   `account-linking` reads `copy_user_metadata: true` to merge secondary
+   *   user_metadata into the primary on link.
+   *
+   * Everything else is opaque to the runtime. Persisted as JSON.
+   */
+  metadata: z.record(z.unknown()).optional(),
 };
 
 const webHookInsertSchema = z.object({

--- a/packages/authhero/src/hooks/post-user-login.ts
+++ b/packages/authhero/src/hooks/post-user-login.ts
@@ -377,7 +377,12 @@ export async function postUserLoginHook(
   for (const hook of templateHooks) {
     if (!isTemplateHook(hook)) continue;
     try {
-      user = await handleTemplateHook(ctx, hook.template_id, user);
+      user = await handleTemplateHook(
+        ctx,
+        hook.template_id,
+        user,
+        hook.metadata,
+      );
     } catch (err) {
       logMessage(ctx, tenant_id, {
         type: LogTypes.FAILED_HOOK,

--- a/packages/authhero/src/hooks/pre-defined/account-linking.ts
+++ b/packages/authhero/src/hooks/pre-defined/account-linking.ts
@@ -1,6 +1,29 @@
 import { HookEvent, OnExecutePostLogin } from "../../types/Hooks";
 import { getPrimaryUserByEmail } from "../../helpers/users";
 
+/**
+ * Coerce a possibly-serialised `user_metadata` blob into a plain record.
+ * Some kysely-adapter code paths return the field still JSON-encoded;
+ * normalising at read time keeps the merge logic agnostic to that quirk.
+ */
+function parseMetadata(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
 export interface AccountLinkingOptions {
   /**
    * Require `email_verified` on the logged-in user before attempting to link.
@@ -10,6 +33,19 @@ export interface AccountLinkingOptions {
    * @default true
    */
   requireVerifiedEmail?: boolean;
+
+  /**
+   * When the link is performed, merge the secondary user's `user_metadata`
+   * into the primary's. Existing keys on the primary are NOT overwritten —
+   * only keys absent from the primary are filled in from the secondary, so
+   * the primary remains the source of truth for any conflicting values.
+   *
+   * `app_metadata` is intentionally never copied to avoid auto-merging into
+   * the admin-only namespace.
+   *
+   * @default false
+   */
+  copyUserMetadata?: boolean;
 }
 
 /**
@@ -66,6 +102,7 @@ export function accountLinking(
   options?: AccountLinkingOptions,
 ): OnExecutePostLogin & AccountLinkingHandler {
   const requireVerifiedEmail = options?.requireVerifiedEmail ?? true;
+  const copyUserMetadata = options?.copyUserMetadata ?? false;
 
   const handler = async (event: HookEvent) => {
     const { ctx, user } = event;
@@ -98,6 +135,33 @@ export function accountLinking(
     await data.users.update(tenantId, user.user_id, {
       linked_to: primary.user_id,
     });
+
+    if (copyUserMetadata) {
+      // Some adapter `create` paths return user_metadata still serialised
+      // as JSON. Normalise both sides defensively so downstream spreads
+      // don't iterate string indexes.
+      const secondaryMetadata = parseMetadata(user.user_metadata);
+      const primaryMetadata = parseMetadata(primary.user_metadata);
+
+      if (secondaryMetadata && Object.keys(secondaryMetadata).length > 0) {
+        // Primary wins on conflict: merge secondary first, then overlay
+        // the primary's existing values so they stay authoritative.
+        const merged = {
+          ...secondaryMetadata,
+          ...primaryMetadata,
+        };
+        // Only write if the merge actually adds keys — a no-op update
+        // would still bump updated_at.
+        const changed = Object.keys(merged).some(
+          (k) => !(k in primaryMetadata) || primaryMetadata[k] !== merged[k],
+        );
+        if (changed) {
+          await data.users.update(tenantId, primary.user_id, {
+            user_metadata: merged,
+          });
+        }
+      }
+    }
   };
 
   // Cast to the dual signature so `init({ hooks: { onExecutePostLogin: ... } })`

--- a/packages/authhero/src/hooks/templatehooks.ts
+++ b/packages/authhero/src/hooks/templatehooks.ts
@@ -20,11 +20,16 @@ export function isTemplateHook(
  * Handles a template hook by executing the corresponding pre-defined hook function.
  * Template hooks map to code-level pre-defined hooks that can be enabled per-tenant
  * through the admin UI without requiring server configuration changes.
+ *
+ * `metadata` carries the configuring tenant's options for the template — see
+ * `hookBaseCommonProperties.metadata` in the adapter-interfaces Hook schema.
+ * Each template that takes options reads its keys from here.
  */
 export async function handleTemplateHook(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
   template_id: string,
   user: User,
+  metadata?: Record<string, unknown>,
 ): Promise<User> {
   const tenant_id = ctx.var.tenant_id || ctx.req.header("tenant-id");
   if (!tenant_id) {
@@ -61,7 +66,9 @@ export async function handleTemplateHook(
       return updatedUser || user;
     }
     case "account-linking": {
-      const hookFn = preDefinedHooks.accountLinking();
+      const hookFn = preDefinedHooks.accountLinking({
+        copyUserMetadata: metadata?.copy_user_metadata === true,
+      });
       await hookFn(
         {
           ctx,

--- a/packages/authhero/src/hooks/user-registration.ts
+++ b/packages/authhero/src/hooks/user-registration.ts
@@ -240,7 +240,12 @@ export function createUserHooks(
         for (const hook of postRegTemplateHooks) {
           if (!isTemplateHook(hook)) continue;
           try {
-            result = await handleTemplateHook(ctx, hook.template_id, result);
+            result = await handleTemplateHook(
+              ctx,
+              hook.template_id,
+              result,
+              hook.metadata,
+            );
           } catch (err) {
             logMessage(ctx, tenant_id, {
               type: LogTypes.FAILED_SIGNUP,

--- a/packages/authhero/src/hooks/user-update.ts
+++ b/packages/authhero/src/hooks/user-update.ts
@@ -178,7 +178,12 @@ export function createUserUpdateHooks(
           for (const hook of enabledTemplateHooks) {
             if (!isTemplateHook(hook)) continue;
             try {
-              cursor = await handleTemplateHook(ctx, hook.template_id, cursor);
+              cursor = await handleTemplateHook(
+                ctx,
+                hook.template_id,
+                cursor,
+                hook.metadata,
+              );
             } catch (err) {
               logMessage(ctx, tenant_id, {
                 type: LogTypes.ACTIONS_EXECUTION_FAILED,

--- a/packages/authhero/test/hooks/account-linking-modes.spec.ts
+++ b/packages/authhero/test/hooks/account-linking-modes.spec.ts
@@ -199,6 +199,83 @@ describe("account-linking template hook at post-user-registration", () => {
   });
 });
 
+describe("account-linking template hook with copy_user_metadata", () => {
+  it("merges secondary user_metadata into the primary on link, primary winning on conflict", async () => {
+    const { env } = await getTestServer();
+    env.userLinkingMode = "off";
+
+    // Seed the primary with some existing user_metadata.
+    await env.data.users.update("tenantId", "email|userId", {
+      user_metadata: { theme: "dark", referrer: "primary" } as any,
+    });
+
+    // Enable the template at post-user-registration with copy_user_metadata.
+    await env.data.hooks.create("tenantId", {
+      trigger_id: "post-user-registration",
+      template_id: "account-linking",
+      enabled: true,
+      metadata: { copy_user_metadata: true },
+    });
+
+    const ctx = mockCtx(env);
+    const dataWithHooks = addDataHooks(ctx, env.data);
+
+    const newId = `${USERNAME_PASSWORD_PROVIDER}|merge-meta`;
+    await dataWithHooks.users.create("tenantId", {
+      user_id: newId,
+      email: "foo@example.com",
+      email_verified: true,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      connection: Strategy.USERNAME_PASSWORD,
+      is_social: false,
+      login_count: 0,
+      // Secondary brings a new key + a conflicting one.
+      user_metadata: { plan: "pro", referrer: "secondary" } as any,
+    });
+
+    const primary = await env.data.users.get("tenantId", "email|userId");
+    // Conflicting key kept primary's value, new key from secondary copied in.
+    expect(primary?.user_metadata).toEqual({
+      theme: "dark",
+      referrer: "primary",
+      plan: "pro",
+    });
+  });
+
+  it("does not copy user_metadata when copy_user_metadata is unset", async () => {
+    const { env } = await getTestServer();
+    env.userLinkingMode = "off";
+
+    await env.data.users.update("tenantId", "email|userId", {
+      user_metadata: { theme: "dark" } as any,
+    });
+
+    await env.data.hooks.create("tenantId", {
+      trigger_id: "post-user-registration",
+      template_id: "account-linking",
+      enabled: true,
+      // No metadata.copy_user_metadata
+    });
+
+    const ctx = mockCtx(env);
+    const dataWithHooks = addDataHooks(ctx, env.data);
+
+    await dataWithHooks.users.create("tenantId", {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|no-merge`,
+      email: "foo@example.com",
+      email_verified: true,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      connection: Strategy.USERNAME_PASSWORD,
+      is_social: false,
+      login_count: 0,
+      user_metadata: { plan: "pro" } as any,
+    });
+
+    const primary = await env.data.users.get("tenantId", "email|userId");
+    expect(primary?.user_metadata).toEqual({ theme: "dark" });
+  });
+});
+
 describe("account-linking template hook at post-user-update", () => {
   it("links a user to an existing primary when their email becomes verified and the template is enabled", async () => {
     const { env } = await getTestServer();

--- a/packages/drizzle/src/adapters/hooks.ts
+++ b/packages/drizzle/src/adapters/hooks.ts
@@ -13,7 +13,7 @@ function generateHookId(): string {
 }
 
 function sqlToHook(row: any): Hook {
-  const { tenant_id: _, created_at_ts, updated_at_ts, ...rest } = row;
+  const { tenant_id: _, created_at_ts, updated_at_ts, metadata, ...rest } = row;
 
   const dates = convertDatesToAdapter({ created_at_ts, updated_at_ts }, [
     "created_at_ts",
@@ -24,6 +24,7 @@ function sqlToHook(row: any): Hook {
     ...rest,
     enabled: !!rest.enabled,
     synchronous: !!rest.synchronous,
+    metadata: metadata ? JSON.parse(metadata) : undefined,
     ...dates,
   });
 }
@@ -45,6 +46,7 @@ export function createHooksAdapter(db: DrizzleDb) {
         form_id: hook.form_id,
         template_id: hook.template_id,
         code_id: hook.code_id,
+        metadata: hook.metadata ? JSON.stringify(hook.metadata) : null,
         created_at_ts: now,
         updated_at_ts: now,
       };
@@ -85,6 +87,9 @@ export function createHooksAdapter(db: DrizzleDb) {
       if (params.template_id !== undefined)
         updateData.template_id = params.template_id;
       if (params.code_id !== undefined) updateData.code_id = params.code_id;
+      if (params.metadata !== undefined)
+        updateData.metadata =
+          params.metadata === null ? null : JSON.stringify(params.metadata);
 
       const results = await db
         .update(hooks)

--- a/packages/drizzle/src/schema/sqlite/branding.ts
+++ b/packages/drizzle/src/schema/sqlite/branding.ts
@@ -256,6 +256,7 @@ export const hooks = sqliteTable(
     form_id: text("form_id", { length: 128 }), // only required for form type hooks
     template_id: text("template_id", { length: 64 }), // only required for template type hooks
     code_id: text("code_id", { length: 21 }), // only required for code type hooks
+    metadata: text("metadata"), // JSON property bag (inheritable flag, template options)
   },
   (table) => [index("hooks_tenant_id_idx").on(table.tenant_id)],
 );

--- a/packages/kysely/migrate/migrations/2026-04-29T10:00:00_hooks_metadata.ts
+++ b/packages/kysely/migrate/migrations/2026-04-29T10:00:00_hooks_metadata.ts
@@ -1,0 +1,19 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/db";
+
+/**
+ * Adds `metadata` to `hooks` — a JSON-serialised property bag with two
+ * well-known keys:
+ *
+ *   - `inheritable: true` — control-plane sync surfaces the hook to sub-tenants
+ *   - template options, e.g. `copy_user_metadata: true` for `account-linking`
+ *
+ * Everything else is opaque.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("hooks").addColumn("metadata", "text").execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("hooks").dropColumn("metadata").execute();
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -152,6 +152,7 @@ import * as o053_refresh_tokens_revoked_at from "./2026-04-22T10:00:00_refresh_t
 import * as o054_client_registration_tokens from "./2026-04-24T10:00:00_client_registration_tokens";
 import * as o055_planetscale_redundant_indexes_cleanup from "./2026-04-24T10:00:00_planetscale_redundant_indexes_cleanup";
 import * as o056_client_user_linking_mode from "./2026-04-28T10:00:00_client_user_linking_mode";
+import * as o057_hooks_metadata from "./2026-04-29T10:00:00_hooks_metadata";
 
 // These need to be in alphabetic order
 export default {
@@ -309,4 +310,5 @@ export default {
   o054_client_registration_tokens,
   o055_planetscale_redundant_indexes_cleanup,
   o056_client_user_linking_mode,
+  o057_hooks_metadata,
 };

--- a/packages/kysely/src/db.ts
+++ b/packages/kysely/src/db.ts
@@ -132,6 +132,7 @@ const sqlHookSchema = z.object({
   form_id: z.string().optional().nullable(),
   template_id: z.string().optional().nullable(),
   code_id: z.string().optional().nullable(),
+  metadata: z.string().optional().nullable(),
 });
 
 export const sqlActionSchema = z.object({

--- a/packages/kysely/src/hooks/create.ts
+++ b/packages/kysely/src/hooks/create.ts
@@ -8,7 +8,7 @@ export function create(db: Kysely<Database>) {
     const now = Date.now();
     const hookId = hook.hook_id || generateHookId();
 
-    const { hook_id: _hookId, enabled, synchronous, ...rest } = hook;
+    const { hook_id: _hookId, enabled, synchronous, metadata, ...rest } = hook;
 
     await db
       .insertInto("hooks")
@@ -18,6 +18,7 @@ export function create(db: Kysely<Database>) {
         tenant_id,
         enabled: enabled ? 1 : 0,
         synchronous: synchronous ? 1 : 0,
+        metadata: metadata ? JSON.stringify(metadata) : null,
         created_at_ts: now,
         updated_at_ts: now,
       })
@@ -28,6 +29,7 @@ export function create(db: Kysely<Database>) {
       hook_id: hookId,
       enabled: enabled ?? false,
       synchronous: synchronous ?? false,
+      ...(metadata ? { metadata } : {}),
       created_at: new Date(now).toISOString(),
       updated_at: new Date(now).toISOString(),
     };

--- a/packages/kysely/src/hooks/get.ts
+++ b/packages/kysely/src/hooks/get.ts
@@ -21,6 +21,7 @@ export function get(db: Kysely<Database>) {
       tenant_id: _tenantId,
       created_at_ts,
       updated_at_ts,
+      metadata,
       ...rest
     } = hook;
 
@@ -34,6 +35,7 @@ export function get(db: Kysely<Database>) {
       ...dates,
       enabled: !!rest.enabled,
       synchronous: !!rest.synchronous,
+      metadata: metadata ? JSON.parse(metadata) : undefined,
     });
   };
 }

--- a/packages/kysely/src/hooks/list.ts
+++ b/packages/kysely/src/hooks/list.ts
@@ -35,6 +35,7 @@ export function list(db: Kysely<Database>) {
         synchronous,
         created_at_ts,
         updated_at_ts,
+        metadata,
         ...rest
       } = hook;
 
@@ -48,6 +49,7 @@ export function list(db: Kysely<Database>) {
         ...dates,
         enabled: !!enabled,
         synchronous: !!synchronous,
+        metadata: metadata ? JSON.parse(metadata) : undefined,
       });
     });
 

--- a/packages/kysely/src/hooks/update.ts
+++ b/packages/kysely/src/hooks/update.ts
@@ -8,7 +8,7 @@ export function update(db: Kysely<Database>) {
     hook_id: string,
     hook: Partial<HookInsert>,
   ): Promise<boolean> => {
-    const { hook_id: _hookId, ...rest } = hook;
+    const { hook_id: _hookId, metadata, ...rest } = hook;
 
     const sqlHook = {
       ...rest,
@@ -16,6 +16,9 @@ export function update(db: Kysely<Database>) {
       enabled: hook.enabled !== undefined ? (hook.enabled ? 1 : 0) : undefined,
       synchronous:
         hook.synchronous !== undefined ? (hook.synchronous ? 1 : 0) : undefined,
+      ...(metadata !== undefined
+        ? { metadata: metadata === null ? null : JSON.stringify(metadata) }
+        : {}),
     };
 
     await db

--- a/packages/multi-tenancy/src/middleware/settings-inheritance.ts
+++ b/packages/multi-tenancy/src/middleware/settings-inheritance.ts
@@ -495,9 +495,100 @@ export function createRuntimeFallbackAdapter(
       controlPlaneTenantId,
     ),
 
+    hooks: wrapHooksWithInheritance(baseAdapters, controlPlaneTenantId),
+
     // Note: Additional adapters can be extended here for runtime fallback:
     // - promptSettings: Fall back to control plane prompts
     // - branding: Fall back to control plane branding/themes
+  };
+}
+
+/**
+ * Returns true when a hook is marked as inheritable by the control plane.
+ * Inheritable hooks surface on every sub-tenant's `hooks.list` so a single
+ * control-plane row drives behaviour fleet-wide. Reads `metadata.inheritable`
+ * on any hook variant (web/form/template/code).
+ */
+function isInheritableHook(hook: unknown): boolean {
+  if (!hook || typeof hook !== "object") return false;
+  const metadata = (hook as { metadata?: unknown }).metadata;
+  if (!metadata || typeof metadata !== "object") return false;
+  return (metadata as Record<string, unknown>).inheritable === true;
+}
+
+/**
+ * Wraps the hooks adapter so child tenants see hooks the control plane
+ * marked as inheritable (`metadata.inheritable === true`) merged into their
+ * own list/get results. Inherited hooks are read-only from a sub-tenant's
+ * perspective: writes go through the base adapter's `tenant_id` clause and
+ * therefore can't touch a row owned by the control plane.
+ *
+ * Filter (`q`) and pagination params are applied to each side independently
+ * by the base adapter, then concatenated. For the `q` shapes the runtime
+ * uses (`trigger_id:foo`) this gives correct results because both sides
+ * filter consistently. The combined `length` for `include_totals: true`
+ * is the sum of both sides.
+ */
+function wrapHooksWithInheritance(
+  baseAdapters: DataAdapters,
+  controlPlaneTenantId?: string,
+): DataAdapters["hooks"] {
+  return {
+    ...baseAdapters.hooks,
+
+    list: async (tenantId: string, params?) => {
+      const result = await baseAdapters.hooks.list(tenantId, params);
+
+      if (!controlPlaneTenantId || tenantId === controlPlaneTenantId) {
+        return result;
+      }
+
+      const controlPlaneResult = await baseAdapters.hooks.list(
+        controlPlaneTenantId,
+        params,
+      );
+
+      const inherited = (controlPlaneResult.hooks || []).filter(
+        isInheritableHook,
+      );
+
+      if (inherited.length === 0) {
+        return result;
+      }
+
+      // Sub-tenant rows take precedence — if both sides somehow share the
+      // same hook_id (vanishingly unlikely with random ids) keep the local.
+      const localIds = new Set(
+        (result.hooks || []).map((h) => h.hook_id),
+      );
+      const additions = inherited.filter((h) => !localIds.has(h.hook_id));
+
+      return {
+        ...result,
+        hooks: [...(result.hooks || []), ...additions],
+        length:
+          typeof result.length === "number"
+            ? result.length + additions.length
+            : result.length,
+      };
+    },
+
+    get: async (tenantId: string, hookId: string) => {
+      const local = await baseAdapters.hooks.get(tenantId, hookId);
+      if (local) return local;
+
+      if (!controlPlaneTenantId || tenantId === controlPlaneTenantId) {
+        return local;
+      }
+
+      const controlPlaneHook = await baseAdapters.hooks.get(
+        controlPlaneTenantId,
+        hookId,
+      );
+      return controlPlaneHook && isInheritableHook(controlPlaneHook)
+        ? controlPlaneHook
+        : null;
+    },
   };
 }
 

--- a/packages/multi-tenancy/test/hook-inheritance.test.ts
+++ b/packages/multi-tenancy/test/hook-inheritance.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Kysely, SqliteDialect } from "kysely";
+import SQLite from "better-sqlite3";
+import createAdapters, {
+  Database,
+  migrateToLatest,
+} from "@authhero/kysely-adapter";
+import { withRuntimeFallback } from "../src/middleware/settings-inheritance";
+
+const controlPlaneTenantId = "control_plane";
+const subTenantId = "tenant-1";
+
+describe("Hook inheritance from control plane", () => {
+  let db: Kysely<Database>;
+  let baseAdapters: ReturnType<typeof createAdapters>;
+  let adapters: ReturnType<typeof createAdapters>;
+
+  beforeEach(async () => {
+    db = new Kysely<Database>({
+      dialect: new SqliteDialect({ database: new SQLite(":memory:") }),
+    });
+    await migrateToLatest(db, false);
+    baseAdapters = createAdapters(db);
+    adapters = withRuntimeFallback(baseAdapters, {
+      controlPlaneTenantId,
+    }) as typeof baseAdapters;
+
+    // Tenants need to exist for FK constraints.
+    await baseAdapters.tenants.create({
+      id: controlPlaneTenantId,
+      friendly_name: "Control Plane",
+    });
+    await baseAdapters.tenants.create({
+      id: subTenantId,
+      friendly_name: "Sub-tenant",
+    });
+  });
+
+  it("surfaces an inheritable control-plane hook on a sub-tenant's list", async () => {
+    await baseAdapters.hooks.create(controlPlaneTenantId, {
+      trigger_id: "post-user-login",
+      template_id: "account-linking",
+      enabled: true,
+      metadata: { inheritable: true },
+    });
+
+    const { hooks } = await adapters.hooks.list(subTenantId, {
+      q: "trigger_id:post-user-login",
+      page: 0,
+      per_page: 100,
+      include_totals: false,
+    });
+
+    expect(hooks).toHaveLength(1);
+    const inherited = hooks[0] as any;
+    expect(inherited.template_id).toBe("account-linking");
+    expect(inherited.metadata?.inheritable).toBe(true);
+  });
+
+  it("does NOT surface a non-inheritable control-plane hook", async () => {
+    await baseAdapters.hooks.create(controlPlaneTenantId, {
+      trigger_id: "post-user-login",
+      template_id: "account-linking",
+      enabled: true,
+      // metadata.inheritable not set
+    });
+
+    const { hooks } = await adapters.hooks.list(subTenantId, {
+      q: "trigger_id:post-user-login",
+      page: 0,
+      per_page: 100,
+      include_totals: false,
+    });
+
+    expect(hooks).toHaveLength(0);
+  });
+
+  it("merges sub-tenant own hooks with inherited ones", async () => {
+    // Sub-tenant has its own hook
+    await baseAdapters.hooks.create(subTenantId, {
+      trigger_id: "post-user-login",
+      template_id: "ensure-username",
+      enabled: true,
+    });
+    // Control plane publishes one inheritable
+    await baseAdapters.hooks.create(controlPlaneTenantId, {
+      trigger_id: "post-user-login",
+      template_id: "account-linking",
+      enabled: true,
+      metadata: { inheritable: true },
+    });
+
+    const { hooks } = await adapters.hooks.list(subTenantId, {
+      q: "trigger_id:post-user-login",
+      page: 0,
+      per_page: 100,
+      include_totals: false,
+    });
+
+    const templateIds = hooks
+      .map((h: any) => h.template_id)
+      .filter(Boolean)
+      .sort();
+    expect(templateIds).toEqual(["account-linking", "ensure-username"]);
+  });
+
+  it("the control plane itself does not see double entries (no self-merge)", async () => {
+    await baseAdapters.hooks.create(controlPlaneTenantId, {
+      trigger_id: "post-user-login",
+      template_id: "account-linking",
+      enabled: true,
+      metadata: { inheritable: true },
+    });
+
+    const { hooks } = await adapters.hooks.list(controlPlaneTenantId, {
+      q: "trigger_id:post-user-login",
+      page: 0,
+      per_page: 100,
+      include_totals: false,
+    });
+
+    expect(hooks).toHaveLength(1);
+  });
+
+  it("trigger_id filter applies to both sides", async () => {
+    // Inheritable on a different trigger
+    await baseAdapters.hooks.create(controlPlaneTenantId, {
+      trigger_id: "post-user-registration",
+      template_id: "account-linking",
+      enabled: true,
+      metadata: { inheritable: true },
+    });
+    // Inheritable on the trigger we're filtering for
+    await baseAdapters.hooks.create(controlPlaneTenantId, {
+      trigger_id: "post-user-login",
+      template_id: "account-linking",
+      enabled: true,
+      metadata: { inheritable: true },
+    });
+
+    const { hooks } = await adapters.hooks.list(subTenantId, {
+      q: "trigger_id:post-user-login",
+      page: 0,
+      per_page: 100,
+      include_totals: false,
+    });
+
+    expect(hooks).toHaveLength(1);
+    expect((hooks[0] as any).trigger_id).toBe("post-user-login");
+  });
+
+  it("get() falls through to the control plane for inheritable hooks", async () => {
+    const created = await baseAdapters.hooks.create(controlPlaneTenantId, {
+      trigger_id: "post-user-login",
+      template_id: "account-linking",
+      enabled: true,
+      metadata: { inheritable: true },
+    });
+
+    const fetched = await adapters.hooks.get(subTenantId, created.hook_id);
+    expect(fetched).not.toBeNull();
+    expect((fetched as any)?.template_id).toBe("account-linking");
+  });
+
+  it("get() does NOT fall through for non-inheritable hooks", async () => {
+    const created = await baseAdapters.hooks.create(controlPlaneTenantId, {
+      trigger_id: "post-user-login",
+      template_id: "account-linking",
+      enabled: true,
+    });
+
+    const fetched = await adapters.hooks.get(subTenantId, created.hook_id);
+    expect(fetched).toBeNull();
+  });
+
+  it("sub-tenant cannot update or delete an inherited hook", async () => {
+    const created = await baseAdapters.hooks.create(controlPlaneTenantId, {
+      trigger_id: "post-user-login",
+      template_id: "account-linking",
+      enabled: true,
+      metadata: { inheritable: true },
+    });
+
+    // The base adapter's WHERE tenant_id clause means cross-tenant writes
+    // are silent no-ops; the inherited hook stays untouched.
+    await adapters.hooks.update(subTenantId, created.hook_id, {
+      enabled: false,
+    });
+    await adapters.hooks.remove(subTenantId, created.hook_id);
+
+    const stillThere = await baseAdapters.hooks.get(
+      controlPlaneTenantId,
+      created.hook_id,
+    );
+    expect(stillThere?.enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Hook `metadata` bag** (re-applied — these commits were on the previous PR branch but didn't make it into the squash). Free-form `metadata: Record<string, unknown>` on every hook variant (web, form, template, code), persisted as JSON in kysely + drizzle. Two well-known keys are defined: `metadata.inheritable: true` (multi-tenancy) and template options like `metadata.copy_user_metadata: true` (passed to `account-linking`).
- **Control-plane hook inheritance**. `withRuntimeFallback` in the multi-tenancy package now wraps `hooks.list` and `hooks.get` so any control-plane hook with `metadata.inheritable === true` surfaces on every sub-tenant. Inherited hooks are read-only — sub-tenant write paths use the base adapter's `tenant_id` WHERE clause, so cross-tenant writes are silent no-ops.

A control plane authors a template hook once and every sub-tenant runs it without per-tenant management-API calls. Sub-tenants can still create their own hooks for the same trigger; both run.

## Notes

- Default behaviour is unchanged for non-multi-tenant deployments — `metadata.inheritable` is only consulted by the runtime fallback wrapper, not the base adapters.
- Includes the kysely migration `2026-04-29T10:00:00_hooks_metadata` (adds the `metadata` column) and the matching drizzle column.
- Trigger filter (`q: "trigger_id:..."`) is applied to both sides of the merge by the base adapter, so inheritance respects the same filtering as a sub-tenant's own list.

## Test plan

- [x] `pnpm multi-tenancy test` — 84 tests pass (76 prior + 8 new in `hook-inheritance.test.ts`)
- [x] `pnpm authhero test` (linking subset) — 9 tests pass for the metadata bag + `copy_user_metadata`
- [x] `pnpm kysely test` — 201 tests pass; new migration applies cleanly
- [ ] Manual smoke-test against a multi-tenant instance: create one inheritable `account-linking` hook on the control plane, observe linking happen on a sub-tenant signup

🤖 Generated with [Claude Code](https://claude.com/claude-code)