### PR TITLE
Trim tenants list for org users

### DIFF
--- a/.changeset/multi-tenancy-org-scoped-tenant-list.md
+++ b/.changeset/multi-tenancy-org-scoped-tenant-list.md
@@ -1,0 +1,5 @@
+---
+"@authhero/multi-tenancy": patch
+---
+
+Fix tenant-list authorization bypass for org-scoped tokens. `GET /tenants` previously returned every tenant whenever the caller's token carried `admin:organizations` or `auth:read`, but `admin:organizations` is also granted via org-scoped roles — so any organization admin received cross-tenant visibility. The full-access shortcut now only applies when the token has no `org_id` claim, and the route additionally requires the `read:tenants` or `auth:read` scope.

--- a/packages/multi-tenancy/src/routes/tenants.ts
+++ b/packages/multi-tenancy/src/routes/tenants.ts
@@ -49,7 +49,7 @@ export function createTenantsOpenAPIRouter(
       },
       security: [
         {
-          Bearer: [],
+          Bearer: ["read:tenants", "auth:read"],
         },
       ],
       responses: {
@@ -79,14 +79,20 @@ export function createTenantsOpenAPIRouter(
             tenant_id: string;
             scope?: string;
             permissions?: string[];
+            org_id?: string;
           }
         | undefined;
 
-      // If user has auth:read or admin:organizations permission, allow access to all tenants
+      // If user has auth:read or admin:organizations permission, allow access to all tenants.
+      // Why: tokens with an org_id were issued for a specific organization, so any
+      // admin:organizations permission they carry came from an org-scoped role — not a
+      // global one — and must not bypass per-org tenant filtering.
       const userPermissions = user?.permissions || [];
+      const tokenIsOrgScoped = Boolean(user?.org_id ?? ctx.var.organization_id);
       const hasFullAccess =
-        userPermissions.includes("auth:read") ||
-        userPermissions.includes("admin:organizations");
+        !tokenIsOrgScoped &&
+        (userPermissions.includes("auth:read") ||
+          userPermissions.includes("admin:organizations"));
 
       if (hasFullAccess) {
         const result = await ctx.env.data.tenants.list({

--- a/packages/multi-tenancy/test/multi-tenancy.test.ts
+++ b/packages/multi-tenancy/test/multi-tenancy.test.ts
@@ -224,6 +224,84 @@ describe("Multi-Tenancy", () => {
     );
   });
 
+  it("should not bypass org filtering when token is org-scoped, even with admin:organizations", async () => {
+    // Regression: an org-scoped token (org_id present) carrying admin:organizations
+    // got that permission via an org role, not a global one. It must not see tenants
+    // the user has no membership for.
+    await adapters.tenants.create({
+      id: "user-tenant",
+      friendly_name: "User Tenant",
+      audience: "https://user.example.com",
+      sender_email: "support@user.com",
+      sender_name: "User",
+    });
+    await adapters.tenants.create({
+      id: "other-tenant",
+      friendly_name: "Other Tenant",
+      audience: "https://other.example.com",
+      sender_email: "support@other.com",
+      sender_name: "Other",
+    });
+
+    await adapters.organizations.create("control_plane", {
+      id: "user-tenant",
+      name: "user-tenant",
+      display_name: "User Tenant",
+    });
+    await adapters.userOrganizations.create("control_plane", {
+      user_id: testUserId,
+      organization_id: "user-tenant",
+    });
+
+    // Build an isolated app where the auth-middleware stand-in injects a token
+    // with admin:organizations and an org_id (matching the linkfire-style JWT).
+    const orgScopedApp = new Hono<{
+      Bindings: { data: typeof adapters };
+      Variables: {
+        tenant_id: string;
+        organization_id?: string;
+        user?: {
+          sub: string;
+          tenant_id: string;
+          permissions?: string[];
+          org_id?: string;
+        };
+      };
+    }>();
+
+    const multiTenancy = setupMultiTenancy({
+      accessControl: {
+        controlPlaneTenantId: "control_plane",
+        requireOrganizationMatch: false,
+        defaultPermissions: ["tenant:admin"],
+      },
+    });
+
+    orgScopedApp.use("*", async (c, next) => {
+      c.set("tenant_id", "control_plane");
+      c.set("organization_id", "org_linkfire");
+      c.set("user", {
+        sub: testUserId,
+        tenant_id: "control_plane",
+        permissions: ["admin:organizations", "read:tenants"],
+        org_id: "org_linkfire",
+      });
+      await next();
+    });
+    orgScopedApp.use("*", multiTenancy.middleware);
+    orgScopedApp.route("/management", multiTenancy.app);
+
+    const response = await orgScopedApp.request("/management/tenants", {}, env);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(Array.isArray(data.tenants)).toBe(true);
+    const ids = data.tenants.map((t: any) => t.id);
+    expect(ids).toContain("user-tenant");
+    expect(ids).not.toContain("other-tenant");
+    expect(ids).not.toContain("control_plane");
+  });
+
   it("should delete a tenant", async () => {
     // Create test tenant
     await adapters.tenants.create({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an authorization bypass in tenant listing that allowed organization admins with certain permissions to access tenants across organizations when using org-scoped tokens. The endpoint now enforces proper authorization controls and restricts tenant access based on the caller's organization scope.

* **Tests**
  * Added test coverage to validate that organization-scoped tokens receive appropriately filtered tenant results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->