### PR TITLE
Fix client secret overwrite

### DIFF
--- a/.changeset/oidc-jumpcloud-fixes.md
+++ b/.changeset/oidc-jumpcloud-fixes.md
@@ -1,0 +1,9 @@
+---
+"authhero": patch
+---
+
+Fix OIDC connections with providers that require `client_secret_post` (e.g. JumpCloud) and accept arrays for the `aud` claim:
+
+- `PATCH /api/v2/connections/:id` now preserves existing secret fields (`client_secret`, `app_secret`, `twilio_token`) when the request body omits them, matching Auth0's "missing = keep existing" contract. GET responses strip these, so a read→edit→PATCH round-trip from the admin UI no longer silently wipes them.
+- The upstream OAuth2 token exchange in `ExtendedOAuth2Client` now handles both `client_secret_basic` and `client_secret_post` directly (instead of falling through to arctic for Basic) and surfaces the raw upstream response body in thrown errors so `invalid_client` failures from providers like JumpCloud are diagnosable from logs.
+- `idTokenSchema.aud` now accepts a string or an array of strings, per OIDC Core §2.

--- a/.changeset/react-admin-strip-null-refresh-token.md
+++ b/.changeset/react-admin-strip-null-refresh-token.md
@@ -1,0 +1,5 @@
+---
+"@authhero/react-admin": patch
+---
+
+Strip null values from `refresh_token` in the client edit form before PATCHing. The numeric fields (`leeway`, `token_lifetime`, `idle_token_lifetime`) are optional on the server and reject null — untouched fields that were null in the stored record were round-tripping back as null on submit and failing validation.

--- a/apps/react-admin/src/components/clients/edit.tsx
+++ b/apps/react-admin/src/components/clients/edit.tsx
@@ -1408,6 +1408,21 @@ export function ClientEdit() {
       transformed.client_metadata = stringifiedMetadata;
     }
 
+    // Strip null values from refresh_token. The numeric fields (leeway,
+    // token_lifetime, idle_token_lifetime) are .optional() on the server —
+    // null is rejected. NumberInput's parse only fires on user input, so
+    // untouched fields that were null in the stored record round-trip back
+    // as null on submit.
+    if (isPlainObject(transformed.refresh_token)) {
+      const cleaned: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(transformed.refresh_token)) {
+        if (value !== null) {
+          cleaned[key] = value;
+        }
+      }
+      transformed.refresh_token = cleaned;
+    }
+
     return transformed;
   };
 

--- a/packages/authhero/src/routes/management-api/connections.ts
+++ b/packages/authhero/src/routes/management-api/connections.ts
@@ -19,12 +19,18 @@ const connectionsWithTotalsSchema = totalsSchema.extend({
 
 // Auth0 omits secret fields from connection responses — callers must POST/PATCH
 // to set them, and a missing value means "keep existing". Mirror that contract.
+const SECRET_OPTION_FIELDS = [
+  "client_secret",
+  "app_secret",
+  "twilio_token",
+] as const;
+
 function stripConnectionSecrets(connection: Connection): Connection {
   if (!connection.options) return connection;
   const options = { ...connection.options };
-  delete options.client_secret;
-  delete options.app_secret;
-  delete options.twilio_token;
+  for (const field of SECRET_OPTION_FIELDS) {
+    delete options[field];
+  }
   return { ...connection, options };
 }
 
@@ -251,6 +257,20 @@ export const connectionRoutes = new OpenAPIHono<{
       const tenantId = ctx.var.tenant_id;
 
       const connectionBefore = await ctx.env.data.connections.get(tenantId, id);
+
+      // GET responses strip secrets, so a read→edit→PATCH round-trip would
+      // otherwise wipe them. Preserve existing secret fields when the caller
+      // didn't send a new value, matching Auth0's "missing = keep" contract.
+      if (body.options && connectionBefore?.options) {
+        for (const field of SECRET_OPTION_FIELDS) {
+          if (
+            body.options[field] === undefined &&
+            connectionBefore.options[field] !== undefined
+          ) {
+            body.options[field] = connectionBefore.options[field];
+          }
+        }
+      }
 
       const result = await ctx.env.data.connections.update(tenantId, id, body);
       if (!result) {

--- a/packages/authhero/src/routes/management-api/connections.ts
+++ b/packages/authhero/src/routes/management-api/connections.ts
@@ -261,18 +261,27 @@ export const connectionRoutes = new OpenAPIHono<{
       // GET responses strip secrets, so a read→edit→PATCH round-trip would
       // otherwise wipe them. Preserve existing secret fields when the caller
       // didn't send a new value, matching Auth0's "missing = keep" contract.
+      // Build a separate patch payload so the original `body` stays free of
+      // backfilled secrets for audit logging.
+      let patchBody = body;
       if (body.options && connectionBefore?.options) {
+        const mergedOptions = { ...body.options };
         for (const field of SECRET_OPTION_FIELDS) {
           if (
-            body.options[field] === undefined &&
+            mergedOptions[field] === undefined &&
             connectionBefore.options[field] !== undefined
           ) {
-            body.options[field] = connectionBefore.options[field];
+            mergedOptions[field] = connectionBefore.options[field];
           }
         }
+        patchBody = { ...body, options: mergedOptions };
       }
 
-      const result = await ctx.env.data.connections.update(tenantId, id, body);
+      const result = await ctx.env.data.connections.update(
+        tenantId,
+        id,
+        patchBody,
+      );
       if (!result) {
         throw new HTTPException(404, {
           message: "Connection not found",

--- a/packages/authhero/src/strategies/internal-oauth2.ts
+++ b/packages/authhero/src/strategies/internal-oauth2.ts
@@ -1,22 +1,17 @@
 import { OAuth2Client, OAuth2Tokens, OAuth2RequestError } from "arctic";
 
 /**
- * Extends arctic's `OAuth2Client` to support `client_secret_post` at the token
- * endpoint. Arctic only supports `client_secret_basic` (HTTP Basic), which is
- * rejected by providers like JumpCloud that require POST-body credentials.
- *
- * The auth-URL builder, PKCE handling, and `OAuth2Tokens` shape are inherited
- * unchanged. Only `validateAuthorizationCode` is overridden — and only when
- * `client_secret_post` is requested with a non-null client password.
+ * Extends arctic's `OAuth2Client` so we own the token-endpoint exchange. We
+ * support both `client_secret_basic` (HTTP Basic) and `client_secret_post`
+ * (credentials in form body), and always surface the upstream response body in
+ * thrown errors — arctic discards it, which makes diagnosing `invalid_client`
+ * from providers like JumpCloud nearly impossible.
  */
 export type TokenEndpointAuthMethod =
   | "client_secret_basic"
   | "client_secret_post";
 
 export class ExtendedOAuth2Client extends OAuth2Client {
-  // Arctic marks its fields as private in d.ts, so we track our own copies for
-  // the override path. The base class still has the same values for its own
-  // basic-auth path via super().
   private readonly _clientId: string;
   private readonly _clientPassword: string | null;
   private readonly _redirectURI: string | null;
@@ -40,17 +35,6 @@ export class ExtendedOAuth2Client extends OAuth2Client {
     code: string,
     codeVerifier: string | null,
   ): Promise<OAuth2Tokens> {
-    if (
-      this._clientPassword === null ||
-      this.tokenEndpointAuthMethod === "client_secret_basic"
-    ) {
-      return super.validateAuthorizationCode(
-        tokenEndpoint,
-        code,
-        codeVerifier,
-      );
-    }
-
     const body = new URLSearchParams();
     body.set("grant_type", "authorization_code");
     body.set("code", code);
@@ -60,30 +44,44 @@ export class ExtendedOAuth2Client extends OAuth2Client {
     if (codeVerifier !== null) {
       body.set("code_verifier", codeVerifier);
     }
-    body.set("client_id", this._clientId);
-    body.set("client_secret", this._clientPassword);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    };
+
+    if (
+      this._clientPassword !== null &&
+      this.tokenEndpointAuthMethod === "client_secret_post"
+    ) {
+      body.set("client_id", this._clientId);
+      body.set("client_secret", this._clientPassword);
+    } else if (this._clientPassword !== null) {
+      const credentials = btoa(`${this._clientId}:${this._clientPassword}`);
+      headers.Authorization = `Basic ${credentials}`;
+    } else {
+      body.set("client_id", this._clientId);
+    }
 
     const response = await fetch(tokenEndpoint, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Accept: "application/json",
-      },
+      headers,
       body: body.toString(),
     });
 
+    const rawBody = await response.text();
     let data: unknown;
     try {
-      data = await response.json();
+      data = JSON.parse(rawBody);
     } catch {
       throw new Error(
-        `Token endpoint returned non-JSON response (${response.status})`,
+        `Token endpoint returned non-JSON response (${response.status}): ${rawBody}`,
       );
     }
 
     if (typeof data !== "object" || data === null) {
       throw new Error(
-        `Token endpoint returned unexpected body (${response.status})`,
+        `Token endpoint returned unexpected body (${response.status}): ${rawBody}`,
       );
     }
 
@@ -92,9 +90,9 @@ export class ExtendedOAuth2Client extends OAuth2Client {
       const errorCode =
         typeof err.error === "string" ? err.error : `http_${response.status}`;
       const description =
-        typeof err.error_description === "string"
-          ? err.error_description
-          : null;
+        typeof err.error_description === "string" && err.error_description
+          ? `${err.error_description} (body: ${rawBody})`
+          : rawBody;
       throw new OAuth2RequestError(errorCode, description, null, null);
     }
 

--- a/packages/authhero/src/types/IdToken.ts
+++ b/packages/authhero/src/types/IdToken.ts
@@ -4,7 +4,8 @@ export const idTokenSchema = z
   .object({
     iss: z.string().url(),
     sub: z.string(),
-    aud: z.string(),
+    // OIDC Core §2: `aud` is either a string or an array of strings.
+    aud: z.union([z.string(), z.array(z.string())]),
     exp: z.number(),
     email: z.string().optional(),
     given_name: z.string().optional(),

--- a/packages/authhero/test/routes/management-api/connections.spec.ts
+++ b/packages/authhero/test/routes/management-api/connections.spec.ts
@@ -426,4 +426,71 @@ describe("connections", () => {
       expect(conn.options?.twilio_token).toBeUndefined();
     }
   });
+
+  it("should preserve existing secrets when PATCH omits them", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+
+    const token = await getAdminToken();
+
+    const createResponse = await managementClient.connections.$post(
+      {
+        json: {
+          name: "jumpcloud",
+          strategy: "oidc",
+          options: {
+            client_id: "jc-client",
+            client_secret: "jc-secret",
+            app_secret: "app-secret",
+            twilio_token: "twilio-secret",
+            token_endpoint_auth_method: "client_secret_post",
+          },
+        },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(createResponse.status).toBe(201);
+    const created = (await createResponse.json()) as Connection;
+
+    // PATCH with options but no secret fields — secrets must survive.
+    const patchResponse = await managementClient.connections[":id"].$patch(
+      {
+        param: { id: created.id },
+        json: {
+          options: {
+            client_id: "jc-client",
+            token_endpoint_auth_method: "client_secret_basic",
+          },
+        },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(patchResponse.status).toBe(200);
+
+    const stored = await env.data.connections.get("tenantId", created.id);
+    expect(stored?.options?.client_secret).toBe("jc-secret");
+    expect(stored?.options?.app_secret).toBe("app-secret");
+    expect(stored?.options?.twilio_token).toBe("twilio-secret");
+    expect(stored?.options?.token_endpoint_auth_method).toBe(
+      "client_secret_basic",
+    );
+
+    // PATCH that explicitly sets a new secret must overwrite the old one.
+    const rotateResponse = await managementClient.connections[":id"].$patch(
+      {
+        param: { id: created.id },
+        json: { options: { client_secret: "rotated" } },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(rotateResponse.status).toBe(200);
+
+    const rotated = await env.data.connections.get("tenantId", created.id);
+    expect(rotated?.options?.client_secret).toBe("rotated");
+    expect(rotated?.options?.app_secret).toBe("app-secret");
+    expect(rotated?.options?.twilio_token).toBe("twilio-secret");
+  });
 });

--- a/packages/authhero/test/schema/id-token.spec.ts
+++ b/packages/authhero/test/schema/id-token.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { idTokenSchema } from "../../src/types/IdToken";
+
+describe("idTokenSchema", () => {
+  const base = {
+    iss: "https://idp.example.com/",
+    sub: "user-123",
+    exp: 1_700_000_000,
+    iat: 1_699_999_000,
+  };
+
+  it("accepts aud as a string", () => {
+    const parsed = idTokenSchema.parse({ ...base, aud: "client-a" });
+    expect(parsed.aud).toBe("client-a");
+  });
+
+  // OIDC Core §2 allows `aud` to be an array of strings — providers like
+  // JumpCloud emit this when the id_token is intended for multiple audiences.
+  it("accepts aud as an array of strings", () => {
+    const parsed = idTokenSchema.parse({
+      ...base,
+      aud: ["client-a", "client-b"],
+    });
+    expect(parsed.aud).toEqual(["client-a", "client-b"]);
+  });
+
+  it("rejects aud values that are neither string nor string[]", () => {
+    expect(() => idTokenSchema.parse({ ...base, aud: 42 })).toThrow();
+    expect(() => idTokenSchema.parse({ ...base, aud: [1, 2] })).toThrow();
+  });
+});

--- a/packages/authhero/test/strategies/internal-oauth2.spec.ts
+++ b/packages/authhero/test/strategies/internal-oauth2.spec.ts
@@ -79,7 +79,7 @@ describe("ExtendedOAuth2Client", () => {
       );
     });
 
-    it("defaults to client_secret_basic (delegates to arctic)", async () => {
+    it("defaults to client_secret_basic (Authorization: Basic header)", async () => {
       const client = new ExtendedOAuth2Client(
         "client-id",
         "s3cret",
@@ -94,7 +94,7 @@ describe("ExtendedOAuth2Client", () => {
       expect(captured).toHaveLength(1);
       const [req] = captured;
       expect(req.method).toBe("POST");
-      // Arctic uses HTTP Basic auth — the credentials live in the Authorization header.
+      // Credentials must be in the Authorization header, not in the body.
       expect(req.headers["authorization"]).toBe(
         `Basic ${btoa("client-id:s3cret")}`,
       );
@@ -128,7 +128,7 @@ describe("ExtendedOAuth2Client", () => {
       expect(req.body.get("code_verifier")).toBe("verifier");
     });
 
-    it("delegates to arctic for public clients regardless of auth method", async () => {
+    it("sends client_id in body and no Authorization header for public clients", async () => {
       const client = new ExtendedOAuth2Client(
         "public-client",
         null,
@@ -149,15 +149,57 @@ describe("ExtendedOAuth2Client", () => {
   });
 
   describe("validateAuthorizationCode errors", () => {
-    it("throws OAuth2RequestError on RFC-6749 error response", async () => {
-      captureFetch(
-        jsonResponse(
-          {
-            error: "invalid_client",
-            error_description: "Client authentication failed",
-          },
-          401,
-        ),
+    it("throws OAuth2RequestError with raw body appended to description", async () => {
+      const responseBody = {
+        error: "invalid_client",
+        error_description: "Client authentication failed",
+        error_hint: "method 'client_secret_basic' was requested",
+      };
+      captureFetch(jsonResponse(responseBody, 401));
+
+      const client = new ExtendedOAuth2Client(
+        "client-id",
+        "s3cret",
+        "https://app/callback",
+        "client_secret_post",
+      );
+      const err = await client
+        .validateAuthorizationCode("https://idp/token", "code", null)
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(OAuth2RequestError);
+      const oauthErr = err as OAuth2RequestError;
+      expect(oauthErr.code).toBe("invalid_client");
+      // Description preserves the upstream error_description AND the full body
+      // so non-standard fields like `error_hint` survive into logs.
+      expect(oauthErr.description).toContain("Client authentication failed");
+      expect(oauthErr.description).toContain("client_secret_basic");
+    });
+
+    it("falls back to raw body when error_description is missing", async () => {
+      captureFetch(jsonResponse({ error: "invalid_request" }, 400));
+
+      const client = new ExtendedOAuth2Client(
+        "client-id",
+        "s3cret",
+        "https://app/callback",
+        "client_secret_post",
+      );
+      const err = (await client
+        .validateAuthorizationCode("https://idp/token", "code", null)
+        .catch((e: unknown) => e)) as OAuth2RequestError;
+
+      expect(err).toBeInstanceOf(OAuth2RequestError);
+      expect(err.code).toBe("invalid_request");
+      expect(err.description).toContain("invalid_request");
+    });
+
+    it("throws a descriptive error for non-JSON responses", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("<html>Bad Gateway</html>", {
+          status: 502,
+          headers: { "content-type": "text/html" },
+        }),
       );
 
       const client = new ExtendedOAuth2Client(
@@ -168,7 +210,7 @@ describe("ExtendedOAuth2Client", () => {
       );
       await expect(
         client.validateAuthorizationCode("https://idp/token", "code", null),
-      ).rejects.toBeInstanceOf(OAuth2RequestError);
+      ).rejects.toThrow(/Bad Gateway/);
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing connection secret values when editing/updating connections
  * Prevent client config forms from sending null where numeric fields are rejected
  * Ensure OAuth2 client auth works for providers requiring secrets in the form body

* **New Features**
  * Accept `aud` as either a string or an array per OIDC Core
  * Include upstream token-response details in error messages to aid debugging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/markusahlstrand/authhero/pull/832)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->