### PR TITLE
Add support for fallback to contol plane tokens

### DIFF
--- a/.changeset/service-token-control-plane.md
+++ b/.changeset/service-token-control-plane.md
@@ -1,0 +1,7 @@
+---
+"authhero": patch
+---
+
+`createClientServiceToken` can now fall back to the control-plane tenant when an M2M client isn't registered in the request tenant. The control plane is resolved via the multi-tenancy config's `resolveControlPlane` resolver (when set) or the static `controlPlaneTenantId`, and the grants, signing key, and `tenant_id` claim all follow the tenant where the client lives. A tenant can opt out of inheritance by returning `undefined` from `resolveControlPlane`.
+
+The fallback is gated behind an explicit `allowControlPlaneFallback` option (off by default), so it is only reachable from operator-deployed code (the built-in email/MFA senders and injected email/SMS service adapters). Hook code, Actions, and HTTP/end-user-driven paths cannot cross the tenant boundary into control-plane clients. Even opted-in callers remain bounded by the control-plane client's `client_grant` records.

--- a/apps/docs/security/multi-tenancy.md
+++ b/apps/docs/security/multi-tenancy.md
@@ -55,6 +55,36 @@ Alice in Acme Corp:    Admin  → read:users, write:users, delete:users
 Alice in Widget Inc:   Viewer → read:users
 ```
 
+## Control-Plane Service Tokens
+
+Some machine-to-machine (M2M) clients — for example the auth service's own email and SMS senders — are registered **once in the control-plane tenant** rather than duplicated into every request tenant. When AuthHero needs to mint a service token for such a client, it first looks for the client in the request tenant and, only if it's missing there, falls back to resolving it against the control plane.
+
+When the fallback fires, the resulting token is minted **in the tenant where the client actually lives**: the `client_grant` records, the signing key, and the `tenant_id` claim all follow the control-plane tenant, not the request tenant.
+
+### How the control plane is resolved
+
+The control plane comes from `multiTenancyConfig` (set by `withRuntimeFallback` in the `@authhero/multi-tenancy` package):
+
+- `resolveControlPlane({ tenant_id })` — a per-tenant resolver, when configured. Returning `undefined` **opts that tenant out** of control-plane inheritance.
+- `controlPlaneTenantId` — the static fallback used when no resolver is set.
+
+If neither is configured, there is no fallback and the token mint fails closed with `Client not found`.
+
+### Trust boundary
+
+The fallback deliberately crosses the tenant-isolation boundary, so it is **gated to operator-deployed code only**. It is reachable from:
+
+- AuthHero's built-in email/MFA senders.
+- Custom email/SMS service adapters that the operator injects at deploy time (these choose the `clientId`).
+
+It is **not** reachable from tenant-supplied or externally driven code:
+
+- **Hook code** (the `token.createServiceToken(...)` API passed to webhooks/code hooks) never enables the fallback — a hook cannot mint a token in the control plane.
+- **Actions** (credentials-exchange code hooks) get an even narrower surface: their token API is hardwired to the request tenant and cannot name a `clientId` at all.
+- Nothing reachable over **HTTP / end-user input** can trigger it — the minter is an in-process function, never exposed on a route.
+
+On top of all of this, even an opted-in caller is still bounded by `client_grant` records: it can only obtain a token for an `(audience, scope)` the control-plane client is actually granted. The fallback expands *which tenant* a trusted caller can mint in — it never expands *what* can be minted.
+
 ## The Multi-Tenancy Package
 
 For advanced multi-tenancy (per-customer databases, subdomain routing, settings inheritance), use the `@authhero/multi-tenancy` package.

--- a/packages/authhero/src/authentication-flows/mfa.ts
+++ b/packages/authhero/src/authentication-flows/mfa.ts
@@ -143,7 +143,9 @@ export async function sendMfaOtp(
         tenantId: tenant.id,
       },
       createServiceToken: async (p) => {
-        const token = await createClientServiceToken(ctx, tenant.id, p);
+        const token = await createClientServiceToken(ctx, tenant.id, p, {
+          allowControlPlaneFallback: true,
+        });
         return token.access_token;
       },
     });

--- a/packages/authhero/src/emails/index.ts
+++ b/packages/authhero/src/emails/index.ts
@@ -26,7 +26,9 @@ function buildCreateServiceToken(
   tenantId: string,
 ): CreateServiceTokenFn {
   return async (p) => {
-    const token = await createClientServiceToken(ctx, tenantId, p);
+    const token = await createClientServiceToken(ctx, tenantId, p, {
+      allowControlPlaneFallback: true,
+    });
     return token.access_token;
   };
 }

--- a/packages/authhero/src/helpers/service-token.ts
+++ b/packages/authhero/src/helpers/service-token.ts
@@ -192,6 +192,35 @@ export interface CreateClientServiceTokenParams {
 }
 
 /**
+ * Resolve the control-plane tenant for a given request tenant, honoring a
+ * per-tenant `resolveControlPlane` resolver when configured and falling back to
+ * the static `controlPlaneTenantId`. Returns `undefined` when the tenant opts
+ * out of control-plane inheritance or no control plane is configured.
+ */
+async function resolveControlPlaneTenantId(
+  ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
+  tenantId: string,
+): Promise<string | undefined> {
+  const config = ctx.env.data.multiTenancyConfig;
+  if (config?.resolveControlPlane) {
+    const resolved = await config.resolveControlPlane({ tenant_id: tenantId });
+    return resolved?.tenantId;
+  }
+  return config?.controlPlaneTenantId;
+}
+
+export interface CreateClientServiceTokenOptions {
+  /**
+   * When the client isn't found in the request tenant, resolve it against the
+   * configured control-plane tenant and mint there instead. Off by default so
+   * that the hook-facing token API (`createTokenAPI`) cannot reach across the
+   * tenant boundary into control-plane clients — only trusted internal callers
+   * (e.g. the auth service's own email/SMS senders) opt in.
+   */
+  allowControlPlaneFallback?: boolean;
+}
+
+/**
  * In-process mint of a grant-bounded access token for a DB-registered M2M
  * client. The caller is trusted (running inside the Worker) so no client
  * secret is required — authorization is governed by the client's
@@ -205,6 +234,7 @@ export async function createClientServiceToken(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
   tenantId: string,
   params: CreateClientServiceTokenParams,
+  options?: CreateClientServiceTokenOptions,
 ): Promise<ServiceTokenResponse> {
   const { clientId, scope } = params;
 
@@ -213,14 +243,42 @@ export async function createClientServiceToken(
     throw new Error(`Tenant not found: ${tenantId}`);
   }
 
-  const client = await ctx.env.data.clients.get(tenantId, clientId);
+  // M2M service clients (e.g. the auth service's own email sender) are
+  // registered once in the control-plane tenant, not per request-tenant. The
+  // multi-tenancy adapter deliberately does not control-plane-wrap `clients.get`
+  // for storage reads, so when the client isn't found in the request tenant we
+  // resolve it against the control plane and mint there: grants, signing key,
+  // and the `tenant_id` claim all follow the tenant where the client lives.
+  // Gated behind `allowControlPlaneFallback` so only trusted internal callers
+  // can cross the tenant boundary; hook-originated calls never reach it.
+  let effectiveTenantId = tenantId;
+  let client = await ctx.env.data.clients.get(tenantId, clientId);
+  if (!client && options?.allowControlPlaneFallback) {
+    const controlPlaneTenantId = await resolveControlPlaneTenantId(
+      ctx,
+      tenantId,
+    );
+    if (controlPlaneTenantId && controlPlaneTenantId !== tenantId) {
+      const controlPlaneClient = await ctx.env.data.clients.get(
+        controlPlaneTenantId,
+        clientId,
+      );
+      if (controlPlaneClient) {
+        client = controlPlaneClient;
+        effectiveTenantId = controlPlaneTenantId;
+      }
+    }
+  }
   if (!client) {
     throw new Error(`Client not found: ${clientId}`);
   }
 
-  const clientGrantsResponse = await ctx.env.data.clientGrants.list(tenantId, {
-    q: `client_id:"${clientId}"`,
-  });
+  const clientGrantsResponse = await ctx.env.data.clientGrants.list(
+    effectiveTenantId,
+    {
+      q: `client_id:"${clientId}"`,
+    },
+  );
   const grants = clientGrantsResponse.client_grants;
   if (grants.length === 0) {
     throw new Error(`Client has no client_grant: ${clientId}`);
@@ -266,7 +324,7 @@ export async function createClientServiceToken(
 
   const resolvedKeys = await resolveSigningKeys(
     ctx.env.data.keys,
-    tenantId,
+    effectiveTenantId,
     ctx.env.signingKeyMode,
     { purpose: "sign" },
   );
@@ -287,7 +345,7 @@ export async function createClientServiceToken(
     sub: clientId,
     azp: clientId,
     iss: getIssuer(ctx.env),
-    tenant_id: tenantId,
+    tenant_id: effectiveTenantId,
     gty: "client_credentials",
   };
 

--- a/packages/authhero/test/helpers/service-token.spec.ts
+++ b/packages/authhero/test/helpers/service-token.spec.ts
@@ -105,6 +105,139 @@ describe("createClientServiceToken", () => {
     ).rejects.toThrow(/Client not found/);
   });
 
+  it("resolves a control-plane client when absent from the request tenant", async () => {
+    const CONTROL_PLANE_TENANT_ID = "control-plane";
+    const { env } = await getTestServer();
+    await env.data.tenants.create({
+      id: CONTROL_PLANE_TENANT_ID,
+      friendly_name: "Control Plane",
+      audience: "https://control-plane.example.com",
+      default_audience: "https://control-plane.example.com",
+      sender_email: "login@example.com",
+      sender_name: "SenderName",
+    });
+    await env.data.clients.create(CONTROL_PLANE_TENANT_ID, {
+      client_id: "auth-email-sender",
+      client_secret: "secret",
+      name: "auth-email-sender",
+      callbacks: [],
+      allowed_logout_urls: [],
+      web_origins: [],
+    });
+    await env.data.clientGrants.create(CONTROL_PLANE_TENANT_ID, {
+      client_id: "auth-email-sender",
+      audience: "urn:sesamy",
+      scope: ["email:queue"],
+    });
+    env.data.multiTenancyConfig = {
+      controlPlaneTenantId: CONTROL_PLANE_TENANT_ID,
+    };
+    // Request tenant is `tenantId`, which has no `auth-email-sender` client.
+    const ctx = makeCtx(env);
+
+    const result = await createClientServiceToken(
+      ctx,
+      TENANT_ID,
+      {
+        clientId: "auth-email-sender",
+        scope: "email:queue",
+        audience: "urn:sesamy",
+      },
+      { allowControlPlaneFallback: true },
+    );
+
+    const payload = parseJWT(result.access_token)!.payload as Record<
+      string,
+      unknown
+    >;
+    expect(payload.sub).toBe("auth-email-sender");
+    expect(payload.aud).toBe("urn:sesamy");
+    expect(payload.scope).toBe("email:queue");
+    // The token is minted in the tenant where the client actually lives.
+    expect(payload.tenant_id).toBe(CONTROL_PLANE_TENANT_ID);
+  });
+
+  it("does not resolve a control-plane client without allowControlPlaneFallback", async () => {
+    // Guards the hook-facing token API: a caller that does not opt in must
+    // never reach across the tenant boundary into control-plane clients, even
+    // when a control plane is configured and holds the named client.
+    const CONTROL_PLANE_TENANT_ID = "control-plane";
+    const { env } = await getTestServer();
+    await env.data.tenants.create({
+      id: CONTROL_PLANE_TENANT_ID,
+      friendly_name: "Control Plane",
+      audience: "https://control-plane.example.com",
+      default_audience: "https://control-plane.example.com",
+      sender_email: "login@example.com",
+      sender_name: "SenderName",
+    });
+    await env.data.clients.create(CONTROL_PLANE_TENANT_ID, {
+      client_id: "auth-email-sender",
+      client_secret: "secret",
+      name: "auth-email-sender",
+      callbacks: [],
+      allowed_logout_urls: [],
+      web_origins: [],
+    });
+    await env.data.clientGrants.create(CONTROL_PLANE_TENANT_ID, {
+      client_id: "auth-email-sender",
+      audience: "urn:sesamy",
+      scope: ["email:queue"],
+    });
+    env.data.multiTenancyConfig = {
+      controlPlaneTenantId: CONTROL_PLANE_TENANT_ID,
+    };
+    const ctx = makeCtx(env);
+
+    await expect(
+      createClientServiceToken(ctx, TENANT_ID, {
+        clientId: "auth-email-sender",
+        scope: "email:queue",
+        audience: "urn:sesamy",
+      }),
+    ).rejects.toThrow(/Client not found/);
+  });
+
+  it("honors a resolveControlPlane opt-out (resolver returns undefined)", async () => {
+    const { env } = await getTestServer();
+    // Client exists in a would-be control plane, but the resolver opts this
+    // request tenant out, so the fallback must not reach it.
+    await env.data.tenants.create({
+      id: "control-plane",
+      friendly_name: "Control Plane",
+      audience: "https://control-plane.example.com",
+      default_audience: "https://control-plane.example.com",
+      sender_email: "login@example.com",
+      sender_name: "SenderName",
+    });
+    await env.data.clients.create("control-plane", {
+      client_id: "auth-email-sender",
+      client_secret: "secret",
+      name: "auth-email-sender",
+      callbacks: [],
+      allowed_logout_urls: [],
+      web_origins: [],
+    });
+    env.data.multiTenancyConfig = {
+      controlPlaneTenantId: "control-plane",
+      resolveControlPlane: async () => undefined,
+    };
+    const ctx = makeCtx(env);
+
+    await expect(
+      createClientServiceToken(
+        ctx,
+        TENANT_ID,
+        {
+          clientId: "auth-email-sender",
+          scope: "email:queue",
+          audience: "urn:sesamy",
+        },
+        { allowControlPlaneFallback: true },
+      ),
+    ).rejects.toThrow(/Client not found/);
+  });
+
   it("rejects when the client has no client_grant at all", async () => {
     const { env } = await getTestServer();
     await env.data.clients.create(TENANT_ID, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added control-plane fallback for service tokens in multi-tenant deployments. Operator-deployed code can now optionally resolve machine-to-machine clients from the control plane when not found in the request tenant, while maintaining security boundaries.

* **Documentation**
  * Updated multi-tenancy security documentation with control-plane service token behavior and configuration guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/markusahlstrand/authhero/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->