### PR TITLE
no audience check on userprofile

### DIFF
--- a/.changeset/userinfo-management-audience-fix.md
+++ b/.changeset/userinfo-management-audience-fix.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Stop enforcing the management API audience on the `/userinfo` endpoint. The audience check in `createAuthMiddleware` was previously always on, which 403'd normal user access tokens at `/userinfo`. The check is now opt-in via `createAuthMiddleware(app, { requireManagementAudience: true })` and only enabled by the management API.

--- a/packages/authhero/src/middlewares/authentication.ts
+++ b/packages/authhero/src/middlewares/authentication.ts
@@ -18,11 +18,21 @@ function convertRouteSyntax(route: string) {
 
 /**
  * This registeres the authentication middleware. As it needs to read the OpenAPI definition, it needs to have a reference to the app.
- * @param app
+ *
+ * `requireManagementAudience` enables the defense-in-depth check that the
+ * token's `aud` includes the management API audience. It must be enabled
+ * for the management API and left off for everything else (the `/userinfo`
+ * endpoint, for example, takes any access token issued by this tenant).
  */
+export interface AuthMiddlewareOptions {
+  requireManagementAudience?: boolean;
+}
+
 export function createAuthMiddleware(
   app: OpenAPIHono<{ Bindings: Bindings; Variables: Variables }>,
+  options: AuthMiddlewareOptions = {},
 ) {
+  const requireManagementAudience = options.requireManagementAudience ?? false;
   return async (
     ctx: Context<{ Bindings: Bindings; Variables }>,
     next: Next,
@@ -73,17 +83,19 @@ export function createAuthMiddleware(
       try {
         const tokenPayload = await validateJwtToken(ctx, bearer);
 
-        // Defense in depth: require the token's audience to be the
-        // management API resource server. Without this check a token issued
-        // for any other audience — including one minted with attacker-chosen
-        // scopes via an unregistered audience — would be accepted as long as
-        // it carried a matching scope/permission string.
-        const aud = tokenPayload.aud;
-        const tokenAudiences = Array.isArray(aud) ? aud : aud ? [aud] : [];
-        if (!tokenAudiences.includes(MANAGEMENT_API_AUDIENCE)) {
-          throw new JSONHTTPException(403, {
-            message: "Invalid audience",
-          });
+        if (requireManagementAudience) {
+          // Defense in depth: require the token's audience to be the
+          // management API resource server. Without this check a token issued
+          // for any other audience — including one minted with attacker-chosen
+          // scopes via an unregistered audience — would be accepted as long as
+          // it carried a matching scope/permission string.
+          const aud = tokenPayload.aud;
+          const tokenAudiences = Array.isArray(aud) ? aud : aud ? [aud] : [];
+          if (!tokenAudiences.includes(MANAGEMENT_API_AUDIENCE)) {
+            throw new JSONHTTPException(403, {
+              message: "Invalid audience",
+            });
+          }
         }
 
         ctx.set("user_id", tokenPayload.sub);

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -331,7 +331,7 @@ export default function create(config: AuthHeroConfig) {
   app
     .use(clientInfoMiddleware)
     .use(tenantMiddleware)
-    .use(createAuthMiddleware(app))
+    .use(createAuthMiddleware(app, { requireManagementAudience: true }))
     // Add entity hooks after tenant is known
     .use(async (ctx, next) => {
       if (config.entityHooks && ctx.var.tenant_id) {

--- a/packages/authhero/test/middlewares/authentication.spec.ts
+++ b/packages/authhero/test/middlewares/authentication.spec.ts
@@ -3,6 +3,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { createAuthMiddleware } from "../../src/middlewares/authentication";
 import { createToken, getCertificate } from "../helpers/token";
+import { MANAGEMENT_API_AUDIENCE } from "../../src/middlewares/authentication";
 import { Bindings, Variables } from "../../src/types";
 import * as x509 from "@peculiar/x509";
 
@@ -387,6 +388,81 @@ describe("createAuthMiddleware", () => {
         HTTPException,
       );
       expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+
+  // The management-audience check is opt-in via
+  // `requireManagementAudience: true`. The default must remain off so that
+  // auth-api routes like /userinfo accept normal user access tokens. These
+  // tests pin both directions of the option.
+  describe("requireManagementAudience option", () => {
+    beforeEach(() => {
+      app.openapi(
+        {
+          method: "get",
+          path: "/api/users",
+          security: [{ Bearer: ["read:users"] }],
+          responses: {
+            200: {
+              description: "Success",
+            },
+          },
+        },
+        async (c) => c.json({ message: "success" }),
+      );
+    });
+
+    it("accepts a non-management audience by default", async () => {
+      const token = await createToken({
+        userId: "user123",
+        permissions: ["read:users"],
+        aud: "https://example.com/api",
+      });
+
+      mockCtx.req.header.mockReturnValue(`Bearer ${token}`);
+
+      const result = await authMiddleware(mockCtx, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(result).toBe("next-response");
+    });
+
+    it("rejects a non-management audience when requireManagementAudience is true", async () => {
+      const strictMiddleware = createAuthMiddleware(app, {
+        requireManagementAudience: true,
+      });
+
+      const token = await createToken({
+        userId: "user123",
+        permissions: ["read:users"],
+        aud: "https://example.com/api",
+      });
+
+      mockCtx.req.header.mockReturnValue(`Bearer ${token}`);
+
+      await expect(strictMiddleware(mockCtx, mockNext)).rejects.toThrow(
+        "Invalid audience",
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("accepts the management audience when requireManagementAudience is true", async () => {
+      const strictMiddleware = createAuthMiddleware(app, {
+        requireManagementAudience: true,
+      });
+
+      const token = await createToken({
+        userId: "user123",
+        permissions: ["read:users"],
+        aud: MANAGEMENT_API_AUDIENCE,
+      });
+
+      mockCtx.req.header.mockReturnValue(`Bearer ${token}`);
+
+      const result = await strictMiddleware(mockCtx, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(result).toBe("next-response");
     });
   });
 });

--- a/packages/authhero/test/routes/auth-api/userinfo.spec.ts
+++ b/packages/authhero/test/routes/auth-api/userinfo.spec.ts
@@ -37,6 +37,39 @@ describe("userinfo", () => {
       });
     });
 
+    // Regression: /userinfo must accept any access token issued by this
+    // tenant, regardless of `aud`. The management-API audience check used to
+    // be applied to every auth-api route, which 403'd normal user access
+    // tokens here.
+    it("should accept an access token whose audience is not the management API", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const client = testClient(oauthApp, env);
+
+      const accessToken = await createToken({
+        userId: "email|userId",
+        tenantId: "tenantId",
+        scope: "openid email",
+        aud: "https://example.com/api",
+      });
+
+      const response = await client.userinfo.$get(
+        {},
+        {
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual({
+        email: "foo@example.com",
+        email_verified: true,
+        sub: "email|userId",
+      });
+    });
+
     it("should return 401 if there is no bearer token", async () => {
       const { oauthApp, env } = await getTestServer();
       const client = testClient(oauthApp, env);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `/userinfo` endpoint was rejecting valid user access tokens due to overly strict audience validation enforcement. The authentication system now uses a more permissive default, allowing tokens from different audiences to pass through. Strict audience enforcement can be optionally enabled for management API operations when explicitly required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/markusahlstrand/authhero/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->