### PR TITLE
feat(emails): pass tenantId and language to email adapter via data

### DIFF
--- a/packages/authhero/src/emails/index.ts
+++ b/packages/authhero/src/emails/index.ts
@@ -72,10 +72,11 @@ export async function sendEmail(
     );
     await logMessage(ctx, ctx.var.tenant_id, {
       type: LogTypes.FAILED_SENDING_NOTIFICATION,
-      description: `email send failed via ${emailProvider.name}: ${errorMessage}`.slice(
-        0,
-        500,
-      ),
+      description:
+        `email send failed via ${emailProvider.name}: ${errorMessage}`.slice(
+          0,
+          500,
+        ),
       details: {
         provider: emailProvider.name,
         template: params.template,
@@ -138,10 +139,11 @@ export async function sendSms(
     );
     await logMessage(ctx, ctx.var.tenant_id, {
       type: LogTypes.FAILED_SENDING_NOTIFICATION,
-      description: `sms send failed via ${smsProvider.name}: ${errorMessage}`.slice(
-        0,
-        500,
-      ),
+      description:
+        `sms send failed via ${smsProvider.name}: ${errorMessage}`.slice(
+          0,
+          500,
+        ),
       details: {
         connection: smsProvider.name,
         to: params.to,
@@ -267,6 +269,8 @@ export async function sendResetPassword(
   const passwordResetUrl = `${getUniversalLoginUrl(ctx.env)}reset-password?state=${state}&code=${code}`;
 
   const data: Record<string, string> = {
+    tenantId: tenant.id,
+    language: language || "en",
     vendorName: tenant.friendly_name,
     logo,
     passwordResetUrl,
@@ -290,7 +294,6 @@ export async function sendResetPassword(
     contactUs: t("contact_us", options),
     copyright: t("copyright", options),
     tenantName: tenant.friendly_name,
-    tenantId: tenant.id,
   };
 
   await sendTemplatedEmail(ctx, {
@@ -324,6 +327,8 @@ export async function sendResetPasswordCode(
   );
 
   const data: Record<string, string> = {
+    tenantId: tenant.id,
+    language: language || "en",
     code,
     vendorName: tenant.friendly_name,
     logo,
@@ -406,6 +411,8 @@ export async function sendCode(
 
   if (connectionType === "email") {
     const data: Record<string, string> = {
+      tenantId: tenant.id,
+      language: language || "en",
       code,
       vendorName: tenant.friendly_name,
       logo,
@@ -514,6 +521,8 @@ export async function sendLink(
 
   if (connectionType === "email") {
     const data: Record<string, string> = {
+      tenantId: tenant.id,
+      language: language || "en",
       code,
       vendorName: tenant.friendly_name,
       logo,
@@ -596,6 +605,8 @@ export async function sendValidateEmailAddress(
   const emailValidationUrl = `${getUniversalLoginUrl(ctx.env)}validate-email`;
 
   const data: Record<string, string> = {
+    tenantId: tenant.id,
+    language: language || "en",
     vendorName: tenant.friendly_name,
     logo,
     emailValidationUrl,
@@ -651,6 +662,8 @@ export async function sendSignupValidateEmailAddress(
   const signupUrl = `${getUniversalLoginUrl(ctx.env)}signup?state=${state}&code=${code}`;
 
   const data: Record<string, string> = {
+    tenantId: tenant.id,
+    language: language || "en",
     vendorName: tenant.friendly_name,
     logo,
     signupUrl,


### PR DESCRIPTION
## Summary

- Adds `tenantId` (the resolved `tenant.id`) and `language` (the request's resolved language, defaulting to `"en"`) to the `data: Record<string, string>` argument handed to `EmailServiceAdapter.send()`.
- Updated in six `emails/index.ts` send functions: `sendResetPassword`, `sendResetPasswordCode`, `sendCode` (email branch), `sendLink` (email branch), `sendValidateEmailAddress`, `sendSignupValidateEmailAddress`.
- Lets host apps route to vendor-driven template renderers (templater2 etc.) by `vendorId`/`language` without extending `EmailServiceSendParams`.
- For `sendResetPassword`, the existing `tenantId: tenant.id` line was relocated to the top of the dict alongside the new `language` entry — net result unchanged, just consolidated.
- Companion PR in [sesamyab/auth#1576](https://github.com/sesamyab/auth/pull/1576) consumes these fields in a new shared-sender-queue email adapter.

## Test plan

- [x] All `@authhero/*` package tests pass locally (pre-commit hook).
- [x] End-to-end manual smoke from auth repo: enqueued `auth-code` via the new adapter → templater2 rendered → email arrived in inbox. `tenantId=acme`, `language=sv` confirmed flowing through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error message formatting and truncation logic for email and SMS failure notifications to ensure consistent and reliable error logging behavior.
  * Enhanced template data structure for email sending functionality to consistently provide tenant identification and language preference information across all email notification types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/markusahlstrand/authhero/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->