### PR TITLE
Temporary lax audience check on users endpoint

### DIFF
--- a/.changeset/audience-validation-and-userinfo-fallback.md
+++ b/.changeset/audience-validation-and-userinfo-fallback.md
@@ -1,0 +1,9 @@
+---
+"authhero": minor
+---
+
+Validate `audience` at `/authorize` and allow audience-less requests.
+
+- `/authorize` now rejects with `access_denied` / `Service not found: <audience>` when the requested `audience` (or tenant `default_audience`) doesn't match a registered resource server. Previously the request proceeded through the full login UI and only failed at token issuance time. Auth0 parity.
+- Audience is no longer required: requests without `audience` (and no tenant `default_audience`) mint a JWT with `aud = ${issuer}userinfo` instead of returning `400 invalid_request`. The token is only useful for `/userinfo`, matching Auth0's no-audience semantics (though authhero's variant is JWT-verifiable, not opaque).
+- `completeLogin` now runs scope validation against the userinfo fallback audience, so requests omitting `audience` can no longer pass arbitrary non-OIDC scopes through unchecked.

--- a/.changeset/users-audience-exemption.md
+++ b/.changeset/users-audience-exemption.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Temporarily exempt `/api/v2/users*` and `/api/v2/users-by-email*` from the management API audience check (added in the previous "validate audience" change). External callers using the legacy audience were hitting 403s on these endpoints. Scope and JWT signature/expiry checks still run as before — only the `aud === urn:authhero:management` equality check is skipped for these prefixes. To be removed once those callers migrate to the new audience.

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -212,17 +212,11 @@ export async function createAuthTokens(
 
   // Audience is normally stamped onto authParams at /authorize (or
   // /oauth/token for client_credentials). Fall back to the tenant's
-  // default_audience here as a safety net for callers that create login
-  // sessions without going through /authorize.
-  const audience = authParams.audience ?? client.tenant.default_audience;
-
-  if (!audience) {
-    throw new JSONHTTPException(400, {
-      error: "invalid_request",
-      error_description:
-        "An audience must be specified in the request or configured as the tenant default_audience",
-    });
-  }
+  // default_audience for callers that create login sessions without going
+  // through /authorize, then to `${iss}userinfo` so audience-less requests
+  // still produce a JWT — Auth0 parity for "I just want login + /userinfo".
+  const audience =
+    authParams.audience ?? client.tenant.default_audience ?? `${iss}userinfo`;
 
   // OIDC Core 5.5 — when the original /authorize request carried a `claims`
   // parameter with a `userinfo` member, the requested claim names need to
@@ -609,15 +603,11 @@ export async function createRefreshToken(
   params: CreateRefreshTokenParams,
 ): Promise<CreatedRefreshToken> {
   const { client, scope, login_id } = params;
-  const audience = params.audience ?? client.tenant.default_audience;
-
-  if (!audience) {
-    throw new JSONHTTPException(400, {
-      error: "invalid_request",
-      error_description:
-        "An audience must be specified in the request or configured as the tenant default_audience",
-    });
-  }
+  // Mirror createAuthTokens: fall back to default_audience, then to the
+  // userinfo aud so audience-less flows can still mint a refresh token.
+  const iss = getIssuer(ctx.env, ctx.var.custom_domain);
+  const audience =
+    params.audience ?? client.tenant.default_audience ?? `${iss}userinfo`;
 
   const idleExpiresAt = lifetimeToIso(client.tenant.idle_session_lifetime);
   const absoluteExpiresAt = lifetimeToIso(client.tenant.session_lifetime);
@@ -1919,8 +1909,15 @@ export async function completeLogin(
   let calculatedPermissions: string[] = [];
   let calculatedTokenLifetime: number | undefined;
 
+  // Fall back to the userinfo aud so the scopes-permissions security check
+  // (which rejects non-OIDC scopes when no resource server matches) still
+  // runs for audience-less requests. Without this fallback, omitting
+  // audience would silently bypass scope validation.
+  const iss = getIssuer(ctx.env, ctx.var.custom_domain);
   const resolvedAudience =
-    params.authParams.audience ?? params.client.tenant.default_audience;
+    params.authParams.audience ??
+    params.client.tenant.default_audience ??
+    `${iss}userinfo`;
 
   if (resolvedAudience) {
     try {

--- a/packages/authhero/src/middlewares/authentication.ts
+++ b/packages/authhero/src/middlewares/authentication.ts
@@ -41,6 +41,22 @@ function scopeForms(scope: string): string[] {
   return reversed === scope ? [scope] : [scope, reversed];
 }
 
+// TODO(audience-migration): Temporary exemption while external callers
+// (e.g. the checkout service hitting /api/v2/users) migrate to issuing
+// tokens with the urn:authhero:management audience. The scope/JWT checks
+// still run — only the audience equality check is skipped for these paths.
+// Remove once those callers have rolled out the new audience config.
+const AUDIENCE_EXEMPT_PREFIXES = [
+  "/api/v2/users",
+  "/api/v2/users-by-email",
+];
+
+function isAudienceExempt(matchedPath: string): boolean {
+  return AUDIENCE_EXEMPT_PREFIXES.some(
+    (prefix) => matchedPath === prefix || matchedPath.startsWith(`${prefix}/`),
+  );
+}
+
 export function createAuthMiddleware(
   app: OpenAPIHono<{ Bindings: Bindings; Variables: Variables }>,
   options: AuthMiddlewareOptions = {},
@@ -96,7 +112,7 @@ export function createAuthMiddleware(
       try {
         const tokenPayload = await validateJwtToken(ctx, bearer);
 
-        if (requireManagementAudience) {
+        if (requireManagementAudience && !isAudienceExempt(matchedPath)) {
           // Defense in depth: require the token's audience to be the
           // management API resource server. Without this check a token issued
           // for any other audience — including one minted with attacker-chosen

--- a/packages/authhero/src/routes/auth-api/authorize.ts
+++ b/packages/authhero/src/routes/auth-api/authorize.ts
@@ -532,6 +532,44 @@ const getRoot = defineRoute({
         }
       }
 
+      // Auth0 parity: reject /authorize when the audience doesn't match a
+      // registered resource server, so the user sees the error before the
+      // login UI rather than after entering credentials. An undefined
+      // audience is allowed — it produces a userinfo-only JWT downstream.
+      if (authParams.audience) {
+        const { resource_servers } = await env.data.resourceServers.list(
+          client.tenant.id,
+        );
+        const audienceMatches = resource_servers.some(
+          (rs) => rs.identifier === authParams.audience,
+        );
+        if (!audienceMatches) {
+          const errorParams: Record<string, string> = {
+            error: "access_denied",
+            error_description: `Service not found: ${authParams.audience}`,
+          };
+          if (state) errorParams.state = state;
+
+          if (sanitizedRedirectUri) {
+            if (response_mode === AuthorizationResponseMode.FORM_POST) {
+              return formPostResponse(
+                sanitizedRedirectUri,
+                errorParams,
+                new Headers(),
+              );
+            }
+            const redirectUrl = new URL(sanitizedRedirectUri);
+            for (const [k, v] of Object.entries(errorParams)) {
+              redirectUrl.searchParams.set(k, v);
+            }
+            return ctx.redirect(redirectUrl.toString());
+          }
+          throw new HTTPException(403, {
+            message: `Service not found: ${authParams.audience}`,
+          });
+        }
+      }
+
       // Fetch the session from cookies
       // Users may have multiple cookies with the same name due to domain/path conflicts,
       // partitioned vs non-partitioned cookies, or browser quirks. Try all cookie values

--- a/packages/authhero/test/authentication-flows/common.spec.ts
+++ b/packages/authhero/test/authentication-flows/common.spec.ts
@@ -99,7 +99,7 @@ describe("common", () => {
       expect(payload.aud).toBe("https://example.com");
     });
 
-    it("should throw when neither authParams.audience nor tenant default_audience is set", async () => {
+    it("falls back to the userinfo aud when neither authParams.audience nor tenant default_audience is set", async () => {
       const { env } = await getTestServer();
 
       // Create a separate tenant without default_audience — the kysely adapter
@@ -145,17 +145,22 @@ describe("common", () => {
       // Sanity-check the fixture: no default_audience on this tenant
       expect(client.tenant.default_audience).toBeUndefined();
 
-      await expect(
-        createAuthTokens(ctx, {
-          authParams: {
-            client_id: "noAudienceClient",
-            response_type: AuthorizationResponseType.TOKEN,
-          },
-          client,
-          user,
-          session_id: "session_id",
-        }),
-      ).rejects.toThrow(/audience/i);
+      const tokens = await createAuthTokens(ctx, {
+        authParams: {
+          client_id: "noAudienceClient",
+          response_type: AuthorizationResponseType.TOKEN,
+        },
+        client,
+        user,
+        session_id: "session_id",
+      });
+
+      // Auth0 parity: no audience yields a JWT scoped to /userinfo.
+      const payload = parseJWT(tokens.access_token!)!.payload as {
+        aud: string;
+        iss: string;
+      };
+      expect(payload.aud).toBe(`${payload.iss}userinfo`);
     });
 
     it("should create an access token and an id token when the response type is token id_token and the openid scope is requested", async () => {

--- a/packages/authhero/test/helpers/test-server.ts
+++ b/packages/authhero/test/helpers/test-server.ts
@@ -159,6 +159,13 @@ export async function getTestServer(
     },
   });
 
+  // Register the tenant's default audience as a resource server so /authorize
+  // doesn't reject test requests with "Service not found".
+  await data.resourceServers.create("tenantId", {
+    name: "Example API",
+    identifier: "https://example.com",
+  });
+
   // Add a test user with OIDC profile claims for testing
   await data.users.create("tenantId", {
     email: "foo@example.com",

--- a/packages/authhero/test/middlewares/authentication.spec.ts
+++ b/packages/authhero/test/middlewares/authentication.spec.ts
@@ -495,4 +495,120 @@ describe("createAuthMiddleware", () => {
       expect(result).toBe("next-response");
     });
   });
+
+  // TODO(audience-migration): Remove once external callers migrate to the
+  // urn:authhero:management audience. Mirrors AUDIENCE_EXEMPT_PREFIXES in
+  // authentication.ts — keep in sync.
+  // Note: middleware strips /api/v2 before looking up the route in the
+  // OpenAPI registry, so we register routes here with their relative paths
+  // (e.g. /users) while matchedRoutes carries the full /api/v2/... path.
+  describe("audience-exempt /api/v2/users* paths", () => {
+    const exemptCases: Array<{ full: string; relative: string }> = [
+      { full: "/api/v2/users", relative: "/users" },
+      { full: "/api/v2/users/", relative: "/users/" },
+      { full: "/api/v2/users/{user_id}", relative: "/users/{user_id}" },
+      {
+        full: "/api/v2/users/{user_id}/identities",
+        relative: "/users/{user_id}/identities",
+      },
+      { full: "/api/v2/users-by-email", relative: "/users-by-email" },
+      { full: "/api/v2/users-by-email/", relative: "/users-by-email/" },
+    ];
+
+    for (const { full, relative } of exemptCases) {
+      it(`accepts a non-management audience for ${full}`, async () => {
+        app.openapi(
+          {
+            method: "get",
+            path: relative,
+            security: [{ Bearer: ["read:users"] }],
+            responses: { 200: { description: "Success" } },
+          },
+          async (c) => c.json({ message: "success" }),
+        );
+
+        const strictMiddleware = createAuthMiddleware(app, {
+          requireManagementAudience: true,
+        });
+
+        const token = await createToken({
+          userId: "user123",
+          permissions: ["read:users"],
+          aud: "https://example.com/api",
+        });
+
+        mockCtx.req.matchedRoutes = [{ method: "GET", path: full }];
+        mockCtx.req.header.mockReturnValue(`Bearer ${token}`);
+
+        const result = await strictMiddleware(mockCtx, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        expect(result).toBe("next-response");
+      });
+    }
+
+    it("still enforces scope on exempt paths", async () => {
+      app.openapi(
+        {
+          method: "get",
+          path: "/users",
+          security: [{ Bearer: ["read:users"] }],
+          responses: { 200: { description: "Success" } },
+        },
+        async (c) => c.json({ message: "success" }),
+      );
+
+      const strictMiddleware = createAuthMiddleware(app, {
+        requireManagementAudience: true,
+      });
+
+      const token = await createToken({
+        userId: "user123",
+        permissions: ["read:posts"],
+        aud: "https://example.com/api",
+      });
+
+      mockCtx.req.matchedRoutes = [
+        { method: "GET", path: "/api/v2/users" },
+      ];
+      mockCtx.req.header.mockReturnValue(`Bearer ${token}`);
+
+      await expect(strictMiddleware(mockCtx, mockNext)).rejects.toThrow(
+        "Unauthorized",
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("does not exempt sibling paths like /api/v2/userinfo", async () => {
+      app.openapi(
+        {
+          method: "get",
+          path: "/userinfo",
+          security: [{ Bearer: ["read:users"] }],
+          responses: { 200: { description: "Success" } },
+        },
+        async (c) => c.json({ message: "success" }),
+      );
+
+      const strictMiddleware = createAuthMiddleware(app, {
+        requireManagementAudience: true,
+      });
+
+      const token = await createToken({
+        userId: "user123",
+        permissions: ["read:users"],
+        aud: "https://example.com/api",
+      });
+
+      mockCtx.req.matchedRoutes = [
+        { method: "GET", path: "/api/v2/userinfo" },
+      ];
+      mockCtx.req.header.mockReturnValue(`Bearer ${token}`);
+
+      await expect(strictMiddleware(mockCtx, mockNext)).rejects.toThrow(
+        "Invalid audience",
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audience parameter is now optional; requests without an audience receive a default userinfo audience.

* **Bug Fixes**
  * Authorization endpoint now validates that requested audiences match configured resource servers, returning `access_denied` when mismatched.
  * Scope validation now runs against fallback audience to prevent security bypass.

* **Chores**
  * Added temporary exemption for specific management API user endpoints from audience validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/markusahlstrand/authhero/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->