### PR TITLE
feat: refresh-token rotation with at-rest hashing

### DIFF
--- a/.changeset/refresh-token-rotation.md
+++ b/.changeset/refresh-token-rotation.md
@@ -1,0 +1,15 @@
+---
+"@authhero/adapter-interfaces": minor
+"@authhero/kysely-adapter": minor
+"@authhero/drizzle": minor
+"@authhero/aws-adapter": minor
+"authhero": minor
+---
+
+Add Auth0-style refresh-token rotation and at-rest hashing.
+
+- New wire format `rt_<lookup>.<secret>`. The `lookup` slice is indexed in `refresh_tokens.token_lookup`; only the SHA-256 of the secret is persisted in `token_hash`. Internal ULID `id` stays as the primary key.
+- New per-client config in `Client.refresh_token`: `rotation_type: "rotating" | "non-rotating"` (default `non-rotating`) and `leeway` seconds (default 30). Set `rotation_type: "rotating"` to opt a client into rotation.
+- Each rotation issues a fresh child sharing `family_id` with the parent. Re-presenting a rotated parent within `leeway` mints a sibling (concurrent-call tolerance); outside `leeway` it triggers reuse detection and revokes the entire family via the new `revokeFamily` adapter method.
+- Admin `DELETE /api/v2/refresh_tokens/:id` now also revokes the rest of the family.
+- Backwards compatible: legacy id-only refresh tokens keep working until `2026-06-05`. After that date a follow-up PR removes the legacy fallback.

--- a/packages/adapter-interfaces/src/adapters/RefreshTokens.ts
+++ b/packages/adapter-interfaces/src/adapters/RefreshTokens.ts
@@ -23,6 +23,15 @@ export interface RefreshTokensAdapter {
     refresh_token: RefreshTokenInsert,
   ) => Promise<RefreshToken>;
   get: (tenant_id: string, id: string) => Promise<RefreshToken | null>;
+  /**
+   * Look up a refresh token by its plaintext `token_lookup` slice (extracted
+   * from the wire format `rt_<lookup>.<secret>`). Returns null if no row
+   * matches. Callers must verify the secret hash before trusting the row.
+   */
+  getByLookup: (
+    tenant_id: string,
+    token_lookup: string,
+  ) => Promise<RefreshToken | null>;
   list(
     tenant_id: string,
     params?: ListParams,
@@ -37,6 +46,16 @@ export interface RefreshTokensAdapter {
   revokeByLoginSession: (
     tenant_id: string,
     login_session_id: string,
+    revoked_at: string,
+  ) => Promise<number>;
+  /**
+   * Soft-revoke every refresh token that shares `family_id` and isn't already
+   * revoked. Used for reuse detection (entire rotation chain torched) and for
+   * admin revocations that should propagate to descendants.
+   */
+  revokeFamily: (
+    tenant_id: string,
+    family_id: string,
     revoked_at: string,
   ) => Promise<number>;
 }

--- a/packages/adapter-interfaces/src/types/Client.ts
+++ b/packages/adapter-interfaces/src/types/Client.ts
@@ -177,9 +177,31 @@ export const clientInsertSchema = z.object({
     description: "Initiate login uri, must be https",
   }),
   native_social_login: z.record(z.any()).default({}).optional(),
-  refresh_token: z.record(z.any()).default({}).optional().openapi({
-    description: "Refresh token configuration",
-  }),
+  refresh_token: z
+    .object({
+      rotation_type: z
+        .enum(["rotating", "non-rotating"])
+        .optional()
+        .openapi({
+          description:
+            "Whether refresh tokens for this client are rotated on every exchange (Auth0 'rotating' behavior) or kept stable (legacy non-rotating). Defaults to 'non-rotating' when unset.",
+        }),
+      leeway: z
+        .number()
+        .int()
+        .min(0)
+        .max(600)
+        .optional()
+        .openapi({
+          description:
+            "Seconds after a parent token's first rotation during which presenting it again still mints a fresh sibling child instead of triggering reuse-detection. Defaults to 30s when unset.",
+        }),
+    })
+    .default({})
+    .optional()
+    .openapi({
+      description: "Refresh token configuration",
+    }),
   default_organization: z.record(z.any()).default({}).optional().openapi({
     description: "Defines the default Organization ID and flows",
   }),

--- a/packages/adapter-interfaces/src/types/Client.ts
+++ b/packages/adapter-interfaces/src/types/Client.ts
@@ -196,6 +196,30 @@ export const clientInsertSchema = z.object({
           description:
             "Seconds after a parent token's first rotation during which presenting it again still mints a fresh sibling child instead of triggering reuse-detection. Defaults to 30s when unset.",
         }),
+      // Auth0-compatible fields. Listed explicitly (rather than using
+      // .passthrough()) so they survive parse cycles AND keep type info,
+      // without tripping dts-bundle-generator's handling of zod's
+      // `objectInputType`. Not yet honored by the engine — added so values
+      // round-trip cleanly when migrating tenants from Auth0.
+      expiration_type: z.enum(["expiring", "non-expiring"]).optional().openapi({
+        description: "Auth0-compatible: whether refresh tokens expire.",
+      }),
+      token_lifetime: z.number().int().min(0).optional().openapi({
+        description:
+          "Auth0-compatible: refresh-token absolute lifetime in seconds.",
+      }),
+      infinite_token_lifetime: z.boolean().optional().openapi({
+        description:
+          "Auth0-compatible: when true, refresh tokens have no absolute expiry.",
+      }),
+      idle_token_lifetime: z.number().int().min(0).optional().openapi({
+        description:
+          "Auth0-compatible: refresh-token idle (sliding) lifetime in seconds.",
+      }),
+      infinite_idle_token_lifetime: z.boolean().optional().openapi({
+        description:
+          "Auth0-compatible: when true, refresh tokens have no idle expiry.",
+      }),
     })
     .default({})
     .optional()

--- a/packages/adapter-interfaces/src/types/RefreshTokens.ts
+++ b/packages/adapter-interfaces/src/types/RefreshTokens.ts
@@ -2,7 +2,7 @@ import { z } from "@hono/zod-openapi";
 import { deviceSchema } from "./Device";
 
 export const refreshTokenInsertSchema = z.object({
-  // The actual refresh token value (primary key).
+  // Internal primary key (ULID). Never sent to clients in the new wire format.
   id: z.string(),
 
   // Link to the login session
@@ -29,6 +29,24 @@ export const refreshTokenInsertSchema = z.object({
   ),
 
   rotating: z.boolean(),
+
+  // Plaintext lookup slice extracted from the wire token. Indexed for the
+  // refresh-grant path. NULL on legacy (pre-hashing) rows.
+  token_lookup: z.string().optional(),
+
+  // SHA-256 hex of the secret part of the wire token. NULL on legacy rows.
+  token_hash: z.string().optional(),
+
+  // Root token id of the rotation chain. NULL on legacy rows; for the first
+  // token in a chain it equals `id`.
+  family_id: z.string().optional(),
+
+  // Most recently issued child id (debug/traceability). NULL until rotated.
+  rotated_to: z.string().optional(),
+
+  // ISO of the *first* rotation. Anchors the leeway window so siblings minted
+  // within the window don't extend the parent's exposure.
+  rotated_at: z.string().optional(),
 });
 
 export type RefreshTokenInsert = z.infer<typeof refreshTokenInsertSchema>;

--- a/packages/authhero/src/authentication-flows/authorization-code.ts
+++ b/packages/authhero/src/authentication-flows/authorization-code.ts
@@ -7,7 +7,6 @@ import { computeCodeChallenge } from "../utils/crypto";
 import { safeCompare } from "../utils/safe-compare";
 import {
   AuthorizationResponseMode,
-  RefreshToken,
   TokenResponse,
   LogTypes,
 } from "@authhero/adapter-interfaces";
@@ -225,19 +224,20 @@ export async function authorizationCodeGrantUser(
 
   await ctx.env.data.codes.used(client.tenant.id, params.code);
 
-  let refreshToken: RefreshToken | undefined;
+  let refreshTokenWire: string | undefined;
   if (
     loginSession.session_id &&
     loginSession.authParams.scope?.split(" ").includes("offline_access")
   ) {
     // If the offline_access scope is requested, we need to create a refresh token
-    refreshToken = await createRefreshToken(ctx, {
+    const created = await createRefreshToken(ctx, {
       user,
       client,
       login_id: loginSession.id,
       scope: loginSession.authParams.scope,
       audience: loginSession.authParams.audience,
     });
+    refreshTokenWire = created.wireToken;
   }
 
   // Fetch organization data if organization ID is provided in the login session
@@ -286,7 +286,7 @@ export async function authorizationCodeGrantUser(
     client,
     loginSession,
     session_id: loginSession.session_id,
-    refresh_token: refreshToken?.id,
+    refresh_token: refreshTokenWire,
     organization,
     auth_time,
     authParams: {

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -4,9 +4,15 @@ import {
   AuthParams,
   LoginSession,
   LoginSessionState,
+  RefreshToken,
   User,
   TokenResponse,
 } from "@authhero/adapter-interfaces";
+import {
+  formatRefreshToken,
+  generateRefreshTokenParts,
+  hashRefreshTokenSecret,
+} from "../utils/refresh-token-format";
 import { EnrichedClient } from "../helpers/client";
 import { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -496,6 +502,11 @@ export interface CreateRefreshTokenParams {
   audience?: string;
 }
 
+export interface CreatedRefreshToken {
+  row: RefreshToken;
+  wireToken: string;
+}
+
 function lifetimeToIso(lifetimeHours?: number): string | undefined {
   if (!lifetimeHours) return undefined;
   return new Date(Date.now() + lifetimeHours * 60 * 60 * 1000).toISOString();
@@ -504,7 +515,7 @@ function lifetimeToIso(lifetimeHours?: number): string | undefined {
 export async function createRefreshToken(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
   params: CreateRefreshTokenParams,
-) {
+): Promise<CreatedRefreshToken> {
   const { client, scope, login_id } = params;
   const audience = params.audience ?? client.tenant.default_audience;
 
@@ -519,35 +530,40 @@ export async function createRefreshToken(
   const idleExpiresAt = lifetimeToIso(client.tenant.idle_session_lifetime);
   const absoluteExpiresAt = lifetimeToIso(client.tenant.session_lifetime);
 
-  const refreshToken = await ctx.env.data.refreshTokens.create(
-    client.tenant.id,
-    {
-      id: ulid(),
-      login_id,
-      client_id: client.client_id,
-      idle_expires_at: idleExpiresAt,
-      expires_at: absoluteExpiresAt,
-      user_id: params.user.user_id,
-      device: {
-        last_ip: ctx.var.ip,
-        initial_ip: ctx.var.ip,
-        last_user_agent: ctx.var.useragent || "",
-        initial_user_agent: ctx.var.useragent || "",
-        // TODO: add Authentication Strength Name
-        initial_asn: "",
-        last_asn: "",
-      },
-      resource_servers: [
-        {
-          audience,
-          scopes: scope,
-        },
-      ],
-      rotating: false,
-    },
-  );
+  const id = ulid();
+  const { lookup, secret } = generateRefreshTokenParts();
+  const token_hash = await hashRefreshTokenSecret(secret);
+  const rotating = client.refresh_token?.rotation_type === "rotating";
 
-  return refreshToken;
+  const row = await ctx.env.data.refreshTokens.create(client.tenant.id, {
+    id,
+    login_id,
+    client_id: client.client_id,
+    idle_expires_at: idleExpiresAt,
+    expires_at: absoluteExpiresAt,
+    user_id: params.user.user_id,
+    device: {
+      last_ip: ctx.var.ip,
+      initial_ip: ctx.var.ip,
+      last_user_agent: ctx.var.useragent || "",
+      initial_user_agent: ctx.var.useragent || "",
+      // TODO: add Authentication Strength Name
+      initial_asn: "",
+      last_asn: "",
+    },
+    resource_servers: [
+      {
+        audience,
+        scopes: scope,
+      },
+    ],
+    rotating,
+    token_lookup: lookup,
+    token_hash,
+    family_id: id,
+  });
+
+  return { row, wireToken: formatRefreshToken(lookup, secret) };
 }
 
 export interface CreateSessionParams {
@@ -1616,7 +1632,7 @@ export async function createFrontChannelAuthResponse(
       scope: authParams.scope,
       audience: authParams.audience,
     });
-    refresh_token = newRefreshToken.id;
+    refresh_token = newRefreshToken.wireToken;
   }
 
   if (responseMode === AuthorizationResponseMode.SAML_POST) {

--- a/packages/authhero/src/authentication-flows/refresh-token.ts
+++ b/packages/authhero/src/authentication-flows/refresh-token.ts
@@ -4,12 +4,21 @@ import { Bindings, Variables, GrantFlowUserResult } from "../types";
 import {
   AuthorizationResponseMode,
   LogTypes,
+  RefreshToken,
 } from "@authhero/adapter-interfaces";
 import { z } from "@hono/zod-openapi";
 import { safeCompare } from "../utils/safe-compare";
 import { appendLog } from "../utils/append-log";
 import { getEnrichedClient } from "../helpers/client";
 import { logMessage } from "../helpers/logging";
+import {
+  formatRefreshToken,
+  generateRefreshTokenParts,
+  hashRefreshTokenSecret,
+  isLegacyRefreshTokenAccepted,
+  parseRefreshToken,
+} from "../utils/refresh-token-format";
+import { ulid } from "../utils/ulid";
 
 export const refreshTokenParamsSchema = z.object({
   grant_type: z.literal("refresh_token"),
@@ -47,17 +56,35 @@ export async function refreshTokenGrant(
     }
   }
 
-  const refreshToken = await ctx.env.data.refreshTokens.get(
-    client.tenant.id,
-    params.refresh_token,
-  );
-
   // Auth0 returns 403 for invalid_grant on the token endpoint; RFC 6749 §5.2
   // mandates 400. Gate on the client's auth0_conformant flag (default true).
   const invalidGrantStatus = client.auth0_conformant === false ? 400 : 403;
 
+  // Resolve the row from either the new `rt_<lookup>.<secret>` format or the
+  // legacy id-only format (back-compat window only).
+  const parsed = parseRefreshToken(params.refresh_token);
+  let refreshToken: RefreshToken | null = null;
+
+  if (parsed.kind === "new") {
+    const candidate = await ctx.env.data.refreshTokens.getByLookup(
+      client.tenant.id,
+      parsed.lookup,
+    );
+    if (candidate?.token_hash) {
+      const presentedHash = await hashRefreshTokenSecret(parsed.secret);
+      if (safeCompare(presentedHash, candidate.token_hash)) {
+        refreshToken = candidate;
+      }
+    }
+  } else if (isLegacyRefreshTokenAccepted()) {
+    refreshToken = await ctx.env.data.refreshTokens.get(
+      client.tenant.id,
+      parsed.id,
+    );
+  }
+
   if (!refreshToken) {
-    appendLog(ctx, `Invalid refresh token: ${params.refresh_token}`);
+    appendLog(ctx, "Invalid refresh token");
     logMessage(ctx, client.tenant.id, {
       type: LogTypes.FAILED_EXCHANGE_REFRESH_TOKEN_FOR_ACCESS_TOKEN,
       description: "Invalid refresh token",
@@ -97,7 +124,7 @@ export async function refreshTokenGrant(
     (refreshToken.idle_expires_at &&
       new Date(refreshToken.idle_expires_at) < new Date())
   ) {
-    appendLog(ctx, `Refresh token has expired: ${params.refresh_token}`);
+    appendLog(ctx, "Refresh token has expired");
     logMessage(ctx, client.tenant.id, {
       type: LogTypes.FAILED_EXCHANGE_REFRESH_TOKEN_FOR_ACCESS_TOKEN,
       description: "Refresh token has expired",
@@ -107,6 +134,35 @@ export async function refreshTokenGrant(
       error: "invalid_grant",
       error_description: "Refresh token has expired",
     });
+  }
+
+  // Reuse detection: if this row was previously rotated, decide whether the
+  // re-presentation falls inside the configured leeway window.
+  if (refreshToken.rotated_at) {
+    const leewaySeconds = client.refresh_token?.leeway ?? 30;
+    const rotatedAtMs = new Date(refreshToken.rotated_at).getTime();
+    if (Date.now() - rotatedAtMs > leewaySeconds * 1000) {
+      const familyId = refreshToken.family_id ?? refreshToken.id;
+      await ctx.env.data.refreshTokens.revokeFamily(
+        client.tenant.id,
+        familyId,
+        new Date().toISOString(),
+      );
+      appendLog(
+        ctx,
+        `Refresh token reuse detected; family ${familyId} revoked`,
+      );
+      logMessage(ctx, client.tenant.id, {
+        type: LogTypes.FAILED_EXCHANGE_REFRESH_TOKEN_FOR_ACCESS_TOKEN,
+        description: "Refresh token reuse detected; family revoked",
+        userId: refreshToken.user_id,
+      });
+      throw new JSONHTTPException(invalidGrantStatus, {
+        error: "invalid_grant",
+        error_description: "Refresh token has been revoked",
+      });
+    }
+    // within leeway: fall through and mint another sibling child
   }
 
   const tokenUser = await ctx.env.data.users.get(
@@ -234,22 +290,82 @@ export async function refreshTokenGrant(
     }
   }
 
-  // Update the idle_expires_at using tenant settings
-  if (refreshToken.idle_expires_at && client.tenant.idle_session_lifetime) {
+  // Token rotation decision: rotate if either the stored row says so or, for
+  // legacy rows that pre-date the rotating column being honored, the client
+  // is configured to rotate.
+  const clientRotates =
+    client.refresh_token?.rotation_type === "rotating";
+  const shouldRotate = refreshToken.rotating || clientRotates;
+
+  const nextLastIp = ctx.req.header("x-real-ip") || "";
+  const nextLastUa = ctx.req.header("user-agent") || "";
+  const deviceChanged =
+    nextLastIp !== refreshToken.device?.last_ip ||
+    nextLastUa !== refreshToken.device?.last_user_agent;
+
+  let outgoingWireToken: string | undefined = params.refresh_token;
+
+  if (shouldRotate) {
+    // Mint a fresh child row that inherits the parent's identity but gets a
+    // new (lookup, secret) pair, refreshed sliding idle window, and the same
+    // family id (anchored to the parent for legacy upgrades).
+    const childId = ulid();
+    const { lookup: childLookup, secret: childSecret } =
+      generateRefreshTokenParts();
+    const childHash = await hashRefreshTokenSecret(childSecret);
+    const familyId = refreshToken.family_id ?? refreshToken.id;
+
+    const newIdleExpiresAt =
+      refreshToken.idle_expires_at && client.tenant.idle_session_lifetime
+        ? new Date(
+            Date.now() + client.tenant.idle_session_lifetime * 60 * 60 * 1000,
+          ).toISOString()
+        : refreshToken.idle_expires_at;
+
+    await ctx.env.data.refreshTokens.create(client.tenant.id, {
+      id: childId,
+      login_id: refreshToken.login_id,
+      user_id: refreshToken.user_id,
+      client_id: refreshToken.client_id,
+      // Absolute expiry never extends across rotation — the family stays
+      // bounded by the original session_lifetime.
+      expires_at: refreshToken.expires_at,
+      idle_expires_at: newIdleExpiresAt,
+      device: {
+        ...refreshToken.device,
+        last_ip: nextLastIp,
+        last_user_agent: nextLastUa,
+      },
+      resource_servers: refreshToken.resource_servers,
+      rotating: true,
+      token_lookup: childLookup,
+      token_hash: childHash,
+      family_id: familyId,
+    });
+
+    // Anchor `rotated_at` to the *first* rotation so leeway-window siblings
+    // don't extend the parent's exposure. Always overwrite `rotated_to` to
+    // the most recent child for traceability.
+    await ctx.env.data.refreshTokens.update(
+      client.tenant.id,
+      refreshToken.id,
+      {
+        rotated_to: childId,
+        rotated_at: refreshToken.rotated_at ?? new Date().toISOString(),
+      },
+    );
+
+    outgoingWireToken = formatRefreshToken(childLookup, childSecret);
+  } else if (
+    refreshToken.idle_expires_at &&
+    client.tenant.idle_session_lifetime
+  ) {
+    // Non-rotating path: slide the parent's idle window forward and let the
+    // client keep using the same wire token they sent.
     const idleExpiresAt = new Date(
       Date.now() + client.tenant.idle_session_lifetime * 60 * 60 * 1000,
     );
 
-    const nextLastIp = ctx.req.header("x-real-ip") || "";
-    const nextLastUa = ctx.req.header("user-agent") || "";
-    const deviceChanged =
-      nextLastIp !== refreshToken.device?.last_ip ||
-      nextLastUa !== refreshToken.device?.last_user_agent;
-
-    // The adapter extends the parent login_session's expires_at in parallel
-    // when loginSessionBump is provided. newLoginSessionExpiry is the larger
-    // of the token's absolute expiry and the just-bumped idle expiry, since
-    // the session needs to outlive whichever is further out.
     const absoluteExpiryMs = refreshToken.expires_at
       ? new Date(refreshToken.expires_at).getTime()
       : 0;
@@ -286,7 +402,7 @@ export async function refreshTokenGrant(
   return {
     user,
     client,
-    refresh_token: refreshToken.id,
+    refresh_token: outgoingWireToken,
     session_id: sessionId,
     login_id: refreshToken.login_id,
     organization,

--- a/packages/authhero/src/authentication-flows/refresh-token.ts
+++ b/packages/authhero/src/authentication-flows/refresh-token.ts
@@ -345,13 +345,18 @@ export async function refreshTokenGrant(
 
     // Anchor `rotated_at` to the *first* rotation so leeway-window siblings
     // don't extend the parent's exposure. Always overwrite `rotated_to` to
-    // the most recent child for traceability.
+    // the most recent child for traceability. Also stamp `family_id` on the
+    // parent — for legacy rows (created before the rotation columns
+    // existed) this is the first time `family_id` gets a value, and
+    // without it `revokeFamily` would skip the parent itself when reuse is
+    // detected later.
     await ctx.env.data.refreshTokens.update(
       client.tenant.id,
       refreshToken.id,
       {
         rotated_to: childId,
         rotated_at: refreshToken.rotated_at ?? new Date().toISOString(),
+        family_id: familyId,
       },
     );
 

--- a/packages/authhero/src/routes/auth-api/revoke.ts
+++ b/packages/authhero/src/routes/auth-api/revoke.ts
@@ -5,6 +5,12 @@ import { getEnrichedClient } from "../../helpers/client";
 import { safeCompare } from "../../utils/safe-compare";
 import { parseBasicAuthHeader } from "../../utils/auth-header";
 import { setTenantId } from "../../helpers/set-tenant-id";
+import {
+  hashRefreshTokenSecret,
+  isLegacyRefreshTokenAccepted,
+  parseRefreshToken,
+} from "../../utils/refresh-token-format";
+import { RefreshToken } from "@authhero/adapter-interfaces";
 
 // RFC 7009 §2.1 — only refresh_token is currently revocable. Access tokens
 // are stateless JWTs and are not tracked server-side, so the hint is accepted
@@ -115,10 +121,26 @@ export const revokeRoutes = new OpenAPIHono<{
     // to prevent token-scanning probes. We only act when the token belongs to
     // the authenticating client; mismatches are silently ignored.
     if (params.token_type_hint !== "access_token") {
-      const refreshToken = await ctx.env.data.refreshTokens.get(
-        client.tenant.id,
-        params.token,
-      );
+      const parsed = parseRefreshToken(params.token);
+      let refreshToken: RefreshToken | null = null;
+
+      if (parsed.kind === "new") {
+        const candidate = await ctx.env.data.refreshTokens.getByLookup(
+          client.tenant.id,
+          parsed.lookup,
+        );
+        if (candidate?.token_hash) {
+          const presentedHash = await hashRefreshTokenSecret(parsed.secret);
+          if (safeCompare(presentedHash, candidate.token_hash)) {
+            refreshToken = candidate;
+          }
+        }
+      } else if (isLegacyRefreshTokenAccepted()) {
+        refreshToken = await ctx.env.data.refreshTokens.get(
+          client.tenant.id,
+          parsed.id,
+        );
+      }
 
       if (
         refreshToken &&

--- a/packages/authhero/src/routes/management-api/refresh_tokens.ts
+++ b/packages/authhero/src/routes/management-api/refresh_tokens.ts
@@ -89,6 +89,15 @@ export const refreshTokensRoutes = new OpenAPIHono<{
     async (ctx) => {
       const { id } = ctx.req.valid("param");
 
+      // Resolve the row first so we know its family. Removing a refresh token
+      // via the admin API also revokes any sibling/descendant tokens in the
+      // same rotation chain — matches the user-stated expectation that
+      // "revoke" should torch the entire family.
+      const target = await ctx.env.data.refreshTokens.get(
+        ctx.var.tenant_id,
+        id,
+      );
+
       const result = await ctx.env.data.refreshTokens.remove(
         ctx.var.tenant_id,
         id,
@@ -97,6 +106,15 @@ export const refreshTokensRoutes = new OpenAPIHono<{
         throw new HTTPException(404, {
           message: "Session not found",
         });
+      }
+
+      const familyId = target?.family_id ?? target?.id;
+      if (familyId) {
+        await ctx.env.data.refreshTokens.revokeFamily(
+          ctx.var.tenant_id,
+          familyId,
+          new Date().toISOString(),
+        );
       }
 
       await logMessage(ctx, ctx.var.tenant_id, {

--- a/packages/authhero/src/routes/management-api/refresh_tokens.ts
+++ b/packages/authhero/src/routes/management-api/refresh_tokens.ts
@@ -93,10 +93,25 @@ export const refreshTokensRoutes = new OpenAPIHono<{
       // via the admin API also revokes any sibling/descendant tokens in the
       // same rotation chain — matches the user-stated expectation that
       // "revoke" should torch the entire family.
+      //
+      // Run revokeFamily *before* the hard remove: revokeFamily is
+      // idempotent ("WHERE revoked_at_ts IS NULL"), so if the subsequent
+      // remove fails the family is already torched and a retry just
+      // re-runs remove. The reverse order would leave siblings active if
+      // the family-revoke step failed after the parent was already gone.
       const target = await ctx.env.data.refreshTokens.get(
         ctx.var.tenant_id,
         id,
       );
+
+      const familyId = target?.family_id ?? target?.id;
+      if (familyId) {
+        await ctx.env.data.refreshTokens.revokeFamily(
+          ctx.var.tenant_id,
+          familyId,
+          new Date().toISOString(),
+        );
+      }
 
       const result = await ctx.env.data.refreshTokens.remove(
         ctx.var.tenant_id,
@@ -106,15 +121,6 @@ export const refreshTokensRoutes = new OpenAPIHono<{
         throw new HTTPException(404, {
           message: "Session not found",
         });
-      }
-
-      const familyId = target?.family_id ?? target?.id;
-      if (familyId) {
-        await ctx.env.data.refreshTokens.revokeFamily(
-          ctx.var.tenant_id,
-          familyId,
-          new Date().toISOString(),
-        );
       }
 
       await logMessage(ctx, ctx.var.tenant_id, {

--- a/packages/authhero/src/utils/refresh-token-format.ts
+++ b/packages/authhero/src/utils/refresh-token-format.ts
@@ -1,0 +1,62 @@
+import { sha256 } from "oslo/crypto";
+import { base64url, encodeHex } from "oslo/encoding";
+
+export const REFRESH_TOKEN_PREFIX = "rt_";
+export const LOOKUP_BYTES = 7;
+export const SECRET_BYTES = 32;
+
+// After this date the legacy (un-prefixed, id-only) refresh-token format is
+// rejected. New format has been the default since 2026-05-05; the ~30 day
+// window covers a full max-age refresh-token lifetime.
+export const LEGACY_CUTOFF = new Date("2026-06-05T00:00:00.000Z");
+
+export type ParsedRefreshToken =
+  | { kind: "new"; lookup: string; secret: string }
+  | { kind: "legacy"; id: string };
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+export function generateRefreshTokenParts(): {
+  lookup: string;
+  secret: string;
+} {
+  return {
+    lookup: base64url.encode(randomBytes(LOOKUP_BYTES), {
+      includePadding: false,
+    }),
+    secret: base64url.encode(randomBytes(SECRET_BYTES), {
+      includePadding: false,
+    }),
+  };
+}
+
+export async function hashRefreshTokenSecret(secret: string): Promise<string> {
+  return encodeHex(await sha256(new TextEncoder().encode(secret)));
+}
+
+export function formatRefreshToken(lookup: string, secret: string): string {
+  return `${REFRESH_TOKEN_PREFIX}${lookup}.${secret}`;
+}
+
+export function parseRefreshToken(token: string): ParsedRefreshToken {
+  if (token.startsWith(REFRESH_TOKEN_PREFIX)) {
+    const body = token.slice(REFRESH_TOKEN_PREFIX.length);
+    const dot = body.indexOf(".");
+    if (dot > 0 && dot < body.length - 1) {
+      return {
+        kind: "new",
+        lookup: body.slice(0, dot),
+        secret: body.slice(dot + 1),
+      };
+    }
+  }
+  return { kind: "legacy", id: token };
+}
+
+export function isLegacyRefreshTokenAccepted(now: Date = new Date()): boolean {
+  return now < LEGACY_CUTOFF;
+}

--- a/packages/authhero/test/routes/auth-api/refresh-token-rotation.spec.ts
+++ b/packages/authhero/test/routes/auth-api/refresh-token-rotation.spec.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect } from "vitest";
+import { testClient } from "hono/testing";
+import { getTestServer } from "../../helpers/test-server";
+import { getAdminToken } from "../../helpers/token";
+import {
+  formatRefreshToken,
+  generateRefreshTokenParts,
+  hashRefreshTokenSecret,
+  parseRefreshToken,
+  REFRESH_TOKEN_PREFIX,
+} from "../../../src/utils/refresh-token-format";
+import { ulid } from "../../../src/utils/ulid";
+
+interface TokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  id_token?: string;
+}
+
+interface ErrorResponse {
+  error: string;
+  error_description?: string;
+}
+
+const idleHour = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+const baseTokenFields = {
+  login_id: "loginSessionId",
+  user_id: "email|userId",
+  client_id: "clientId",
+  resource_servers: [{ audience: "http://example.com", scopes: "openid" }],
+  device: {
+    last_ip: "",
+    initial_ip: "",
+    last_user_agent: "",
+    initial_user_agent: "",
+    initial_asn: "",
+    last_asn: "",
+  },
+};
+
+async function seedNewFormatToken(
+  env: Awaited<ReturnType<typeof getTestServer>>["env"],
+  overrides: {
+    rotating?: boolean;
+    family_id?: string;
+    rotated_at?: string;
+    rotated_to?: string;
+    id?: string;
+  } = {},
+) {
+  const id = overrides.id ?? ulid();
+  const { lookup, secret } = generateRefreshTokenParts();
+  const token_hash = await hashRefreshTokenSecret(secret);
+  await env.data.refreshTokens.create("tenantId", {
+    ...baseTokenFields,
+    id,
+    rotating: overrides.rotating ?? true,
+    token_lookup: lookup,
+    token_hash,
+    family_id: overrides.family_id ?? id,
+    rotated_at: overrides.rotated_at,
+    rotated_to: overrides.rotated_to,
+    expires_at: idleHour(),
+    idle_expires_at: idleHour(),
+  });
+  return { id, lookup, secret, wire: formatRefreshToken(lookup, secret) };
+}
+
+async function setRotating(
+  env: Awaited<ReturnType<typeof getTestServer>>["env"],
+  rotation_type: "rotating" | "non-rotating",
+  leeway?: number,
+) {
+  await env.data.clients.update("tenantId", "clientId", {
+    refresh_token: { rotation_type, ...(leeway !== undefined && { leeway }) },
+  });
+}
+
+describe("refresh token rotation", () => {
+  it("issues a rotated refresh token in the new format on exchange", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await setRotating(env, "rotating");
+    const seeded = await seedNewFormatToken(env, { rotating: true });
+    const client = testClient(oauthApp, env);
+
+    const response = await client.oauth.token.$post(
+      // @ts-expect-error - testClient type requires both form and json
+      {
+        form: {
+          grant_type: "refresh_token",
+          refresh_token: seeded.wire,
+          client_id: "clientId",
+        },
+      },
+      { headers: { "tenant-id": "tenantId" } },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as TokenResponse;
+    expect(body.refresh_token).toBeTypeOf("string");
+    expect(body.refresh_token).not.toBe(seeded.wire);
+    expect(body.refresh_token!.startsWith(REFRESH_TOKEN_PREFIX)).toBe(true);
+
+    // Parent row is marked rotated; child row exists in the same family.
+    const parent = await env.data.refreshTokens.get("tenantId", seeded.id);
+    expect(parent?.rotated_at).toBeTypeOf("string");
+    expect(parent?.rotated_to).toBeTypeOf("string");
+
+    const childParsed = parseRefreshToken(body.refresh_token!);
+    if (childParsed.kind !== "new") {
+      throw new Error("expected new-format wire token");
+    }
+    const child = await env.data.refreshTokens.getByLookup(
+      "tenantId",
+      childParsed.lookup,
+    );
+    expect(child).toBeTruthy();
+    expect(child!.family_id).toBe(seeded.id);
+    expect(child!.rotating).toBe(true);
+  });
+
+  it("does not store the secret at rest (only the SHA-256 hash)", async () => {
+    const { env } = await getTestServer();
+    const seeded = await seedNewFormatToken(env, { rotating: true });
+    const row = await env.data.refreshTokens.get("tenantId", seeded.id);
+    expect(row).toBeTruthy();
+    expect(row!.token_hash).not.toBe(seeded.secret);
+    expect(row!.token_hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("revokes the entire family when an already-rotated parent is reused outside leeway", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await setRotating(env, "rotating", 1); // 1 second leeway
+    const seeded = await seedNewFormatToken(env, { rotating: true });
+    const client = testClient(oauthApp, env);
+
+    // First rotation succeeds and produces a child.
+    const firstRes = await client.oauth.token.$post(
+      // @ts-expect-error
+      {
+        form: {
+          grant_type: "refresh_token",
+          refresh_token: seeded.wire,
+          client_id: "clientId",
+        },
+      },
+      { headers: { "tenant-id": "tenantId" } },
+    );
+    expect(firstRes.status).toBe(200);
+    const firstBody = (await firstRes.json()) as TokenResponse;
+    const childWire = firstBody.refresh_token!;
+
+    // Sleep just past the 1-second leeway window so the next presentation
+    // counts as reuse.
+    await new Promise((r) => setTimeout(r, 1100));
+
+    // Re-presenting the parent triggers reuse detection.
+    const reuseRes = await client.oauth.token.$post(
+      // @ts-expect-error
+      {
+        form: {
+          grant_type: "refresh_token",
+          refresh_token: seeded.wire,
+          client_id: "clientId",
+        },
+      },
+      { headers: { "tenant-id": "tenantId" } },
+    );
+    expect(reuseRes.status === 400 || reuseRes.status === 403).toBe(true);
+    const err = (await reuseRes.json()) as ErrorResponse;
+    expect(err.error).toBe("invalid_grant");
+
+    // Both the parent and the new child are revoked (entire family torched).
+    const parent = await env.data.refreshTokens.get("tenantId", seeded.id);
+    expect(parent?.revoked_at).toBeTypeOf("string");
+
+    const childParsed = parseRefreshToken(childWire);
+    if (childParsed.kind !== "new") {
+      throw new Error("expected new-format wire token");
+    }
+    const child = await env.data.refreshTokens.getByLookup(
+      "tenantId",
+      childParsed.lookup,
+    );
+    expect(child?.revoked_at).toBeTypeOf("string");
+  });
+
+  it("allows multiple rotations within the leeway window (concurrent-call tolerance)", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await setRotating(env, "rotating", 60); // generous leeway
+    const seeded = await seedNewFormatToken(env, { rotating: true });
+    const client = testClient(oauthApp, env);
+
+    const exchange = () =>
+      client.oauth.token.$post(
+        // @ts-expect-error
+        {
+          form: {
+            grant_type: "refresh_token",
+            refresh_token: seeded.wire,
+            client_id: "clientId",
+          },
+        },
+        { headers: { "tenant-id": "tenantId" } },
+      );
+
+    const r1 = await exchange();
+    const r2 = await exchange();
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    const b1 = (await r1.json()) as TokenResponse;
+    const b2 = (await r2.json()) as TokenResponse;
+    expect(b1.refresh_token).not.toBe(b2.refresh_token);
+
+    // Both children share the parent's family_id.
+    const c1 = parseRefreshToken(b1.refresh_token!);
+    const c2 = parseRefreshToken(b2.refresh_token!);
+    if (c1.kind !== "new" || c2.kind !== "new") {
+      throw new Error("expected new-format wire tokens");
+    }
+    const child1 = await env.data.refreshTokens.getByLookup(
+      "tenantId",
+      c1.lookup,
+    );
+    const child2 = await env.data.refreshTokens.getByLookup(
+      "tenantId",
+      c2.lookup,
+    );
+    expect(child1?.family_id).toBe(seeded.id);
+    expect(child2?.family_id).toBe(seeded.id);
+  });
+
+  it("non-rotating clients echo the same refresh token back", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await setRotating(env, "non-rotating");
+    const seeded = await seedNewFormatToken(env, { rotating: false });
+    const client = testClient(oauthApp, env);
+
+    const res = await client.oauth.token.$post(
+      // @ts-expect-error
+      {
+        form: {
+          grant_type: "refresh_token",
+          refresh_token: seeded.wire,
+          client_id: "clientId",
+        },
+      },
+      { headers: { "tenant-id": "tenantId" } },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TokenResponse;
+    expect(body.refresh_token).toBe(seeded.wire);
+  });
+
+  it("rejects a wire token whose secret hash doesn't match the stored row", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await setRotating(env, "rotating");
+    const seeded = await seedNewFormatToken(env, { rotating: true });
+    const client = testClient(oauthApp, env);
+
+    // Replace the secret with a fresh random one but keep the lookup. The
+    // row exists under that lookup, but the hash won't match.
+    const tampered = formatRefreshToken(
+      seeded.lookup,
+      "definitely-not-the-original-secret",
+    );
+
+    const res = await client.oauth.token.$post(
+      // @ts-expect-error
+      {
+        form: {
+          grant_type: "refresh_token",
+          refresh_token: tampered,
+          client_id: "clientId",
+        },
+      },
+      { headers: { "tenant-id": "tenantId" } },
+    );
+    expect(res.status === 400 || res.status === 403).toBe(true);
+    const err = (await res.json()) as ErrorResponse;
+    expect(err.error).toBe("invalid_grant");
+  });
+
+  it("legacy (id-only) refresh tokens still resolve before the cutoff", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await env.data.refreshTokens.create("tenantId", {
+      ...baseTokenFields,
+      id: "legacyRefreshToken",
+      rotating: false,
+      expires_at: idleHour(),
+      idle_expires_at: idleHour(),
+    });
+    const client = testClient(oauthApp, env);
+
+    const res = await client.oauth.token.$post(
+      // @ts-expect-error
+      {
+        form: {
+          grant_type: "refresh_token",
+          refresh_token: "legacyRefreshToken",
+          client_id: "clientId",
+        },
+      },
+      { headers: { "tenant-id": "tenantId" } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("admin DELETE on a single token revokes the entire family", async () => {
+    const { managementApp, env } = await getTestServer();
+    const seeded = await seedNewFormatToken(env, { rotating: true });
+
+    // Create two children attached to the same family root.
+    const child1Id = ulid();
+    await env.data.refreshTokens.create("tenantId", {
+      ...baseTokenFields,
+      id: child1Id,
+      rotating: true,
+      family_id: seeded.id,
+      expires_at: idleHour(),
+      idle_expires_at: idleHour(),
+    });
+
+    const child2Id = ulid();
+    await env.data.refreshTokens.create("tenantId", {
+      ...baseTokenFields,
+      id: child2Id,
+      rotating: true,
+      family_id: seeded.id,
+      expires_at: idleHour(),
+      idle_expires_at: idleHour(),
+    });
+
+    const adminToken = await getAdminToken();
+    const res = await managementApp.request(
+      `/refresh_tokens/${seeded.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${adminToken}`,
+          "tenant-id": "tenantId",
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+
+    const c1 = await env.data.refreshTokens.get("tenantId", child1Id);
+    const c2 = await env.data.refreshTokens.get("tenantId", child2Id);
+    expect(c1?.revoked_at).toBeTypeOf("string");
+    expect(c2?.revoked_at).toBeTypeOf("string");
+  });
+});

--- a/packages/authhero/test/utils/refresh-token-format.spec.ts
+++ b/packages/authhero/test/utils/refresh-token-format.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  REFRESH_TOKEN_PREFIX,
+  formatRefreshToken,
+  generateRefreshTokenParts,
+  hashRefreshTokenSecret,
+  isLegacyRefreshTokenAccepted,
+  parseRefreshToken,
+  LEGACY_CUTOFF,
+} from "../../src/utils/refresh-token-format";
+
+describe("refresh-token-format", () => {
+  describe("generateRefreshTokenParts", () => {
+    it("returns a fresh (lookup, secret) pair on each call", () => {
+      const a = generateRefreshTokenParts();
+      const b = generateRefreshTokenParts();
+      expect(a.lookup).not.toBe(b.lookup);
+      expect(a.secret).not.toBe(b.secret);
+      // base64url charset only
+      expect(a.lookup).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(a.secret).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+  });
+
+  describe("hashRefreshTokenSecret", () => {
+    it("is deterministic for a given input", async () => {
+      const h1 = await hashRefreshTokenSecret("abc.def-123");
+      const h2 = await hashRefreshTokenSecret("abc.def-123");
+      expect(h1).toBe(h2);
+      expect(h1).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("differs for different inputs", async () => {
+      const h1 = await hashRefreshTokenSecret("a");
+      const h2 = await hashRefreshTokenSecret("b");
+      expect(h1).not.toBe(h2);
+    });
+  });
+
+  describe("formatRefreshToken / parseRefreshToken", () => {
+    it("round-trips a freshly generated pair", () => {
+      const { lookup, secret } = generateRefreshTokenParts();
+      const wire = formatRefreshToken(lookup, secret);
+      expect(wire.startsWith(REFRESH_TOKEN_PREFIX)).toBe(true);
+      const parsed = parseRefreshToken(wire);
+      expect(parsed.kind).toBe("new");
+      if (parsed.kind === "new") {
+        expect(parsed.lookup).toBe(lookup);
+        expect(parsed.secret).toBe(secret);
+      }
+    });
+
+    it("treats inputs without the rt_ prefix as legacy", () => {
+      const parsed = parseRefreshToken("01HXY3Z9KQ2M4PSOMEULID");
+      expect(parsed).toEqual({ kind: "legacy", id: "01HXY3Z9KQ2M4PSOMEULID" });
+    });
+
+    it("treats prefixed-but-no-dot inputs as legacy (defensive)", () => {
+      const parsed = parseRefreshToken("rt_lookuponly");
+      expect(parsed.kind).toBe("legacy");
+    });
+
+    it("treats prefixed inputs with empty lookup or secret as legacy", () => {
+      expect(parseRefreshToken("rt_.secret").kind).toBe("legacy");
+      expect(parseRefreshToken("rt_lookup.").kind).toBe("legacy");
+    });
+
+    it("preserves dots in the secret beyond the first separator", () => {
+      // The implementation splits on the *first* dot so a secret containing
+      // base64url chars only never collides, but if random output ever had a
+      // '.', the lookup must end at the first dot.
+      const parsed = parseRefreshToken("rt_abc.def.ghi");
+      expect(parsed).toEqual({
+        kind: "new",
+        lookup: "abc",
+        secret: "def.ghi",
+      });
+    });
+  });
+
+  describe("isLegacyRefreshTokenAccepted", () => {
+    it("returns true before the cutoff", () => {
+      const before = new Date(LEGACY_CUTOFF.getTime() - 1000);
+      expect(isLegacyRefreshTokenAccepted(before)).toBe(true);
+    });
+
+    it("returns false after the cutoff", () => {
+      const after = new Date(LEGACY_CUTOFF.getTime() + 1000);
+      expect(isLegacyRefreshTokenAccepted(after)).toBe(false);
+    });
+  });
+});

--- a/packages/aws/src/adapters/refreshTokens.ts
+++ b/packages/aws/src/adapters/refreshTokens.ts
@@ -14,6 +14,7 @@ import {
   getItem,
   putItem,
   deleteItem,
+  queryItems,
   queryWithPagination,
   updateItem,
   stripDynamoDBFields,
@@ -32,6 +33,12 @@ interface RefreshTokenItem extends DynamoDBBaseItem {
   device: string; // JSON string
   resource_servers: string; // JSON array string
   rotating: boolean;
+  token_lookup?: string;
+  token_hash?: string;
+  family_id?: string;
+  rotated_to?: string;
+  rotated_at?: string;
+  revoked_at?: string;
 }
 
 function toRefreshToken(item: RefreshTokenItem): RefreshToken {
@@ -74,9 +81,25 @@ export function createRefreshTokensAdapter(
         device: JSON.stringify(refreshToken.device),
         resource_servers: JSON.stringify(refreshToken.resource_servers),
         rotating: refreshToken.rotating,
+        token_lookup: refreshToken.token_lookup,
+        token_hash: refreshToken.token_hash,
+        family_id: refreshToken.family_id,
+        rotated_to: refreshToken.rotated_to,
+        rotated_at: refreshToken.rotated_at,
         created_at: now,
         updated_at: now,
       };
+
+      // Wire up GSI2 for token_lookup → row resolution on the refresh-grant
+      // path. Only set when present; legacy rows without a lookup remain
+      // resolvable only via primary key.
+      if (refreshToken.token_lookup) {
+        item.GSI2PK = refreshTokenKeys.gsi2pk(
+          tenantId,
+          refreshToken.token_lookup,
+        );
+        item.GSI2SK = refreshTokenKeys.gsi2sk();
+      }
 
       // Set TTL for automatic expiration if expires_at is set
       if (refreshToken.expires_at) {
@@ -100,6 +123,22 @@ export function createRefreshTokensAdapter(
       if (!item) return null;
 
       return toRefreshToken(item);
+    },
+
+    async getByLookup(
+      tenantId: string,
+      tokenLookup: string,
+    ): Promise<RefreshToken | null> {
+      const result = await queryItems<RefreshTokenItem>(
+        ctx,
+        refreshTokenKeys.gsi2pk(tenantId, tokenLookup),
+        {
+          indexName: "GSI2",
+          skValue: refreshTokenKeys.gsi2sk(),
+          limit: 1,
+        },
+      );
+      return result.items[0] ? toRefreshToken(result.items[0]) : null;
     },
 
     async list(
@@ -200,6 +239,66 @@ export function createRefreshTokensAdapter(
         );
         for (const item of result.items) {
           if (item.login_id !== login_session_id) continue;
+          if ((item as { revoked_at?: string }).revoked_at) continue;
+          try {
+            await ctx.client.send(
+              new UpdateCommand({
+                TableName: ctx.tableName,
+                Key: {
+                  PK: refreshTokenKeys.pk(tenantId),
+                  SK: refreshTokenKeys.sk(item.id),
+                },
+                UpdateExpression:
+                  "SET #revoked_at = :revoked_at, #updated_at = :updated_at",
+                ConditionExpression:
+                  "attribute_exists(PK) AND attribute_not_exists(#revoked_at)",
+                ExpressionAttributeNames: {
+                  "#revoked_at": "revoked_at",
+                  "#updated_at": "updated_at",
+                },
+                ExpressionAttributeValues: {
+                  ":revoked_at": revoked_at,
+                  ":updated_at": new Date().toISOString(),
+                },
+              }),
+            );
+            count++;
+          } catch (err: unknown) {
+            if (
+              (err as { name?: string })?.name ===
+              "ConditionalCheckFailedException"
+            ) {
+              continue;
+            }
+            throw err;
+          }
+        }
+        if (result.items.length < per_page) break;
+        page++;
+      }
+      return count;
+    },
+
+    async revokeFamily(
+      tenantId: string,
+      family_id: string,
+      revoked_at: string,
+    ): Promise<number> {
+      // No dedicated GSI for family_id; scan tenant refresh tokens and
+      // soft-revoke siblings whose family_id matches and that aren't already
+      // revoked.
+      let count = 0;
+      let page = 0;
+      const per_page = 100;
+      for (;;) {
+        const result = await queryWithPagination<RefreshTokenItem>(
+          ctx,
+          refreshTokenKeys.pk(tenantId),
+          { page, per_page },
+          { skPrefix: "REFRESH_TOKEN#" },
+        );
+        for (const item of result.items) {
+          if (item.family_id !== family_id) continue;
           if ((item as { revoked_at?: string }).revoked_at) continue;
           try {
             await ctx.client.send(

--- a/packages/aws/src/keys.ts
+++ b/packages/aws/src/keys.ts
@@ -151,6 +151,10 @@ export const refreshTokenKeys = {
   gsi1pk: (tenantId: string, userId: string) =>
     `TENANT#${tenantId}#USER#${userId}`,
   gsi1sk: (tokenId: string) => `REFRESH_TOKEN#${tokenId}`,
+  // GSI2 for token_lookup (the plaintext slice extracted from the wire token)
+  gsi2pk: (tenantId: string, tokenLookup: string) =>
+    `TENANT#${tenantId}#RT_LOOKUP#${tokenLookup}`,
+  gsi2sk: () => "REFRESH_TOKEN",
 };
 
 // Form keys

--- a/packages/drizzle/drizzle/0000_watery_loners.sql
+++ b/packages/drizzle/drizzle/0000_watery_loners.sql
@@ -196,14 +196,19 @@ CREATE TABLE `otps` (
 CREATE INDEX `otps_email_index` ON `otps` (`email`);--> statement-breakpoint
 CREATE INDEX `otps_expires_at_index` ON `otps` (`expires_at`);--> statement-breakpoint
 CREATE TABLE `refresh_tokens` (
-	`id` text(21) NOT NULL,
+	`id` text(26) NOT NULL,
 	`tenant_id` text(191) NOT NULL,
 	`client_id` text(191) NOT NULL,
-	`login_id` text(21) NOT NULL,
+	`login_id` text(26) NOT NULL,
 	`user_id` text(255),
 	`resource_servers` text NOT NULL,
 	`device` text NOT NULL,
 	`rotating` integer NOT NULL,
+	`token_lookup` text(16),
+	`token_hash` text(64),
+	`family_id` text(26),
+	`rotated_to` text(26),
+	`rotated_at_ts` integer,
 	`created_at_ts` integer NOT NULL,
 	`expires_at_ts` integer,
 	`idle_expires_at_ts` integer,
@@ -216,6 +221,8 @@ CREATE TABLE `refresh_tokens` (
 CREATE INDEX `idx_refresh_tokens_user_id` ON `refresh_tokens` (`tenant_id`,`user_id`);--> statement-breakpoint
 CREATE INDEX `idx_refresh_tokens_login_id` ON `refresh_tokens` (`login_id`);--> statement-breakpoint
 CREATE INDEX `idx_refresh_tokens_expires_at_ts` ON `refresh_tokens` (`expires_at_ts`);--> statement-breakpoint
+CREATE INDEX `idx_refresh_tokens_token_lookup` ON `refresh_tokens` (`tenant_id`,`token_lookup`);--> statement-breakpoint
+CREATE INDEX `idx_refresh_tokens_family_id` ON `refresh_tokens` (`tenant_id`,`family_id`);--> statement-breakpoint
 CREATE TABLE `sessions` (
 	`id` text(21) NOT NULL,
 	`tenant_id` text(191) NOT NULL,

--- a/packages/drizzle/src/adapters/refreshTokens.ts
+++ b/packages/drizzle/src/adapters/refreshTokens.ts
@@ -28,6 +28,7 @@ function sqlToRefreshToken(row: any): RefreshToken {
     idle_expires_at_ts,
     last_exchanged_at_ts,
     revoked_at_ts,
+    rotated_at_ts,
     device,
     resource_servers,
     rotating,
@@ -41,6 +42,7 @@ function sqlToRefreshToken(row: any): RefreshToken {
       idle_expires_at_ts,
       last_exchanged_at_ts,
       revoked_at_ts,
+      rotated_at_ts,
     },
     ["created_at_ts"],
     [
@@ -48,6 +50,7 @@ function sqlToRefreshToken(row: any): RefreshToken {
       "idle_expires_at_ts",
       "last_exchanged_at_ts",
       "revoked_at_ts",
+      "rotated_at_ts",
     ],
   );
 
@@ -81,6 +84,11 @@ export function createRefreshTokensAdapter(db: DrizzleDb) {
         device: JSON.stringify(token.device || {}),
         resource_servers: JSON.stringify(token.resource_servers || []),
         rotating: token.rotating ?? false,
+        token_lookup: token.token_lookup ?? null,
+        token_hash: token.token_hash ?? null,
+        family_id: token.family_id ?? null,
+        rotated_to: token.rotated_to ?? null,
+        rotated_at_ts: isoToDbDate(token.rotated_at),
         created_at_ts: now,
         expires_at_ts: isoToDbDate(token.expires_at),
         idle_expires_at_ts: isoToDbDate(token.idle_expires_at),
@@ -137,6 +145,25 @@ export function createRefreshTokensAdapter(db: DrizzleDb) {
       return sqlToRefreshToken(result);
     },
 
+    async getByLookup(
+      tenant_id: string,
+      token_lookup: string,
+    ): Promise<RefreshToken | null> {
+      const result = await db
+        .select()
+        .from(refreshTokens)
+        .where(
+          and(
+            eq(refreshTokens.tenant_id, tenant_id),
+            eq(refreshTokens.token_lookup, token_lookup),
+          ),
+        )
+        .get();
+
+      if (!result) return null;
+      return sqlToRefreshToken(result);
+    },
+
     async update(
       tenant_id: string,
       id: string,
@@ -150,6 +177,16 @@ export function createRefreshTokensAdapter(db: DrizzleDb) {
       if (token.resource_servers !== undefined)
         updateData.resource_servers = JSON.stringify(token.resource_servers);
       if (token.rotating !== undefined) updateData.rotating = token.rotating;
+      if (token.token_lookup !== undefined)
+        updateData.token_lookup = token.token_lookup;
+      if (token.token_hash !== undefined)
+        updateData.token_hash = token.token_hash;
+      if (token.family_id !== undefined)
+        updateData.family_id = token.family_id;
+      if (token.rotated_to !== undefined)
+        updateData.rotated_to = token.rotated_to;
+      if (token.rotated_at !== undefined)
+        updateData.rotated_at_ts = isoToDbDate(token.rotated_at);
       if (token.expires_at !== undefined)
         updateData.expires_at_ts = isoToDbDate(token.expires_at);
       if (token.idle_expires_at !== undefined)
@@ -272,6 +309,26 @@ export function createRefreshTokensAdapter(db: DrizzleDb) {
           and(
             eq(refreshTokens.tenant_id, tenant_id),
             eq(refreshTokens.login_id, login_session_id),
+            isNull(refreshTokens.revoked_at_ts),
+          ),
+        )
+        .returning();
+
+      return results.length;
+    },
+
+    async revokeFamily(
+      tenant_id: string,
+      family_id: string,
+      revoked_at: string,
+    ): Promise<number> {
+      const results = await db
+        .update(refreshTokens)
+        .set({ revoked_at_ts: isoToDbDate(revoked_at) })
+        .where(
+          and(
+            eq(refreshTokens.tenant_id, tenant_id),
+            eq(refreshTokens.family_id, family_id),
             isNull(refreshTokens.revoked_at_ts),
           ),
         )

--- a/packages/drizzle/src/schema/sqlite/sessions.ts
+++ b/packages/drizzle/src/schema/sqlite/sessions.ts
@@ -38,16 +38,21 @@ export const sessions = sqliteTable(
 export const refreshTokens = sqliteTable(
   "refresh_tokens",
   {
-    id: text("id", { length: 21 }).notNull(),
+    id: text("id", { length: 26 }).notNull(),
     tenant_id: text("tenant_id", { length: 191 })
       .notNull()
       .references(() => tenants.id, { onDelete: "cascade" }),
     client_id: text("client_id", { length: 191 }).notNull(),
-    login_id: text("login_id", { length: 21 }).notNull(),
+    login_id: text("login_id", { length: 26 }).notNull(),
     user_id: text("user_id", { length: 255 }),
     resource_servers: text("resource_servers").notNull(),
     device: text("device").notNull(),
     rotating: integer("rotating", { mode: "boolean" }).notNull(),
+    token_lookup: text("token_lookup", { length: 16 }),
+    token_hash: text("token_hash", { length: 64 }),
+    family_id: text("family_id", { length: 26 }),
+    rotated_to: text("rotated_to", { length: 26 }),
+    rotated_at_ts: integer("rotated_at_ts"),
     created_at_ts: integer("created_at_ts").notNull(),
     expires_at_ts: integer("expires_at_ts"),
     idle_expires_at_ts: integer("idle_expires_at_ts"),
@@ -62,6 +67,11 @@ export const refreshTokens = sqliteTable(
     index("idx_refresh_tokens_user_id").on(table.tenant_id, table.user_id),
     index("idx_refresh_tokens_login_id").on(table.login_id),
     index("idx_refresh_tokens_expires_at_ts").on(table.expires_at_ts),
+    index("idx_refresh_tokens_token_lookup").on(
+      table.tenant_id,
+      table.token_lookup,
+    ),
+    index("idx_refresh_tokens_family_id").on(table.tenant_id, table.family_id),
   ],
 );
 

--- a/packages/kysely/migrate/migrations/2026-05-05T10:00:00_refresh_tokens_rotation.ts
+++ b/packages/kysely/migrate/migrations/2026-05-05T10:00:00_refresh_tokens_rotation.ts
@@ -1,0 +1,96 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/db";
+
+/**
+ * Adds the columns needed for Auth0-style refresh-token rotation and at-rest
+ * hashing. All columns are nullable so legacy (pre-rotation) rows continue to
+ * resolve via the `id`-only lookup path during the back-compat window.
+ *
+ *   - `token_lookup`: plaintext lookup slice extracted from the wire token
+ *     (`rt_<lookup>.<secret>`); indexed for the refresh-grant path.
+ *   - `token_hash`: SHA-256 hex of the secret part of the wire token.
+ *   - `family_id`: root token id of a rotation chain. Used to revoke an
+ *     entire family on reuse detection or admin revocation.
+ *   - `rotated_to`: most recently issued child id (debug/traceability).
+ *   - `rotated_at_ts`: time of the *first* rotation; anchors the leeway
+ *     window so siblings minted within it don't extend exposure.
+ *
+ * Each addColumn / dropColumn is its own ALTER TABLE statement because
+ * SQLite (and some MySQL configurations) don't accept multiple ADD COLUMN
+ * clauses in a single ALTER TABLE.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("refresh_tokens")
+    .addColumn("token_lookup", "varchar(16)")
+    .execute();
+
+  await db.schema
+    .alterTable("refresh_tokens")
+    .addColumn("token_hash", "varchar(64)")
+    .execute();
+
+  await db.schema
+    .alterTable("refresh_tokens")
+    .addColumn("family_id", "varchar(26)")
+    .execute();
+
+  await db.schema
+    .alterTable("refresh_tokens")
+    .addColumn("rotated_to", "varchar(26)")
+    .execute();
+
+  await db.schema
+    .alterTable("refresh_tokens")
+    .addColumn("rotated_at_ts", "bigint")
+    .execute();
+
+  await db.schema
+    .createIndex("idx_refresh_tokens_token_lookup")
+    .on("refresh_tokens")
+    .columns(["tenant_id", "token_lookup"])
+    .execute();
+
+  await db.schema
+    .createIndex("idx_refresh_tokens_family_id")
+    .on("refresh_tokens")
+    .columns(["tenant_id", "family_id"])
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .dropIndex("idx_refresh_tokens_family_id")
+    .on("refresh_tokens")
+    .execute();
+
+  await db.schema
+    .dropIndex("idx_refresh_tokens_token_lookup")
+    .on("refresh_tokens")
+    .execute();
+
+  await db.schema
+    .alterTable("refresh_tokens")
+    .dropColumn("rotated_at_ts")
+    .execute();
+
+  await db.schema
+    .alterTable("refresh_tokens")
+    .dropColumn("rotated_to")
+    .execute();
+
+  await db.schema
+    .alterTable("refresh_tokens")
+    .dropColumn("family_id")
+    .execute();
+
+  await db.schema
+    .alterTable("refresh_tokens")
+    .dropColumn("token_hash")
+    .execute();
+
+  await db.schema
+    .alterTable("refresh_tokens")
+    .dropColumn("token_lookup")
+    .execute();
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -153,6 +153,7 @@ import * as o054_client_registration_tokens from "./2026-04-24T10:00:00_client_r
 import * as o055_planetscale_redundant_indexes_cleanup from "./2026-04-24T10:00:00_planetscale_redundant_indexes_cleanup";
 import * as o056_client_user_linking_mode from "./2026-04-28T10:00:00_client_user_linking_mode";
 import * as o057_hooks_metadata from "./2026-04-29T10:00:00_hooks_metadata";
+import * as o058_refresh_tokens_rotation from "./2026-05-05T10:00:00_refresh_tokens_rotation";
 
 // These need to be in alphabetic order
 export default {
@@ -311,4 +312,5 @@ export default {
   o055_planetscale_redundant_indexes_cleanup,
   o056_client_user_linking_mode,
   o057_hooks_metadata,
+  o058_refresh_tokens_rotation,
 };

--- a/packages/kysely/src/db.ts
+++ b/packages/kysely/src/db.ts
@@ -204,6 +204,7 @@ const sqlRefreshTokensSchema = refreshTokenSchema
     idle_expires_at: true,
     last_exchanged_at: true,
     revoked_at: true,
+    rotated_at: true,
     device: true,
     resource_servers: true,
     rotating: true,
@@ -219,6 +220,7 @@ const sqlRefreshTokensSchema = refreshTokenSchema
     idle_expires_at_ts: z.number().nullable().optional(),
     last_exchanged_at_ts: z.number().nullable().optional(),
     revoked_at_ts: z.number().nullable().optional(),
+    rotated_at_ts: z.number().nullable().optional(),
   });
 
 const sqlCustomDomainSchema = z.object({

--- a/packages/kysely/src/refreshTokens/create.ts
+++ b/packages/kysely/src/refreshTokens/create.ts
@@ -20,6 +20,7 @@ export function create(db: Kysely<Database>) {
       expires_at,
       idle_expires_at,
       last_exchanged_at,
+      rotated_at,
       device,
       resource_servers,
       rotating,
@@ -50,6 +51,7 @@ export function create(db: Kysely<Database>) {
           last_exchanged_at_ts: last_exchanged_at
             ? isoToDbDate(last_exchanged_at)
             : null,
+          rotated_at_ts: rotated_at ? isoToDbDate(rotated_at) : null,
         })
         .execute();
 

--- a/packages/kysely/src/refreshTokens/getByLookup.ts
+++ b/packages/kysely/src/refreshTokens/getByLookup.ts
@@ -3,15 +3,15 @@ import { Kysely } from "kysely";
 import { Database } from "../db";
 import { convertDatesToAdapter } from "../utils/dateConversion";
 
-export function get(db: Kysely<Database>) {
+export function getByLookup(db: Kysely<Database>) {
   return async (
     tenant_id: string,
-    id: string,
+    token_lookup: string,
   ): Promise<RefreshToken | null> => {
     const refreshToken = await db
       .selectFrom("refresh_tokens")
       .where("refresh_tokens.tenant_id", "=", tenant_id)
-      .where("refresh_tokens.id", "=", id)
+      .where("refresh_tokens.token_lookup", "=", token_lookup)
       .selectAll()
       .executeTakeFirst();
 
@@ -30,7 +30,6 @@ export function get(db: Kysely<Database>) {
       ...rest
     } = refreshToken;
 
-    // Convert dates from DB format (bigint) to ISO strings
     const dates = convertDatesToAdapter(
       {
         created_at_ts,

--- a/packages/kysely/src/refreshTokens/index.ts
+++ b/packages/kysely/src/refreshTokens/index.ts
@@ -1,9 +1,11 @@
 import { RefreshTokensAdapter } from "@authhero/adapter-interfaces";
 import { get } from "./get";
+import { getByLookup } from "./getByLookup";
 import { create } from "./create";
 import { Kysely } from "kysely";
 import { remove } from "./remove";
 import { revokeByLoginSession } from "./revokeByLoginSession";
+import { revokeFamily } from "./revokeFamily";
 import { update } from "./update";
 import { list } from "./list";
 import { Database } from "../db";
@@ -14,9 +16,11 @@ export function createRefreshTokensAdapter(
   return {
     create: create(db),
     get: get(db),
+    getByLookup: getByLookup(db),
     list: list(db),
     remove: remove(db),
     revokeByLoginSession: revokeByLoginSession(db),
+    revokeFamily: revokeFamily(db),
     update: update(db),
   };
 }

--- a/packages/kysely/src/refreshTokens/list.ts
+++ b/packages/kysely/src/refreshTokens/list.ts
@@ -42,6 +42,7 @@ export function list(db: Kysely<Database>) {
         idle_expires_at_ts,
         last_exchanged_at_ts,
         revoked_at_ts,
+        rotated_at_ts,
         ...rest
       } = refresh_token;
 
@@ -53,6 +54,7 @@ export function list(db: Kysely<Database>) {
           idle_expires_at_ts,
           last_exchanged_at_ts,
           revoked_at_ts,
+          rotated_at_ts,
         },
         ["created_at_ts"],
         [
@@ -60,6 +62,7 @@ export function list(db: Kysely<Database>) {
           "idle_expires_at_ts",
           "last_exchanged_at_ts",
           "revoked_at_ts",
+          "rotated_at_ts",
         ],
       ) as {
         created_at: string;
@@ -67,6 +70,7 @@ export function list(db: Kysely<Database>) {
         idle_expires_at?: string;
         last_exchanged_at?: string;
         revoked_at?: string;
+        rotated_at?: string;
       };
 
       return {

--- a/packages/kysely/src/refreshTokens/revokeFamily.ts
+++ b/packages/kysely/src/refreshTokens/revokeFamily.ts
@@ -1,0 +1,23 @@
+import { Kysely } from "kysely";
+import { Database } from "../db";
+import { isoToDbDate } from "../utils/dateConversion";
+
+export function revokeFamily(db: Kysely<Database>) {
+  return async (
+    tenant_id: string,
+    family_id: string,
+    revoked_at: string,
+  ): Promise<number> => {
+    const revokedAtTs = isoToDbDate(revoked_at);
+
+    const results = await db
+      .updateTable("refresh_tokens")
+      .set({ revoked_at_ts: revokedAtTs })
+      .where("tenant_id", "=", tenant_id)
+      .where("family_id", "=", family_id)
+      .where("revoked_at_ts", "is", null)
+      .executeTakeFirst();
+
+    return Number(results.numUpdatedRows ?? 0);
+  };
+}

--- a/packages/kysely/src/refreshTokens/update.ts
+++ b/packages/kysely/src/refreshTokens/update.ts
@@ -20,6 +20,7 @@ export function update(db: Kysely<Database>) {
       idle_expires_at,
       last_exchanged_at,
       revoked_at,
+      rotated_at,
       device,
       resource_servers,
       rotating,
@@ -47,6 +48,8 @@ export function update(db: Kysely<Database>) {
           : undefined,
       revoked_at_ts:
         revoked_at !== undefined ? isoToDbDate(revoked_at) : undefined,
+      rotated_at_ts:
+        rotated_at !== undefined ? isoToDbDate(rotated_at) : undefined,
     };
 
     const bump = options?.loginSessionBump;

--- a/packages/kysely/test/refreshTokens/rotation.spec.ts
+++ b/packages/kysely/test/refreshTokens/rotation.spec.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+import {
+  AuthorizationResponseType,
+  LoginSessionState,
+} from "@authhero/adapter-interfaces";
+
+async function seedTenantAndClient(data: any) {
+  await data.tenants.create({
+    id: "tenantId",
+    friendly_name: "Test Tenant",
+    audience: "https://example.com",
+    sender_email: "login@example.com",
+    sender_name: "SenderName",
+  });
+
+  await data.clients.create("tenantId", {
+    client_id: "clientId",
+    client_secret: "clientSecret",
+    name: "Test Client",
+    callbacks: ["https://example.com/callback"],
+    allowed_logout_urls: ["https://example.com/callback"],
+    web_origins: ["https://example.com"],
+    client_metadata: {},
+  });
+}
+
+async function createLoginSession(data: any, expiresAt: string) {
+  return data.loginSessions.create("tenantId", {
+    csrf_token: "csrf",
+    authParams: {
+      client_id: "clientId",
+      response_type: AuthorizationResponseType.CODE,
+      scope: "openid offline_access",
+    },
+    expires_at: expiresAt,
+    state: LoginSessionState.PENDING,
+  });
+}
+
+function device() {
+  return {
+    last_ip: "",
+    initial_ip: "",
+    last_user_agent: "",
+    initial_user_agent: "",
+    initial_asn: "",
+    last_asn: "",
+  };
+}
+
+const baseFields = (login_id: string) => ({
+  login_id,
+  user_id: "email|userId",
+  client_id: "clientId",
+  resource_servers: [{ audience: "http://example.com", scopes: "openid" }],
+  device: device(),
+  rotating: true,
+  expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  idle_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+});
+
+describe("refresh tokens — rotation columns", () => {
+  it("getByLookup returns the row matching the plaintext lookup slice", async () => {
+    const { data } = await getTestServer();
+    await seedTenantAndClient(data);
+    const ls = await createLoginSession(
+      data,
+      new Date(Date.now() + 3600_000).toISOString(),
+    );
+
+    await data.refreshTokens.create("tenantId", {
+      ...baseFields(ls.id),
+      id: "rt-with-lookup",
+      token_lookup: "abc123",
+      token_hash:
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      family_id: "rt-with-lookup",
+    });
+
+    const found = await data.refreshTokens.getByLookup("tenantId", "abc123");
+    expect(found?.id).toBe("rt-with-lookup");
+    expect(found?.token_hash).toBe(
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    );
+
+    const missing = await data.refreshTokens.getByLookup(
+      "tenantId",
+      "doesnotexist",
+    );
+    expect(missing).toBeNull();
+  });
+
+  it("revokeFamily soft-revokes every sibling sharing the family_id", async () => {
+    const { data } = await getTestServer();
+    await seedTenantAndClient(data);
+    const ls = await createLoginSession(
+      data,
+      new Date(Date.now() + 3600_000).toISOString(),
+    );
+
+    await data.refreshTokens.create("tenantId", {
+      ...baseFields(ls.id),
+      id: "parent",
+      family_id: "parent",
+    });
+    await data.refreshTokens.create("tenantId", {
+      ...baseFields(ls.id),
+      id: "child-1",
+      family_id: "parent",
+    });
+    await data.refreshTokens.create("tenantId", {
+      ...baseFields(ls.id),
+      id: "child-2",
+      family_id: "parent",
+    });
+    // unrelated row in a different family — should be untouched.
+    await data.refreshTokens.create("tenantId", {
+      ...baseFields(ls.id),
+      id: "outsider",
+      family_id: "outsider",
+    });
+
+    const revokedAt = new Date().toISOString();
+    const updated = await data.refreshTokens.revokeFamily(
+      "tenantId",
+      "parent",
+      revokedAt,
+    );
+    expect(updated).toBe(3);
+
+    const parent = await data.refreshTokens.get("tenantId", "parent");
+    const child1 = await data.refreshTokens.get("tenantId", "child-1");
+    const child2 = await data.refreshTokens.get("tenantId", "child-2");
+    const outsider = await data.refreshTokens.get("tenantId", "outsider");
+    expect(parent?.revoked_at).toBeTypeOf("string");
+    expect(child1?.revoked_at).toBeTypeOf("string");
+    expect(child2?.revoked_at).toBeTypeOf("string");
+    expect(outsider?.revoked_at).toBeUndefined();
+  });
+
+  it("revokeFamily skips already-revoked rows", async () => {
+    const { data } = await getTestServer();
+    await seedTenantAndClient(data);
+    const ls = await createLoginSession(
+      data,
+      new Date(Date.now() + 3600_000).toISOString(),
+    );
+
+    await data.refreshTokens.create("tenantId", {
+      ...baseFields(ls.id),
+      id: "rt-pre-revoked",
+      family_id: "rt-pre-revoked",
+    });
+    await data.refreshTokens.update("tenantId", "rt-pre-revoked", {
+      revoked_at: new Date(Date.now() - 1000).toISOString(),
+    });
+
+    await data.refreshTokens.create("tenantId", {
+      ...baseFields(ls.id),
+      id: "rt-active",
+      family_id: "rt-pre-revoked",
+    });
+
+    const updated = await data.refreshTokens.revokeFamily(
+      "tenantId",
+      "rt-pre-revoked",
+      new Date().toISOString(),
+    );
+    expect(updated).toBe(1); // only the active sibling
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Auth0-style refresh-token rotation, with reuse detection that revokes the entire token family.
- Hashes refresh-token secrets at rest (SHA-256). Internal ULID `id` stays as the primary key; the wire format becomes `rt_<lookup>.<secret>`.
- New per-client config in `Client.refresh_token`: `rotation_type` (`"rotating"` | `"non-rotating"`, default non-rotating) and `leeway` seconds (default 30). Existing clients see no behavior change unless they opt in.
- Implemented across all three adapters (kysely, drizzle, aws). Adapters get two new methods: `getByLookup` and `revokeFamily`. AWS adds GSI2 on `token_lookup`; AWS family revocation page-scans the tenant partition (matching the existing `revokeByLoginSession` path).
- **Backwards compatible**: legacy id-only refresh tokens continue to resolve via the existing `get(tenant_id, id)` path until `LEGACY_CUTOFF = 2026-06-05`. A follow-up PR will remove the fallback.

### Behavior details

- **Issuance**: `createRefreshToken` generates `(lookup, secret)`, persists `family_id = id` and `token_hash = sha256(secret)`, and returns `{ row, wireToken }`. Wired through `authorization-code.ts` and `common.ts`.
- **Rotation**: each exchange mints a new child sharing `family_id`. Within `leeway` of the parent's first rotation, repeat presentations of the parent mint fresh siblings (concurrent-call tolerance). Outside `leeway`, the entire family is revoked via `revokeFamily`.
- **Non-rotating clients** (default): the same wire token is echoed back to the client (Auth0 behavior), so libraries that store and reuse `refresh_token` keep working.
- **Hash mismatch**: rejected as `invalid_grant` without revealing whether the lookup row existed.
- **Admin DELETE** `/api/v2/refresh_tokens/:id` now also revokes the rest of the family.
- **Legacy upgrade**: when a legacy token is presented to a now-rotating client, the legacy row becomes the family root and a hashed child is minted.

### Schema changes

New nullable columns on `refresh_tokens`: `token_lookup`, `token_hash`, `family_id`, `rotated_to`, `rotated_at_ts`. New indexes on `(tenant_id, token_lookup)` and `(tenant_id, family_id)`. All nullable so legacy rows continue to validate without backfill.

## Test plan

- [x] Unit tests for `refresh-token-format` helpers (round-trip, malformed inputs, legacy detection, hash determinism).
- [x] Integration tests covering rotation, reuse detection inside/outside leeway, non-rotating echo, hash-mismatch rejection, legacy compat, admin family revocation.
- [x] Kysely adapter tests for `getByLookup` and `revokeFamily` (incl. cross-family isolation and skipping already-revoked rows).
- [x] All existing 1054 authhero, 212 kysely, 25 aws, 10 drizzle tests pass.
- [ ] Smoke test with the demo app (`pnpm demo dev`): log in, exchange the refresh token twice with curl, confirm the second exchange returns a new token and reusing the first after leeway revokes the family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added refresh token rotation with Auth0-style at-rest hashing; new token format `rt_<lookup>.<secret>` where only the secret hash is stored
  * Per-client rotation configuration with `rotation_type` ("rotating" or "non-rotating") and configurable leeway window
  * Automatic rotation with child token generation and family tracking; siblings issued on concurrent requests within leeway
  * Reuse detection outside leeway revokes entire token family
  * Admin endpoint updated to revoke token families instead of individual tokens
  * Backwards compatible with legacy tokens until June 5, 2026

* **Tests**
  * Added comprehensive test coverage for rotation, reuse detection, and family revocation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->