### PR TITLE
react-admin hook metadata UI + safe parsing

### DIFF
--- a/.changeset/safe-parse-hook-metadata.md
+++ b/.changeset/safe-parse-hook-metadata.md
@@ -1,0 +1,8 @@
+---
+"@authhero/kysely-adapter": patch
+"@authhero/drizzle": patch
+---
+
+Defensively parse the hook `metadata` JSON blob on read.
+
+Wraps `JSON.parse` in a try/catch in `hooks.get` and `hooks.list` (kysely + drizzle) and only accepts the result when it's a plain object. Malformed payloads, arrays, primitives, or legacy rows now collapse to `undefined` instead of throwing — a single corrupt row no longer breaks hook retrieval for the whole tenant. Adds a shared `parseJsonObjectIfDefined` helper next to `parseJsonIfDefined` in the kysely adapter.

--- a/apps/react-admin/src/components/hooks/create.tsx
+++ b/apps/react-admin/src/components/hooks/create.tsx
@@ -221,6 +221,22 @@ export function HooksCreate() {
             return Number.isNaN(num) ? undefined : num;
           }}
         />
+        <BooleanInput
+          source="metadata.inheritable"
+          label="Publish to sub-tenants"
+          helperText="When enabled on a control-plane tenant, surfaces this hook on every sub-tenant via the multi-tenancy runtime fallback. Sub-tenants see it as read-only."
+        />
+        <FormDataConsumer>
+          {({ formData }) =>
+            formData?.template_id === "account-linking" ? (
+              <BooleanInput
+                source="metadata.copy_user_metadata"
+                label="Copy user metadata to primary on link"
+                helperText="When the secondary user is linked, merge its user_metadata into the primary's. Primary wins on key conflicts; app_metadata is never copied."
+              />
+            ) : null
+          }
+        </FormDataConsumer>
       </SimpleForm>
     </Create>
   );

--- a/apps/react-admin/src/components/hooks/edit.tsx
+++ b/apps/react-admin/src/components/hooks/edit.tsx
@@ -193,6 +193,22 @@ export function HookEdit() {
             return Number.isNaN(num) ? undefined : num;
           }}
         />
+        <BooleanInput
+          source="metadata.inheritable"
+          label="Publish to sub-tenants"
+          helperText="When enabled on a control-plane tenant, surfaces this hook on every sub-tenant via the multi-tenancy runtime fallback. Sub-tenants see it as read-only."
+        />
+        <FormDataConsumer>
+          {({ formData }) =>
+            formData?.template_id === "account-linking" ? (
+              <BooleanInput
+                source="metadata.copy_user_metadata"
+                label="Copy user metadata to primary on link"
+                helperText="When the secondary user is linked, merge its user_metadata into the primary's. Primary wins on key conflicts; app_metadata is never copied."
+              />
+            ) : null
+          }
+        </FormDataConsumer>
         <Labeled label={<FieldTitle source="created_at" />}>
           <DateField source="created_at" showTime={true} />
         </Labeled>

--- a/apps/react-admin/src/components/hooks/list.tsx
+++ b/apps/react-admin/src/components/hooks/list.tsx
@@ -24,6 +24,12 @@ export function HookList() {
         <TextField source="trigger_id" />
         <BooleanField source="enabled" />
         <BooleanField source="synchronous" />
+        <FunctionField
+          label="Inheritable"
+          render={(record: any) =>
+            record?.metadata?.inheritable === true ? "✓" : ""
+          }
+        />
       </Datagrid>
     </List>
   );

--- a/packages/drizzle/src/adapters/hooks.ts
+++ b/packages/drizzle/src/adapters/hooks.ts
@@ -12,6 +12,25 @@ function generateHookId(): string {
   return `h_${generate()}`;
 }
 
+/**
+ * Parse a JSON metadata blob from the database. Returns the value only if
+ * it's a plain object — arrays, primitives, and parse errors all collapse
+ * to undefined so corruption or legacy rows don't crash hook retrieval.
+ */
+function parseMetadata(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (typeof value !== "string" || !value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function sqlToHook(row: any): Hook {
   const { tenant_id: _, created_at_ts, updated_at_ts, metadata, ...rest } = row;
 
@@ -24,7 +43,7 @@ function sqlToHook(row: any): Hook {
     ...rest,
     enabled: !!rest.enabled,
     synchronous: !!rest.synchronous,
-    metadata: metadata ? JSON.parse(metadata) : undefined,
+    metadata: parseMetadata(metadata),
     ...dates,
   });
 }

--- a/packages/kysely/src/helpers/parse.ts
+++ b/packages/kysely/src/helpers/parse.ts
@@ -17,6 +17,25 @@ export function parseJsonIfDefined<T>(
 }
 
 /**
+ * Parse a JSON metadata blob from the database. Returns the parsed value
+ * only if it's a plain object (rejects arrays, primitives, and parse errors)
+ * — those would be corruption or legacy rows we don't want to crash on.
+ */
+export function parseJsonObjectIfDefined(
+  value: string | null | undefined,
+): Record<string, unknown> | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Parse multiple JSON string properties of an object.
  * Properties that are undefined or null will use their default values.
  *

--- a/packages/kysely/src/hooks/get.ts
+++ b/packages/kysely/src/hooks/get.ts
@@ -1,5 +1,6 @@
 import { Kysely } from "kysely";
 import { removeNullProperties } from "../helpers/remove-nulls";
+import { parseJsonObjectIfDefined } from "../helpers/parse";
 import { Hook } from "@authhero/adapter-interfaces";
 import { Database } from "../db";
 import { convertDatesToAdapter } from "../utils/dateConversion";
@@ -35,7 +36,7 @@ export function get(db: Kysely<Database>) {
       ...dates,
       enabled: !!rest.enabled,
       synchronous: !!rest.synchronous,
-      metadata: metadata ? JSON.parse(metadata) : undefined,
+      metadata: parseJsonObjectIfDefined(metadata),
     });
   };
 }

--- a/packages/kysely/src/hooks/list.ts
+++ b/packages/kysely/src/hooks/list.ts
@@ -1,5 +1,6 @@
 import { Kysely } from "kysely";
 import { removeNullProperties } from "../helpers/remove-nulls";
+import { parseJsonObjectIfDefined } from "../helpers/parse";
 import { luceneFilter } from "../helpers/filter";
 import { ListHooksResponse, ListParams } from "@authhero/adapter-interfaces";
 import { Database } from "../db";
@@ -49,7 +50,7 @@ export function list(db: Kysely<Database>) {
         ...dates,
         enabled: !!enabled,
         synchronous: !!synchronous,
-        metadata: metadata ? JSON.parse(metadata) : undefined,
+        metadata: parseJsonObjectIfDefined(metadata),
       });
     });
 


### PR DESCRIPTION
## Summary

Two follow-ups to the merged inheritance work that didn't make it into PR #775:

- **react-admin UI surface for hook metadata** (cherry-picked from the closed PR #775 branch). Adds a "Publish to sub-tenants" toggle (`metadata.inheritable`), a "Copy user metadata to primary on link" toggle (`metadata.copy_user_metadata`, only shown when `template_id === "account-linking"`), and an "Inheritable" column on the hooks list view.
- **Safe metadata parsing** in the hook adapters (kysely + drizzle). `JSON.parse` is now wrapped in try/catch and the result is rejected unless it's a plain object — arrays, primitives, and malformed payloads collapse to `undefined` instead of throwing, so a single corrupt or legacy row no longer breaks `hooks.list` for an entire tenant. Adds a shared `parseJsonObjectIfDefined` helper in the kysely adapter; drizzle uses an equivalent local helper.

## Test plan

- [x] `pnpm kysely test` — adapter tests pass
- [x] `pnpm authhero test` (linking subset) — 9 tests still pass
- [x] `pnpm multi-tenancy test` — 84 tests still pass
- [ ] Manual smoke-test in react-admin: open a hook in edit mode, toggle "Publish to sub-tenants", save, confirm `metadata.inheritable` round-trips
- [ ] Manual: corrupt a hook's `metadata` column to `'not json'` directly in SQL and confirm `GET /api/v2/hooks` still returns the row with `metadata: undefined` rather than 500ing

🤖 Generated with [Claude Code](https://claude.com/claude-code)