### PR TITLE
Add custom certificates support

### DIFF
--- a/.changeset/admin-cimd-banner.md
+++ b/.changeset/admin-cimd-banner.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": patch
+---
+
+Admin UI: detect CIMD clients (via `client_metadata.cimd === "true"` marker set by the auth backend) and show a banner on the client edit page explaining that configuration is managed via the metadata document URL.

--- a/.changeset/cimd-workers-fixes.md
+++ b/.changeset/cimd-workers-fixes.md
@@ -1,0 +1,8 @@
+---
+"authhero": patch
+---
+
+Fix two issues that broke the CIMD (Client ID Metadata Document) flow end-to-end on Cloudflare Workers + PlanetScale:
+
+- **`ssrfSafeFetch` threw `TypeError` on Workers.** The helper passed `redirect: "error"` to `fetch`, which Workers rejects ("must be one of follow or manual"). Switched to `redirect: "manual"` and reject 3xx responses explicitly so the no-redirect security property is preserved. This unblocks CIMD (`client_id` as a metadata URL) and `request_uri` request objects on Workers — both surfaced as 500s on `/authorize`.
+- **CIMD token issuance failed FK constraint.** `refresh_tokens.client_id` (and `login_sessions.authParams_client_id`) have a FK to `clients` (added 2025-09-16), but CIMD synthesizes the client in memory only. `getEnrichedClient` now idempotently upserts a minimal `clients` row keyed by the CIMD URL as an FK anchor on first use, marked with `client_metadata.cimd: "true"`. Runtime values still come from the freshly-fetched document each request — the stub row is only there to satisfy referential integrity.

--- a/.changeset/client-app-types.md
+++ b/.changeset/client-app-types.md
@@ -1,0 +1,19 @@
+---
+"authhero": patch
+"@authhero/admin": patch
+---
+
+Auth0-style typed clients: pick an app type up front, get the right defaults, see the right fields.
+
+**Backend (`authhero`)**
+- `POST /api/v2/clients` now derives `token_endpoint_auth_method` and `grant_types` from `app_type` when the caller doesn't supply them:
+  - `spa`, `native` → `token_endpoint_auth_method: "none"`, `grant_types: ["authorization_code", "refresh_token"]`, no `client_secret` generated (PKCE-only).
+  - `regular_web` → `token_endpoint_auth_method: "client_secret_basic"`, `grant_types: ["authorization_code", "refresh_token"]`, secret generated.
+  - `non_interactive` → `token_endpoint_auth_method: "client_secret_basic"`, `grant_types: ["client_credentials"]`, secret generated.
+  - Explicit caller values always win.
+- `PATCH /api/v2/clients/:id` rejects with 400 when the target is a CIMD-marked client (`client_metadata.cimd === "true"`) — those are managed via the metadata document.
+- `POST /api/v2/clients` rejects with 400 when `client_id` is a URL — CIMD clients are registered automatically on first `/authorize`.
+
+**Admin UI (`@authhero/admin`)**
+- Client create is now a two-step picker: choose app type (Regular Web / SPA / Native / Machine-to-Machine), then a small form scoped to that type. The selected `app_type` is sent with the create request so the backend defaults kick in.
+- Client edit hides the `client_secret` field for public types (SPA, Native) and CIMD clients; hides Callbacks / Logout URLs / Web Origins for Machine-to-Machine clients.

--- a/.changeset/custom-domain-cert-upload.md
+++ b/.changeset/custom-domain-cert-upload.md
@@ -1,0 +1,13 @@
+---
+"@authhero/adapter-interfaces": minor
+"@authhero/cloudflare-adapter": minor
+"authhero": minor
+---
+
+Add custom domain certificate upload (PEM) for adapters that can terminate TLS at the edge.
+
+- `@authhero/adapter-interfaces`: new `customDomainCertificateUploadSchema` (`{ certificate, private_key }` PEM-validated) and an optional `uploadCertificate(tenant_id, id, cert)` method on `CustomDomainsAdapter`.
+- `@authhero/cloudflare-adapter`: implements `uploadCertificate`, forwarding `custom_certificate` and `custom_key` to Cloudflare's Custom Hostnames API (BYOC). Cert and key are not persisted by authhero.
+- `authhero`: new `PUT /custom-domains/{id}/certificate` management-api route, scoped to `update:custom_domains`. Returns 501 if the configured adapter doesn't implement `uploadCertificate`.
+
+This is an authhero extension beyond Auth0's API surface — Auth0's `self_managed_certs` mode requires customers to run their own reverse proxy. Here we let the Cloudflare edge terminate TLS with a customer-supplied cert.

--- a/.changeset/proxy-immutable-response-headers.md
+++ b/.changeset/proxy-immutable-response-headers.md
@@ -1,0 +1,11 @@
+---
+"@authhero/proxy": patch
+---
+
+Fix `TypeError: Can't modify immutable headers` 500s in the data-plane router on Cloudflare Workers.
+
+Response objects returned by `fetch()` on Workers (and Miniflare/`wrangler dev --local`) have immutable headers — calling `set`/`append`/`delete` on them throws. The response-phase handlers `rewrite_location`, `rewrite_cookies`, `headers`, `cors`, and `cache` all mutated `c.res.headers` in place, which crashed the worker on any upstream response that triggered them (e.g. a 3xx with a Location header through `rewrite_location`).
+
+Tests passed because Hono's `app.request(...)` constructs Responses in-process where headers are mutable; only real Workers traffic hit the constraint.
+
+Each handler now calls a new `ensureMutableResponseHeaders(c)` helper before mutating, which swaps `c.res` for a copy whose headers are a writable `new Headers(...)` (no-op when already mutable). Regression tests simulate the Workers constraint by freezing the fetch-returned Response's header mutators and exercising each handler end-to-end.

--- a/apps/admin/src/auth0DataProvider.ts
+++ b/apps/admin/src/auth0DataProvider.ts
@@ -228,6 +228,10 @@ async function fetchSingleton(
 export interface AuthHeroDataProvider extends DataProvider {
   rotateSigningKeys: () => Promise<void>;
   revokeSigningKey: (kid: string) => Promise<void>;
+  uploadCustomDomainCertificate: (
+    id: string,
+    cert: { certificate: string; private_key: string },
+  ) => Promise<void>;
 }
 
 /**
@@ -2283,6 +2287,17 @@ export default (
         {
           method: "PUT",
           headers: createHeaders(tenantId),
+        },
+      );
+    },
+
+    uploadCustomDomainCertificate: async (id, cert) => {
+      await httpClient(
+        `${apiUrl}/api/v2/custom-domains/${encodeURIComponent(id)}/certificate`,
+        {
+          method: "PUT",
+          headers: createHeaders(tenantId),
+          body: JSON.stringify(cert),
         },
       );
     },

--- a/apps/admin/src/resources/clients/cimd.tsx
+++ b/apps/admin/src/resources/clients/cimd.tsx
@@ -19,7 +19,8 @@ export function CimdBanner() {
       <Info />
       <AlertTitle>Managed via Client ID Metadata Document</AlertTitle>
       <AlertDescription>
-        Configuration is fetched on every request from{" "}
+        This client configuration is read-only. Configuration is fetched on
+        every request from{" "}
         <a
           href={record!.client_id}
           target="_blank"
@@ -28,7 +29,9 @@ export function CimdBanner() {
         >
           {record!.client_id}
         </a>
-        . Edits made here may be overwritten by the document.
+        . PATCH /clients/{"{id}"} is rejected with a 400 — update the document
+        instead. Connections are updated via PATCH /clients/{"{id}"}
+        /connections.
       </AlertDescription>
     </Alert>
   );

--- a/apps/admin/src/resources/clients/cimd.tsx
+++ b/apps/admin/src/resources/clients/cimd.tsx
@@ -1,0 +1,35 @@
+import { useRecordContext } from "ra-core";
+import { Info } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+type ClientLike = {
+  client_id?: string;
+  client_metadata?: Record<string, unknown> | null;
+};
+
+export function isCimdClient(record: ClientLike | undefined): boolean {
+  return record?.client_metadata?.cimd === "true";
+}
+
+export function CimdBanner() {
+  const record = useRecordContext<ClientLike>();
+  if (!isCimdClient(record)) return null;
+  return (
+    <Alert className="mb-4">
+      <Info />
+      <AlertTitle>Managed via Client ID Metadata Document</AlertTitle>
+      <AlertDescription>
+        Configuration is fetched on every request from{" "}
+        <a
+          href={record!.client_id}
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          {record!.client_id}
+        </a>
+        . Edits made here may be overwritten by the document.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/apps/admin/src/resources/clients/create.tsx
+++ b/apps/admin/src/resources/clients/create.tsx
@@ -1,11 +1,121 @@
+import { useState } from "react";
+import { Globe, Monitor, Server, Smartphone } from "lucide-react";
 import { Create, SimpleForm, TextInput } from "@/components/admin";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+type AppType = "spa" | "native" | "regular_web" | "non_interactive";
+
+const APP_TYPES: Array<{
+  id: AppType;
+  label: string;
+  description: string;
+  icon: typeof Globe;
+}> = [
+  {
+    id: "regular_web",
+    label: "Regular Web App",
+    description: "Server-rendered app with a backend that can hold a secret.",
+    icon: Globe,
+  },
+  {
+    id: "spa",
+    label: "Single Page App",
+    description: "Browser-only app (React, Vue, etc.). PKCE, no client secret.",
+    icon: Monitor,
+  },
+  {
+    id: "native",
+    label: "Native App",
+    description: "Mobile or desktop app. PKCE, no client secret.",
+    icon: Smartphone,
+  },
+  {
+    id: "non_interactive",
+    label: "Machine to Machine",
+    description:
+      "Backend service or CLI. Client credentials grant — no user redirects.",
+    icon: Server,
+  },
+];
 
 export function ClientCreate() {
+  const [appType, setAppType] = useState<AppType | null>(null);
+
+  if (!appType) {
+    return (
+      <Create>
+        <div className="flex flex-col gap-4 p-4 max-w-3xl">
+          <div>
+            <h2 className="text-lg font-medium">Choose application type</h2>
+            <p className="text-sm text-muted-foreground">
+              Picks sensible defaults for grant types and auth method. You can
+              change individual fields later.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {APP_TYPES.map((t) => {
+              const Icon = t.icon;
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setAppType(t.id)}
+                  className={cn(
+                    "text-left rounded-lg border p-4 hover:border-primary hover:bg-accent transition-colors",
+                    "flex flex-col gap-2",
+                  )}
+                >
+                  <div className="flex items-center gap-2">
+                    <Icon className="h-5 w-5" />
+                    <span className="font-medium">{t.label}</span>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {t.description}
+                  </p>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </Create>
+    );
+  }
+
+  const isM2M = appType === "non_interactive";
+
   return (
     <Create>
-      <SimpleForm>
+      <SimpleForm defaultValues={{ app_type: appType }}>
+        <div className="flex items-center justify-between gap-4 mb-2">
+          <div>
+            <Label className="text-xs text-muted-foreground">
+              Application type
+            </Label>
+            <div className="text-sm font-medium">
+              {APP_TYPES.find((t) => t.id === appType)?.label}
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setAppType(null)}
+          >
+            Change
+          </Button>
+        </div>
         <TextInput source="name" required />
-        <TextInput source="client_id" required />
+        {!isM2M && (
+          <TextInput
+            source="callbacks"
+            label="Callback URL (optional)"
+            helperText="Where the auth server redirects after login. You can add more later."
+            parse={(v: string) => (v ? [v] : [])}
+            format={(v: string[] | undefined) => (v && v[0]) || ""}
+          />
+        )}
       </SimpleForm>
     </Create>
   );

--- a/apps/admin/src/resources/clients/edit.tsx
+++ b/apps/admin/src/resources/clients/edit.tsx
@@ -8,6 +8,7 @@ import { ConnectionsTab } from "./tabs/connections-tab";
 import { AdvancedTab } from "./tabs/advanced-tab";
 import { RefreshTokensTab } from "./tabs/refresh-tokens-tab";
 import { RawJsonTab } from "./tabs/raw-json-tab";
+import { CimdBanner } from "./cimd";
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -44,6 +45,7 @@ export function ClientEdit() {
   return (
     <Edit mutationMode="pessimistic" transform={transformClient as never}>
       <SimpleForm className="max-w-none">
+        <CimdBanner />
         <UrlTabs defaultValue="details" className="w-full">
           <TabsList>
             <TabsTrigger value="details">Details</TabsTrigger>

--- a/apps/admin/src/resources/clients/shape.ts
+++ b/apps/admin/src/resources/clients/shape.ts
@@ -1,0 +1,50 @@
+import { isCimdClient } from "./cimd";
+
+type ClientLike = {
+  app_type?: string;
+  client_metadata?: Record<string, unknown> | null;
+};
+
+export type ClientShape = {
+  // Whether the client authenticates with a secret (vs. PKCE/public).
+  showSecret: boolean;
+  // Whether the client makes user-agent (browser/native) redirects.
+  showCallbacks: boolean;
+  // Whether the client is externally managed (CIMD / DCR) and locally edited
+  // fields will be overwritten.
+  isExternallyManaged: boolean;
+};
+
+// Mirrors Auth0's app-type model: SPA and Native are public (no secret, no
+// confidential grants); Machine-to-Machine has no user agent so no callbacks
+// apply; Regular Web is the conventional confidential interactive client.
+export function getClientShape(record: ClientLike | undefined): ClientShape {
+  if (isCimdClient(record)) {
+    return {
+      showSecret: false,
+      showCallbacks: true,
+      isExternallyManaged: true,
+    };
+  }
+  switch (record?.app_type) {
+    case "spa":
+    case "native":
+      return {
+        showSecret: false,
+        showCallbacks: true,
+        isExternallyManaged: false,
+      };
+    case "non_interactive":
+      return {
+        showSecret: true,
+        showCallbacks: false,
+        isExternallyManaged: false,
+      };
+    default:
+      return {
+        showSecret: true,
+        showCallbacks: true,
+        isExternallyManaged: false,
+      };
+  }
+}

--- a/apps/admin/src/resources/clients/tabs/details-tab.tsx
+++ b/apps/admin/src/resources/clients/tabs/details-tab.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { getClientShape } from "../shape";
 
 const GRANT_TYPE_CHOICES = [
   { id: "implicit", name: "Implicit" },
@@ -182,11 +183,17 @@ function Timestamps() {
 }
 
 export function DetailsTab() {
+  const record = useRecordContext<{
+    id: string;
+    app_type?: string;
+    client_metadata?: Record<string, unknown> | null;
+  }>();
+  const shape = getClientShape(record);
   return (
     <div className="flex flex-col gap-3">
       <TextInput source="id" readOnly />
       <TextInput source="name" />
-      <SecretInput source="client_secret" />
+      {shape.showSecret && <SecretInput source="client_secret" />}
       <BooleanInput
         source="auth0_conformant"
         label="Auth0 Conformant Mode"
@@ -206,12 +213,16 @@ export function DetailsTab() {
       />
       <ClientMetadataInput />
       <GrantTypesInput />
-      <TextArrayInput source="callbacks" label="Callbacks" />
-      <TextArrayInput
-        source="allowed_logout_urls"
-        label="Allowed Logout URLs"
-      />
-      <TextArrayInput source="web_origins" label="Web Origins" />
+      {shape.showCallbacks && (
+        <>
+          <TextArrayInput source="callbacks" label="Callbacks" />
+          <TextArrayInput
+            source="allowed_logout_urls"
+            label="Allowed Logout URLs"
+          />
+          <TextArrayInput source="web_origins" label="Web Origins" />
+        </>
+      )}
       <TextArrayInput source="allowed_clients" label="Allowed Clients" />
       <Timestamps />
     </div>

--- a/apps/admin/src/resources/custom-domains/edit.tsx
+++ b/apps/admin/src/resources/custom-domains/edit.tsx
@@ -2,6 +2,7 @@ import { Edit, SimpleForm } from "@/components/admin";
 import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UrlTabs } from "@/components/ui/url-tabs";
 import { flattenDomainMetadata } from "@/components/custom-domains/domainMetadataUtils";
+import { CertificateTab } from "./tabs/certificate-tab";
 import { DetailsTab } from "./tabs/details-tab";
 import { ProxyTab } from "./tabs/proxy-tab";
 import { RawJsonTab } from "./tabs/raw-json-tab";
@@ -13,11 +14,15 @@ export function DomainEdit() {
         <UrlTabs defaultValue="details" className="w-full">
           <TabsList>
             <TabsTrigger value="details">Details</TabsTrigger>
+            <TabsTrigger value="certificate">Certificate</TabsTrigger>
             <TabsTrigger value="proxy">Proxy</TabsTrigger>
             <TabsTrigger value="raw">Raw</TabsTrigger>
           </TabsList>
           <TabsContent value="details" className="mt-4">
             <DetailsTab />
+          </TabsContent>
+          <TabsContent value="certificate" className="mt-4">
+            <CertificateTab />
           </TabsContent>
           <TabsContent value="proxy" className="mt-4">
             <ProxyTab />

--- a/apps/admin/src/resources/custom-domains/tabs/certificate-tab.tsx
+++ b/apps/admin/src/resources/custom-domains/tabs/certificate-tab.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { useDataProvider, useNotify, useRecordContext, useRefresh } from "ra-core";
+import { ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { AuthHeroDataProvider } from "../../../auth0DataProvider";
+
+interface CustomDomainRecord {
+  id?: string;
+  custom_domain_id?: string;
+}
+
+const PEM_CERT = /-----BEGIN CERTIFICATE-----[\s\S]+-----END CERTIFICATE-----\s*$/;
+const PEM_KEY =
+  /-----BEGIN (?:RSA |EC |ENCRYPTED )?PRIVATE KEY-----[\s\S]+-----END (?:RSA |EC |ENCRYPTED )?PRIVATE KEY-----\s*$/;
+
+export function CertificateTab() {
+  const record = useRecordContext<CustomDomainRecord>();
+  const dataProvider = useDataProvider<AuthHeroDataProvider>();
+  const notify = useNotify();
+  const refresh = useRefresh();
+
+  const [certificate, setCertificate] = useState("");
+  const [privateKey, setPrivateKey] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const id = record?.id ?? record?.custom_domain_id;
+  const certValid = PEM_CERT.test(certificate.trim());
+  const keyValid = PEM_KEY.test(privateKey.trim());
+  const canSubmit = !!id && !busy && certValid && keyValid;
+
+  const handleUpload = async () => {
+    if (!id) return;
+    setBusy(true);
+    try {
+      await dataProvider.uploadCustomDomainCertificate(id, {
+        certificate: certificate.trim(),
+        private_key: privateKey.trim(),
+      });
+      notify("Certificate uploaded", { type: "success" });
+      setCertificate("");
+      setPrivateKey("");
+      refresh();
+    } catch (err) {
+      notify(
+        err instanceof Error
+          ? `Failed to upload certificate: ${err.message}`
+          : "Failed to upload certificate",
+        { type: "error" },
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4 max-w-2xl">
+      <div className="rounded-md border p-4">
+        <h3 className="text-base font-medium">Upload TLS certificate</h3>
+        <p className="text-sm text-muted-foreground">
+          Paste a PEM-encoded certificate (with the full chain, leaf first) and
+          the matching private key. The cert and key are forwarded to the edge
+          and are not stored by authhero. To convert a PFX file:{" "}
+          <code className="font-mono text-xs">
+            openssl pkcs12 -in cert.pfx -nodes -out cert.pem
+          </code>
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="cert-pem" className="text-sm font-medium">
+          Certificate (PEM)
+        </label>
+        <Textarea
+          id="cert-pem"
+          rows={10}
+          spellCheck={false}
+          className="font-mono text-xs"
+          placeholder={"-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"}
+          value={certificate}
+          onChange={(e) => setCertificate(e.target.value)}
+        />
+        {certificate && !certValid && (
+          <span className="text-xs text-destructive">
+            Doesn't look like a PEM-encoded certificate.
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="key-pem" className="text-sm font-medium">
+          Private key (PEM)
+        </label>
+        <Textarea
+          id="key-pem"
+          rows={10}
+          spellCheck={false}
+          className="font-mono text-xs"
+          placeholder={"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"}
+          value={privateKey}
+          onChange={(e) => setPrivateKey(e.target.value)}
+        />
+        {privateKey && !keyValid && (
+          <span className="text-xs text-destructive">
+            Doesn't look like a PEM-encoded private key.
+          </span>
+        )}
+      </div>
+
+      <div>
+        <Button type="button" disabled={!canSubmit} onClick={handleUpload}>
+          <ShieldCheck className="h-4 w-4 mr-1" />
+          {busy ? "Uploading..." : "Upload certificate"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/resources/custom-domains/tabs/certificate-tab.tsx
+++ b/apps/admin/src/resources/custom-domains/tabs/certificate-tab.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import { useDataProvider, useNotify, useRecordContext, useRefresh } from "ra-core";
+import {
+  useDataProvider,
+  useNotify,
+  useRecordContext,
+  useRefresh,
+} from "ra-core";
 import { ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -10,7 +15,8 @@ interface CustomDomainRecord {
   custom_domain_id?: string;
 }
 
-const PEM_CERT = /-----BEGIN CERTIFICATE-----[\s\S]+-----END CERTIFICATE-----\s*$/;
+const PEM_CERT =
+  /-----BEGIN CERTIFICATE-----[\s\S]+-----END CERTIFICATE-----\s*$/;
 const PEM_KEY =
   /-----BEGIN (?:RSA |EC |ENCRYPTED )?PRIVATE KEY-----[\s\S]+-----END (?:RSA |EC |ENCRYPTED )?PRIVATE KEY-----\s*$/;
 
@@ -76,7 +82,9 @@ export function CertificateTab() {
           rows={10}
           spellCheck={false}
           className="font-mono text-xs"
-          placeholder={"-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"}
+          placeholder={
+            "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+          }
           value={certificate}
           onChange={(e) => setCertificate(e.target.value)}
         />
@@ -96,7 +104,9 @@ export function CertificateTab() {
           rows={10}
           spellCheck={false}
           className="font-mono text-xs"
-          placeholder={"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"}
+          placeholder={
+            "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+          }
           value={privateKey}
           onChange={(e) => setPrivateKey(e.target.value)}
         />

--- a/apps/admin/src/resources/settings/tabs/feature-flags-tab.tsx
+++ b/apps/admin/src/resources/settings/tabs/feature-flags-tab.tsx
@@ -46,6 +46,11 @@ export function FeatureFlagsTab() {
         helperText="AuthHero extension (no Auth0 equivalent). When off, /oidc/register is open and any caller can register a client — matches Auth0's behavior. When on, callers must present a valid RFC 7591 Initial Access Token (minted via the management API or the consent flow). Turn this on for self-hosted deployments without rate-limiting in front of /oidc/register."
       />
       <BooleanInput
+        source="flags.client_id_metadata_document_registration"
+        label="Client ID Metadata Document Registration"
+        helperText="Enables Client ID Metadata Documents (CIMD): clients pass an https URL as `client_id`; the authorization server fetches it at request time to discover their metadata, with no pre-registration. Advertised as `client_id_metadata_document_supported` in the OAuth AS metadata. Off by default."
+      />
+      <BooleanInput
         source="flags.enable_idtoken_api2"
         label="Enable ID Token API v2"
       />

--- a/apps/docs/auth0-comparison/index.md
+++ b/apps/docs/auth0-comparison/index.md
@@ -341,7 +341,7 @@ AuthHero provides a per-client `auth0_conformant` flag (default: `true`) to ensu
 | User Management      | ✅              | ✅              |
 | Logs & Analytics     | ✅              | ✅              |
 | Geo Location Data    | ⚠️ Country only | ✅ Full details |
-| Custom Domains       | ✅ Enterprise   | ✅ All plans    |
+| Custom Domains       | ✅ Enterprise   | ✅ All plans, with edge cert upload |
 | Branding             | ✅ Limited      | ✅ Full control |
 | Email Templates      | ✅              | ✅              |
 | Multi-tenant Support | ✅ Enterprise   | ✅ Built-in     |
@@ -508,6 +508,31 @@ GET /api/v2/prompts/custom-text/defaults?language=en&prompt=login
 - `language` is matched on the base locale (e.g. `en-US` resolves to `en`)
 - The response payload is identical across tenants, so it's safe to cache aggressively in the UI
 - The per-tenant `GET /api/v2/prompts/{prompt}/custom-text/{language}` endpoint still returns overrides only (preserving PUT/GET symmetry for Terraform's `auth0/auth0` provider) — the new endpoint is a separate, read-only manifest
+
+This is an AuthHero extension and is not present in Auth0.
+
+### Custom Domain Certificate Upload
+
+**Auth0 Limitation**: Auth0's custom domain feature has two modes — Auth0-managed certificates (issued automatically via Let's Encrypt or Google Trust Services) and self-managed certificates. Critically, neither mode lets you upload your own certificate to Auth0. "Self-managed" means *you* run a reverse proxy (CloudFront, Cloudflare, Akamai, NGINX, …) in front of Auth0 and terminate TLS there — Auth0 never sees the certificate. This has been a [recurring community request](https://community.auth0.com/t/certificate-upload-for-custom-domain/10242) since 2018 and is still not supported.
+
+**AuthHero Solution**: When deployed with the `@authhero/cloudflare-adapter`, AuthHero accepts a PEM-encoded certificate and private key for any custom domain and installs them at the Cloudflare edge via the Custom Hostnames BYOC API. The customer doesn't need to operate a separate reverse proxy.
+
+```http
+PUT /api/v2/custom-domains/{id}/certificate
+Content-Type: application/json
+
+{
+  "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+}
+```
+
+**Key properties**:
+
+- **Edge terminates TLS**: The cert and key are forwarded to Cloudflare and installed on the custom hostname's SSL record. AuthHero does not persist them.
+- **PEM-only**: For a PFX file, convert with `openssl pkcs12 -in cert.pfx -nodes -out cert.pem`. Keeping the upload format narrow avoids shipping a PKCS#12 parser with its legacy-cipher footguns.
+- **Optional capability**: The route returns `501 Not Implemented` if the configured custom-domain adapter doesn't support certificate upload (e.g. running AuthHero without an edge that can terminate TLS for you).
+- **Scope**: Same `update:custom_domains` scope as the other custom-domain management endpoints.
 
 This is an AuthHero extension and is not present in Auth0.
 

--- a/apps/docs/customization/cloudflare-adapter/custom-domains.md
+++ b/apps/docs/customization/cloudflare-adapter/custom-domains.md
@@ -29,6 +29,7 @@ The custom domains adapter provides the following methods:
 - `list(tenantId, params)` - List custom domains with pagination
 - `remove(tenantId, domainId)` - Remove a custom domain
 - `update(tenantId, domainId, data)` - Update a custom domain
+- `uploadCertificate(tenantId, domainId, { certificate, private_key })` - Install a customer-supplied PEM certificate and private key on the Cloudflare custom hostname (BYOC)
 
 ## Usage Example
 
@@ -50,7 +51,27 @@ const { domains, total } = await customDomains.list("tenant-123", {
 
 // Remove a domain
 await customDomains.remove("tenant-123", "domain-id-456");
+
+// Upload a customer-supplied certificate (Cloudflare BYOC)
+await customDomains.uploadCertificate!("tenant-123", "domain-id-456", {
+  certificate: "-----BEGIN CERTIFICATE-----\n...",
+  private_key: "-----BEGIN PRIVATE KEY-----\n...",
+});
 ```
+
+## Bring Your Own Certificate (BYOC)
+
+The adapter exposes an optional `uploadCertificate` method that forwards a PEM-encoded certificate and private key to Cloudflare's Custom Hostnames API. The cert and key are installed at the edge and are never persisted by AuthHero.
+
+The management API exposes this as `PUT /api/v2/custom-domains/{id}/certificate` (scope: `update:custom_domains`). If the configured custom-domain adapter doesn't implement `uploadCertificate`, the route returns `501 Not Implemented`.
+
+To convert a PFX file to the expected PEM format:
+
+```sh
+openssl pkcs12 -in cert.pfx -nodes -out cert.pem
+```
+
+Then split `cert.pem` into the certificate chain (everything between `BEGIN CERTIFICATE` / `END CERTIFICATE` blocks, leaf first) and the private key block.
 
 ## Environment Variables
 

--- a/packages/adapter-interfaces/src/adapters/CustomDomains.ts
+++ b/packages/adapter-interfaces/src/adapters/CustomDomains.ts
@@ -1,5 +1,6 @@
 import {
   CustomDomain,
+  CustomDomainCertificateUpload,
   CustomDomainInsert,
   CustomDomainWithTenantId,
 } from "../types/CustomDomain";
@@ -19,4 +20,13 @@ export interface CustomDomainsAdapter {
     id: string,
     custom_domain: Partial<CustomDomain>,
   ) => Promise<boolean>;
+  // Optional. Implemented by adapters whose edge can terminate TLS with a
+  // customer-supplied certificate (e.g. Cloudflare Custom Hostnames BYOC).
+  // The certificate and key are forwarded to the edge and never persisted
+  // by authhero.
+  uploadCertificate?: (
+    tenant_id: string,
+    id: string,
+    cert: CustomDomainCertificateUpload,
+  ) => Promise<CustomDomain>;
 }

--- a/packages/adapter-interfaces/src/types/CustomDomain.ts
+++ b/packages/adapter-interfaces/src/types/CustomDomain.ts
@@ -59,3 +59,22 @@ export const customDomainWithTenantIdSchema = customDomainSchema.extend({
 export type CustomDomainWithTenantId = z.infer<
   typeof customDomainWithTenantIdSchema
 >;
+
+export const customDomainCertificateUploadSchema = z.object({
+  certificate: z
+    .string()
+    .regex(
+      /-----BEGIN CERTIFICATE-----[\s\S]+-----END CERTIFICATE-----\s*$/,
+      "must be PEM-encoded; include the full certificate chain in leaf-first order",
+    ),
+  private_key: z
+    .string()
+    .regex(
+      /-----BEGIN (?:RSA |EC |ENCRYPTED )?PRIVATE KEY-----[\s\S]+-----END (?:RSA |EC |ENCRYPTED )?PRIVATE KEY-----\s*$/,
+      "must be a PEM-encoded private key",
+    ),
+});
+
+export type CustomDomainCertificateUpload = z.infer<
+  typeof customDomainCertificateUploadSchema
+>;

--- a/packages/adapter-interfaces/src/types/CustomDomain.ts
+++ b/packages/adapter-interfaces/src/types/CustomDomain.ts
@@ -64,13 +64,13 @@ export const customDomainCertificateUploadSchema = z.object({
   certificate: z
     .string()
     .regex(
-      /-----BEGIN CERTIFICATE-----[\s\S]+-----END CERTIFICATE-----\s*$/,
+      /^-----BEGIN CERTIFICATE-----[\s\S]+-----END CERTIFICATE-----\s*$/,
       "must be PEM-encoded; include the full certificate chain in leaf-first order",
     ),
   private_key: z
     .string()
     .regex(
-      /-----BEGIN (?:RSA |EC |ENCRYPTED )?PRIVATE KEY-----[\s\S]+-----END (?:RSA |EC |ENCRYPTED )?PRIVATE KEY-----\s*$/,
+      /-----BEGIN (RSA |EC |ENCRYPTED )?PRIVATE KEY-----[\s\S]+-----END \1PRIVATE KEY-----\s*$/,
       "must be a PEM-encoded private key",
     ),
 });

--- a/packages/authhero/src/adapters/createEncryptedDataAdapter.ts
+++ b/packages/authhero/src/adapters/createEncryptedDataAdapter.ts
@@ -212,7 +212,9 @@ function wrapClientConnections(
     listByClient: async (tenant_id, client_id) => {
       const connections = await base.listByClient(tenant_id, client_id);
       return Promise.all(
-        connections.map((connection) => mapConnection(connection, key, decrypt)),
+        connections.map((connection) =>
+          mapConnection(connection, key, decrypt),
+        ),
       );
     },
     updateByClient: (tenant_id, client_id, connection_ids) =>

--- a/packages/authhero/src/authentication-flows/passwordless.ts
+++ b/packages/authhero/src/authentication-flows/passwordless.ts
@@ -95,11 +95,14 @@ export async function passwordlessGrantUser(
         description: "Rate limit exceeded for passwordless OTP",
       });
       const retryAfterSeconds = decision.retryAfterSeconds;
-      const body: { message: string; code: string; retryAfterSeconds?: number } =
-        {
-          message: "Too many requests",
-          code: "TOO_MANY_REQUESTS",
-        };
+      const body: {
+        message: string;
+        code: string;
+        retryAfterSeconds?: number;
+      } = {
+        message: "Too many requests",
+        code: "TOO_MANY_REQUESTS",
+      };
       if (typeof retryAfterSeconds === "number") {
         body.retryAfterSeconds = retryAfterSeconds;
       }

--- a/packages/authhero/src/helpers/client.ts
+++ b/packages/authhero/src/helpers/client.ts
@@ -115,10 +115,12 @@ async function ensureCimdStubClient(
       grant_types: synthesized.grant_types,
       client_metadata: { cimd: "true" },
     });
-  } catch {
-    // Two concurrent CIMD requests can race the get/create. Either won — the
-    // FK anchor exists. Treat any insert error as benign; if it wasn't a
-    // duplicate, the FK insert later will surface a clearer error.
+  } catch (err) {
+    // Two concurrent CIMD requests can race the get/create. If the row now
+    // exists, the other request won — swallow. Otherwise this was a real
+    // adapter/validation failure and must surface.
+    const raced = await env.data.clients.get(tenantId, synthesized.client_id);
+    if (!raced) throw err;
   }
 }
 

--- a/packages/authhero/src/helpers/client.ts
+++ b/packages/authhero/src/helpers/client.ts
@@ -91,6 +91,37 @@ function enrichClient(
   };
 }
 
+/**
+ * Idempotently insert a minimal `clients` row for a CIMD client so the
+ * `refresh_tokens` / `login_sessions` foreign keys to `clients` are satisfied.
+ * The row is an FK anchor only — runtime values come from the freshly-fetched
+ * metadata document each request. The `client_metadata.cimd: true` marker
+ * identifies stub rows for admin tooling and future cleanup.
+ */
+async function ensureCimdStubClient(
+  env: Bindings,
+  tenantId: string,
+  synthesized: Client,
+): Promise<void> {
+  const existing = await env.data.clients.get(tenantId, synthesized.client_id);
+  if (existing) return;
+  try {
+    await env.data.clients.create(tenantId, {
+      client_id: synthesized.client_id,
+      name: synthesized.name,
+      app_type: synthesized.app_type,
+      is_first_party: false,
+      token_endpoint_auth_method: synthesized.token_endpoint_auth_method,
+      grant_types: synthesized.grant_types,
+      client_metadata: { cimd: "true" },
+    });
+  } catch {
+    // Two concurrent CIMD requests can race the get/create. Either won — the
+    // FK anchor exists. Treat any insert error as benign; if it wasn't a
+    // duplicate, the FK insert later will surface a clearer error.
+  }
+}
+
 export async function getEnrichedClient(
   env: Bindings,
   clientId: string,
@@ -100,7 +131,10 @@ export async function getEnrichedClient(
   // CIMD: the client_id is an https URL hosting the client metadata document.
   // Requires the tenant to be known (resolved from the request host/domain) and
   // the per-tenant flag to be enabled. The document is fetched and validated on
-  // every request — no DB record is created.
+  // every request — the synthesized client is what callers see. A stub row in
+  // `clients` is upserted on first use as an FK anchor for `refresh_tokens` /
+  // `login_sessions` (see migration 2025-09-16T12:30:00); runtime values still
+  // come from the freshly-fetched document, not the stub.
   if (isCimdClientId(clientId)) {
     if (!tenantId) {
       throw new JSONHTTPException(400, {
@@ -116,6 +150,7 @@ export async function getEnrichedClient(
     }
     const synthesized = await resolveCimdClient(clientId, fetchOpts);
     const allConnections = await env.data.connections.list(tenantId);
+    await ensureCimdStubClient(env, tenantId, synthesized);
     return enrichClient(env, synthesized, tenant, allConnections.connections);
   }
 

--- a/packages/authhero/src/middlewares/authentication.ts
+++ b/packages/authhero/src/middlewares/authentication.ts
@@ -127,15 +127,15 @@ export function createAuthMiddleware(
             requestTenantId &&
             tokenTenantId !== requestTenantId
           ) {
-            const cpId =
-              ctx.env.data?.multiTenancyConfig?.controlPlaneTenantId;
+            const cpId = ctx.env.data?.multiTenancyConfig?.controlPlaneTenantId;
             // Multi-tenant deployments must configure a control plane.
             // Single-tenant deployments shouldn't see this branch in practice
             // (there's only one tenant) — fail closed if we land here without
             // a configured control plane.
             if (!cpId || tokenTenantId !== cpId) {
               throw new JSONHTTPException(403, {
-                message: "Cross-tenant management requires a control-plane token",
+                message:
+                  "Cross-tenant management requires a control-plane token",
               });
             }
           }

--- a/packages/authhero/src/routes/management-api/clients.ts
+++ b/packages/authhero/src/routes/management-api/clients.ts
@@ -21,10 +21,25 @@ import { defineRoute } from "../../utils/define-route";
 // grant_types, token_endpoint_auth_method, jwks_uri) get overwritten on the
 // next /authorize, so accepting writes here would be misleading. Detect via
 // the `client_metadata.cimd === "true"` marker set by ensureCimdStubClient.
-function isCimdClient(client: {
-  client_metadata?: Record<string, string> | null;
-} | null): boolean {
-  return client?.client_metadata?.cimd === "true";
+function isCimdClient(
+  client: {
+    client_id?: string;
+    client_metadata?: Record<string, string> | null;
+  } | null,
+): boolean {
+  if (client?.client_metadata?.cimd !== "true") return false;
+  if (!client.client_id) return false;
+  return isCimdClientId(client.client_id);
+}
+
+// External callers must not be able to forge the CIMD marker via
+// client_metadata.cimd. Only ensureCimdStubClient (internal) should set it.
+function stripCimdMetadata<
+  T extends { client_metadata?: Record<string, string> | null },
+>(body: T): T {
+  if (!body.client_metadata) return body;
+  const { cimd: _cimd, ...rest } = body.client_metadata;
+  return { ...body, client_metadata: rest };
 }
 
 // Auth0-parity defaults: when a client is created with an `app_type` but no
@@ -84,8 +99,7 @@ function applyAppTypeDefaults<
       "token_endpoint_auth_method" in raw
         ? body.token_endpoint_auth_method
         : defaults.token_endpoint_auth_method,
-    grant_types:
-      "grant_types" in raw ? body.grant_types : defaults.grant_types,
+    grant_types: "grant_types" in raw ? body.grant_types : defaults.grant_types,
   };
 }
 const clientWithTotalsSchema = totalsSchema.extend({
@@ -287,7 +301,7 @@ const patchById = defineRoute({
     const { id } = ctx.req.valid("param");
     const body = ctx.req.valid("json");
 
-    const clientUpdate = body;
+    const clientUpdate = stripCimdMetadata(body);
 
     const clientBefore = await ctx.env.data.clients.get(tenant_id, id);
     if (isCimdClient(clientBefore)) {
@@ -351,7 +365,7 @@ const postRoot = defineRoute({
   }),
   handler: async (ctx) => {
     const tenant_id = ctx.var.tenant_id;
-    const body = ctx.req.valid("json");
+    const body = stripCimdMetadata(ctx.req.valid("json"));
     const rawBody = (await ctx.req.json().catch(() => ({}))) as Record<
       string,
       unknown

--- a/packages/authhero/src/routes/management-api/clients.ts
+++ b/packages/authhero/src/routes/management-api/clients.ts
@@ -12,8 +12,82 @@ import { logMessage } from "../../helpers/logging";
 import { nanoid } from "nanoid";
 import { querySchema } from "../../types/auth0/Query";
 import { parseSort } from "../../utils/sort";
+import { isCimdClientId } from "../../helpers/cimd";
 
 import { defineRoute } from "../../utils/define-route";
+
+// CIMD clients are managed via their metadata document URL, not the management
+// API. Any locally-stored fields the document controls (name, callbacks,
+// grant_types, token_endpoint_auth_method, jwks_uri) get overwritten on the
+// next /authorize, so accepting writes here would be misleading. Detect via
+// the `client_metadata.cimd === "true"` marker set by ensureCimdStubClient.
+function isCimdClient(client: {
+  client_metadata?: Record<string, string> | null;
+} | null): boolean {
+  return client?.client_metadata?.cimd === "true";
+}
+
+// Auth0-parity defaults: when a client is created with an `app_type` but no
+// explicit `token_endpoint_auth_method` / `grant_types`, derive them from the
+// type. Native and SPA are public (PKCE-only, no secret); Regular Web is
+// confidential with code+refresh; Machine-to-Machine (non_interactive) is
+// confidential with client_credentials only. Explicit values from the caller
+// always win — defaults only fill gaps.
+const APP_TYPE_DEFAULTS: Record<
+  string,
+  {
+    token_endpoint_auth_method:
+      | "none"
+      | "client_secret_post"
+      | "client_secret_basic"
+      | "client_secret_jwt"
+      | "private_key_jwt";
+    grant_types: string[];
+  }
+> = {
+  native: {
+    token_endpoint_auth_method: "none",
+    grant_types: ["authorization_code", "refresh_token"],
+  },
+  spa: {
+    token_endpoint_auth_method: "none",
+    grant_types: ["authorization_code", "refresh_token"],
+  },
+  regular_web: {
+    token_endpoint_auth_method: "client_secret_basic",
+    grant_types: ["authorization_code", "refresh_token"],
+  },
+  non_interactive: {
+    token_endpoint_auth_method: "client_secret_basic",
+    grant_types: ["client_credentials"],
+  },
+};
+
+// Zod fills `app_type`, `token_endpoint_auth_method`, and `grant_types` with
+// schema defaults before we see the body, so we can't tell from the validated
+// value whether the caller meant it. Inspect the raw JSON keys to detect
+// explicit intent, and only derive from app_type when the caller chose one.
+function applyAppTypeDefaults<
+  T extends {
+    app_type?: string;
+    token_endpoint_auth_method?: string;
+    grant_types?: string[];
+  },
+>(body: T, raw: Record<string, unknown>): T {
+  const rawAppType = raw.app_type;
+  if (typeof rawAppType !== "string") return body;
+  const defaults = APP_TYPE_DEFAULTS[rawAppType];
+  if (!defaults) return body;
+  return {
+    ...body,
+    token_endpoint_auth_method:
+      "token_endpoint_auth_method" in raw
+        ? body.token_endpoint_auth_method
+        : defaults.token_endpoint_auth_method,
+    grant_types:
+      "grant_types" in raw ? body.grant_types : defaults.grant_types,
+  };
+}
 const clientWithTotalsSchema = totalsSchema.extend({
   clients: z.array(clientSchema),
 });
@@ -216,6 +290,11 @@ const patchById = defineRoute({
     const clientUpdate = body;
 
     const clientBefore = await ctx.env.data.clients.get(tenant_id, id);
+    if (isCimdClient(clientBefore)) {
+      throw new HTTPException(400, {
+        message: `Client is managed via its Client ID Metadata Document at ${id}. Update the document instead.`,
+      });
+    }
     await ctx.env.data.clients.update(tenant_id, id, clientUpdate);
     const client = await ctx.env.data.clients.get(tenant_id, id);
 
@@ -273,11 +352,29 @@ const postRoot = defineRoute({
   handler: async (ctx) => {
     const tenant_id = ctx.var.tenant_id;
     const body = ctx.req.valid("json");
+    const rawBody = (await ctx.req.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+
+    if (body.client_id && isCimdClientId(body.client_id)) {
+      throw new HTTPException(400, {
+        message:
+          "Cannot create a Client ID Metadata Document client via the management API. CIMD clients are registered automatically on first /authorize.",
+      });
+    }
+
+    const withDefaults = applyAppTypeDefaults(body, rawBody);
+    const isPublic = withDefaults.token_endpoint_auth_method === "none";
 
     const clientCreate = {
-      ...body,
-      client_id: body.client_id || nanoid(),
-      client_secret: body.client_secret || nanoid(),
+      ...withDefaults,
+      client_id: withDefaults.client_id || nanoid(),
+      // Public clients (SPA, Native) authenticate via PKCE and have no secret.
+      // Only generate a secret when the caller will actually use it.
+      client_secret: isPublic
+        ? undefined
+        : withDefaults.client_secret || nanoid(),
     };
 
     const client = await ctx.env.data.clients.create(tenant_id, clientCreate);

--- a/packages/authhero/src/routes/management-api/custom-domains.ts
+++ b/packages/authhero/src/routes/management-api/custom-domains.ts
@@ -3,6 +3,7 @@ import { Bindings, Variables } from "../../types";
 import { HTTPException } from "hono/http-exception";
 import { querySchema } from "../../types";
 import {
+  customDomainCertificateUploadSchema,
   customDomainInsertSchema,
   customDomainSchema,
   LogTypes,
@@ -261,6 +262,68 @@ const postRoot = defineRoute({
   },
 });
 
+const putByIdCertificate = defineRoute({
+  route: createRoute({
+    tags: ["custom-domains"],
+    method: "put",
+    path: "/{id}/certificate",
+    request: {
+      body: {
+        content: {
+          "application/json": {
+            schema: customDomainCertificateUploadSchema,
+          },
+        },
+      },
+      params: z.object({
+        id: z.string(),
+      }),
+      headers: z.object({
+        "tenant-id": z.string().optional(),
+      }),
+    },
+    security: [
+      {
+        Bearer: ["update:custom_domains"],
+      },
+    ],
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: customDomainSchema,
+          },
+        },
+        description:
+          "The custom domain with the uploaded certificate installed at the edge",
+      },
+    },
+  }),
+  handler: async (ctx) => {
+    const { id } = ctx.req.valid("param");
+    const body = ctx.req.valid("json");
+
+    const { uploadCertificate } = ctx.env.data.customDomains;
+    if (!uploadCertificate) {
+      throw new HTTPException(501, {
+        message:
+          "The configured custom-domain adapter does not support certificate upload",
+      });
+    }
+
+    const customDomain = await uploadCertificate(ctx.var.tenant_id, id, body);
+
+    await logMessage(ctx, ctx.var.tenant_id, {
+      type: LogTypes.SUCCESS_API_OPERATION,
+      description: "Upload a Custom Domain Certificate",
+      targetType: "custom_domain",
+      targetId: id,
+    });
+
+    return ctx.json(customDomain);
+  },
+});
+
 const postByIdVerify = defineRoute({
   route: createRoute({
     tags: ["custom-domains"],
@@ -306,5 +369,6 @@ export const customDomainRoutes = new OpenAPIHono<{
   deleteById,
   patchById,
   postRoot,
+  putByIdCertificate,
   postByIdVerify,
 ] as const);

--- a/packages/authhero/src/routes/universal-login/error-page.tsx
+++ b/packages/authhero/src/routes/universal-login/error-page.tsx
@@ -43,7 +43,8 @@ export function ErrorPage({
   darkMode = "auto",
 }: ErrorPageProps) {
   const isInfo = variant === "info";
-  const resolvedTitle = title ?? (isInfo ? "Information" : "Something went wrong");
+  const resolvedTitle =
+    title ?? (isInfo ? "Information" : "Something went wrong");
   const pageBackground = buildThemePageBackground(
     theme?.page_background,
     branding?.colors?.page_background,

--- a/packages/authhero/src/utils/ssrf-fetch.ts
+++ b/packages/authhero/src/utils/ssrf-fetch.ts
@@ -160,12 +160,21 @@ export async function ssrfSafeFetch(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    // Cloudflare Workers' fetch only accepts "follow" or "manual" for
+    // `redirect`; passing "error" throws TypeError at runtime. Use "manual"
+    // and reject 3xx ourselves so the no-redirect property still holds.
     const response = await fetch(url, {
       method: "GET",
-      redirect: "error",
+      redirect: "manual",
       signal: controller.signal,
       headers: { accept: "application/json, application/jwt, text/plain" },
     });
+
+    if (response.status >= 300 && response.status < 400) {
+      throw new SsrfBlockedError(
+        `redirect (status ${response.status}) not allowed`,
+      );
+    }
 
     if (!response.body) {
       return {

--- a/packages/authhero/test/helpers/scopes-permissions.spec.ts
+++ b/packages/authhero/test/helpers/scopes-permissions.spec.ts
@@ -349,16 +349,12 @@ describe("scopes-permissions helper", () => {
           },
         );
 
-        await env.data.userPermissions.create(
-          "tenantId",
-          "strictAuthzUser",
-          {
-            user_id: "strictAuthzUser",
-            resource_server_identifier:
-              "https://strict-authz-rbac-on.example.com",
-            permission_name: "read:users",
-          },
-        );
+        await env.data.userPermissions.create("tenantId", "strictAuthzUser", {
+          user_id: "strictAuthzUser",
+          resource_server_identifier:
+            "https://strict-authz-rbac-on.example.com",
+          permission_name: "read:users",
+        });
 
         const result = await calculateScopesAndPermissions(ctx, {
           tenantId: "tenantId",
@@ -460,16 +456,11 @@ describe("scopes-permissions helper", () => {
           },
         );
 
-        await env.data.userPermissions.create(
-          "tenantId",
-          "looseAuthzUser",
-          {
-            user_id: "looseAuthzUser",
-            resource_server_identifier:
-              "https://loose-authz-rbac-on.example.com",
-            permission_name: "read:users",
-          },
-        );
+        await env.data.userPermissions.create("tenantId", "looseAuthzUser", {
+          user_id: "looseAuthzUser",
+          resource_server_identifier: "https://loose-authz-rbac-on.example.com",
+          permission_name: "read:users",
+        });
 
         const result = await calculateScopesAndPermissions(ctx, {
           tenantId: "tenantId",

--- a/packages/authhero/test/routes/auth-api/cimd.spec.ts
+++ b/packages/authhero/test/routes/auth-api/cimd.spec.ts
@@ -290,4 +290,31 @@ describe("/authorize with a CIMD client_id", () => {
     expect(response.status).toBe(400);
     expect(await response.text()).toMatch(/does not match/);
   });
+
+  it("upserts a stub client row so refresh_token FK is satisfied", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await enableCimd(env);
+    env.ALLOW_PRIVATE_OUTBOUND_FETCH = true;
+    mockFetchJson(validDocument());
+
+    expect(await env.data.clients.get("tenantId", CIMD_URL)).toBeNull();
+
+    const oauthClient = testClient(oauthApp, env);
+    await oauthClient.authorize.$get({
+      query: {
+        client_id: CIMD_URL,
+        redirect_uri: "https://rp.example.com/callback",
+        response_type: "code",
+        scope: "openid",
+        code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+        code_challenge_method: "S256",
+        state: "xyz",
+      },
+    });
+
+    const stub = await env.data.clients.get("tenantId", CIMD_URL);
+    expect(stub).not.toBeNull();
+    expect(stub?.name).toBe("Example MCP Client");
+    expect(stub?.client_metadata?.cimd).toBe("true");
+  });
 });

--- a/packages/authhero/test/routes/auth-api/well-known.spec.ts
+++ b/packages/authhero/test/routes/auth-api/well-known.spec.ts
@@ -285,7 +285,9 @@ describe("jwks", () => {
     const { oauthApp, env } = await getTestServer();
     const client = testClient(oauthApp, env);
 
-    const before = await client[".well-known"]["oauth-authorization-server"].$get(
+    const before = await client[".well-known"][
+      "oauth-authorization-server"
+    ].$get(
       {
         param: {},
       },
@@ -303,7 +305,9 @@ describe("jwks", () => {
       flags: { client_id_metadata_document_registration: true },
     });
 
-    const after = await client[".well-known"]["oauth-authorization-server"].$get(
+    const after = await client[".well-known"][
+      "oauth-authorization-server"
+    ].$get(
       {
         param: {},
       },

--- a/packages/authhero/test/routes/management-api/clients.spec.ts
+++ b/packages/authhero/test/routes/management-api/clients.spec.ts
@@ -404,4 +404,119 @@ describe("clients", () => {
       conn2.id,
     );
   });
+
+  describe("app_type defaults on create", () => {
+    async function create(json: Record<string, unknown>) {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+      const response = await managementClient.clients.$post(
+        { json: json as never, header: { "tenant-id": "tenantId" } },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(response.status).toBe(201);
+      return (await response.json()) as Client;
+    }
+
+    it("derives PKCE/no-secret defaults for SPA", async () => {
+      const client = await create({ name: "spa-app", app_type: "spa" });
+      expect(client.token_endpoint_auth_method).toBe("none");
+      expect(client.client_secret).toBeFalsy();
+      expect(client.grant_types).toEqual([
+        "authorization_code",
+        "refresh_token",
+      ]);
+    });
+
+    it("derives PKCE/no-secret defaults for Native", async () => {
+      const client = await create({
+        name: "native-app",
+        app_type: "native",
+      });
+      expect(client.token_endpoint_auth_method).toBe("none");
+      expect(client.client_secret).toBeFalsy();
+    });
+
+    it("derives confidential defaults for Regular Web", async () => {
+      const client = await create({
+        name: "rw-app",
+        app_type: "regular_web",
+      });
+      expect(client.token_endpoint_auth_method).toBe("client_secret_basic");
+      expect(client.client_secret).toBeTruthy();
+      expect(client.grant_types).toEqual([
+        "authorization_code",
+        "refresh_token",
+      ]);
+    });
+
+    it("derives client_credentials defaults for M2M", async () => {
+      const client = await create({
+        name: "m2m-app",
+        app_type: "non_interactive",
+      });
+      expect(client.token_endpoint_auth_method).toBe("client_secret_basic");
+      expect(client.client_secret).toBeTruthy();
+      expect(client.grant_types).toEqual(["client_credentials"]);
+    });
+
+    it("preserves explicit grant_types over the default", async () => {
+      const client = await create({
+        name: "custom",
+        app_type: "spa",
+        grant_types: ["authorization_code"],
+      });
+      expect(client.grant_types).toEqual(["authorization_code"]);
+    });
+  });
+
+  describe("CIMD client management API restrictions", () => {
+    const CIMD_URL = "https://rp.example.com/cimd.json";
+
+    it("rejects POST with a URL-shaped client_id", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      const response = await managementClient.clients.$post(
+        {
+          json: { client_id: CIMD_URL, name: "Claude" },
+          header: { "tenant-id": "tenantId" },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toMatch(/CIMD/);
+    });
+
+    it("rejects PATCH on a CIMD-marked client", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      // Seed a CIMD-marked client directly via the adapter so we don't have to
+      // drive the /authorize flow just to populate the row.
+      await env.data.clients.create("tenantId", {
+        client_id: CIMD_URL,
+        name: "Claude",
+        client_metadata: { cimd: "true" },
+      });
+
+      // Hono's RPC test client substitutes path params verbatim (no
+      // encoding), so a URL-shaped id needs to be pre-encoded — otherwise its
+      // embedded slashes split the segment and `/clients/:id` never matches.
+      const response = await managementClient.clients[":id"].$patch(
+        {
+          param: { id: encodeURIComponent(CIMD_URL) },
+          json: { name: "Renamed" },
+          header: { "tenant-id": "tenantId" },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toMatch(/metadata document/i);
+    });
+  });
 });

--- a/packages/authhero/test/routes/universal-login/passwords.spec.ts
+++ b/packages/authhero/test/routes/universal-login/passwords.spec.ts
@@ -822,9 +822,9 @@ describe("passwords", () => {
       },
     });
     const location = authorizeResponse.headers.get("location");
-    const state = new URL(
-      `https://example.com${location}`,
-    ).searchParams.get("state");
+    const state = new URL(`https://example.com${location}`).searchParams.get(
+      "state",
+    );
     if (!state) throw new Error("No state found");
 
     const response = await u2Screen(u2App, env, "reset-password/request").$post(

--- a/packages/authhero/test/strategies/saml-response-form.spec.ts
+++ b/packages/authhero/test/strategies/saml-response-form.spec.ts
@@ -9,7 +9,11 @@ describe("samlResponseForm — auto-submit HTML escaping", () => {
   it("escapes a RelayState payload that tries to break out of the attribute", async () => {
     const malicious = `" autofocus onfocus="alert(1)`;
     const html = await bodyText(
-      samlResponseForm("https://sp.example.com/acs", "BASE64SAMLRESPONSE", malicious),
+      samlResponseForm(
+        "https://sp.example.com/acs",
+        "BASE64SAMLRESPONSE",
+        malicious,
+      ),
     );
 
     // The raw payload must NOT appear unescaped in the HTML.

--- a/packages/authhero/test/utils/ssrf-fetch.spec.ts
+++ b/packages/authhero/test/utils/ssrf-fetch.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   assertSsrfSafeUrl,
+  ssrfSafeFetch,
   SsrfBlockedError,
 } from "../../src/utils/ssrf-fetch";
 
@@ -93,5 +94,24 @@ describe("assertSsrfSafeUrl", () => {
 
   it("rejects malformed URLs", () => {
     expect(() => assertSsrfSafeUrl("not-a-url")).toThrow(SsrfBlockedError);
+  });
+});
+
+describe("ssrfSafeFetch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws SsrfBlockedError on a 3xx redirect response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://example.com" },
+      }),
+    );
+
+    await expect(
+      ssrfSafeFetch("https://example.com/.well-known/jwks.json"),
+    ).rejects.toThrow(SsrfBlockedError);
   });
 });

--- a/packages/cloudflare/src/customDomains/index.ts
+++ b/packages/cloudflare/src/customDomains/index.ts
@@ -53,6 +53,7 @@ function extractSslFromMetadata(metadata?: Record<string, string>): {
 function mapCustomDomainResponse(
   result: CustomDomainResult & {
     primary: boolean;
+    type?: CustomDomain["type"];
     domain_metadata?: Record<string, string>;
   },
 ): CustomDomain {
@@ -115,7 +116,7 @@ function mapCustomDomainResponse(
     domain: result.hostname,
     primary: result.primary,
     status: result.status === "active" ? "ready" : "pending",
-    type: "auth0_managed_certs",
+    type: result.type ?? "auth0_managed_certs",
     verification: {
       methods: z.array(verificationMethodsSchema).parse(methods),
     },
@@ -160,6 +161,7 @@ export function createCustomDomainsAdapter(
       const customDomain = mapCustomDomainResponse({
         ...result,
         primary: false,
+        type: domain.type,
         domain_metadata: rest,
       });
 

--- a/packages/cloudflare/src/customDomains/index.ts
+++ b/packages/cloudflare/src/customDomains/index.ts
@@ -1,5 +1,6 @@
 import {
   CustomDomain,
+  CustomDomainCertificateUpload,
   CustomDomainInsert,
   CustomDomainsAdapter,
   VerificationMethods,
@@ -326,6 +327,42 @@ export function createCustomDomainsAdapter(
         domain_id,
         custom_domain,
       );
+    },
+    uploadCertificate: async (
+      tenant_id: string,
+      domain_id: string,
+      cert: CustomDomainCertificateUpload,
+    ) => {
+      const existing = await config.customDomainAdapter.get(
+        tenant_id,
+        domain_id,
+      );
+      if (!existing) {
+        throw new HTTPException(404);
+      }
+
+      const response = await getClient(config)
+        .patch(
+          {
+            ssl: {
+              custom_certificate: cert.certificate,
+              custom_key: cert.private_key,
+            },
+          },
+          `/custom_hostnames/${encodeURIComponent(domain_id)}`,
+        )
+        .json();
+
+      const { result, errors, success } =
+        customDomainResponseSchema.parse(response);
+
+      if (!success) {
+        throw new HTTPException(503, {
+          message: JSON.stringify(errors),
+        });
+      }
+
+      return mapCustomDomainResponse({ ...existing, ...result });
     },
   };
 }

--- a/packages/cloudflare/test/customDomains.spec.ts
+++ b/packages/cloudflare/test/customDomains.spec.ts
@@ -402,4 +402,85 @@ describe("customDomains", () => {
       },
     });
   });
+
+  it("uploadCertificate forwards custom_certificate and custom_key to Cloudflare", async () => {
+    const { data } = await getTestServer();
+
+    const { customDomains } = createAdapters({
+      zoneId: "zoneId",
+      authKey: "authKey",
+      authEmail: "authEmail",
+      enterprise: false,
+      customDomainAdapter: data.customDomains,
+    });
+
+    await data.tenants.create({
+      id: "tenantId",
+      friendly_name: "Test Tenant",
+      audience: "https://example.com",
+      sender_email: "login@example.com",
+      sender_name: "SenderName",
+    });
+
+    const created = await customDomains.create("tenantId", {
+      domain: "example.com",
+      type: "self_managed_certs",
+    });
+
+    const pem_cert =
+      "-----BEGIN CERTIFICATE-----\nMIIBfake\n-----END CERTIFICATE-----\n";
+    const pem_key =
+      "-----BEGIN PRIVATE KEY-----\nMIIBfake\n-----END PRIVATE KEY-----\n";
+
+    const result = await customDomains.uploadCertificate!(
+      "tenantId",
+      created.custom_domain_id,
+      { certificate: pem_cert, private_key: pem_key },
+    );
+
+    expect(lastUpdatePayload).toEqual({
+      ssl: {
+        custom_certificate: pem_cert,
+        custom_key: pem_key,
+      },
+    });
+
+    expect(result).toMatchObject({
+      custom_domain_id: created.custom_domain_id,
+      domain: "example.com",
+    });
+  });
+
+  it("uploadCertificate throws 404 when the domain isn't in the tenant's DB", async () => {
+    const { data } = await getTestServer();
+
+    const { customDomains } = createAdapters({
+      zoneId: "zoneId",
+      authKey: "authKey",
+      authEmail: "authEmail",
+      enterprise: false,
+      customDomainAdapter: data.customDomains,
+    });
+
+    await data.tenants.create({
+      id: "tenantId",
+      friendly_name: "Test Tenant",
+      audience: "https://example.com",
+      sender_email: "login@example.com",
+      sender_name: "SenderName",
+    });
+
+    try {
+      await customDomains.uploadCertificate!("tenantId", "customHostnameId", {
+        certificate:
+          "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+        private_key:
+          "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      if (!(err instanceof HTTPException)) throw err;
+      expect(err.status).toBe(404);
+    }
+  });
 });

--- a/packages/proxy/src/data-plane/handlers/cache.ts
+++ b/packages/proxy/src/data-plane/handlers/cache.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import { defineHandler } from "../registry";
+import { ensureMutableResponseHeaders } from "./util";
 
 const optionsSchema = z.object({
   ttl_seconds: z.number().int().positive(),
@@ -19,6 +20,7 @@ export const cacheHandler = defineHandler<Options>({
         const visibility = c.res.headers.has("set-cookie")
           ? "private"
           : "public";
+        ensureMutableResponseHeaders(c);
         c.res.headers.set(
           "Cache-Control",
           `${visibility}, max-age=${options.ttl_seconds}`,

--- a/packages/proxy/src/data-plane/handlers/cors.ts
+++ b/packages/proxy/src/data-plane/handlers/cors.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import { defineHandler } from "../registry";
+import { ensureMutableResponseHeaders } from "./util";
 
 const optionsSchema = z
   .object({
@@ -77,9 +78,8 @@ export const corsHandler = defineHandler<Options>({
 
       await next();
 
-      // Mutate headers in place — Hono's c.res setter merges old headers
-      // over new ones, which would clobber any reassignment.
       const corsHeaders = buildCorsHeaders(options, origin);
+      ensureMutableResponseHeaders(c);
       corsHeaders.forEach((value, key) => {
         if (key.toLowerCase() === "vary") c.res.headers.append(key, value);
         else c.res.headers.set(key, value);

--- a/packages/proxy/src/data-plane/handlers/headers.ts
+++ b/packages/proxy/src/data-plane/handlers/headers.ts
@@ -1,6 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import { defineHandler } from "../registry";
-import { mutateRequestHeaders } from "./util";
+import { ensureMutableResponseHeaders, mutateRequestHeaders } from "./util";
 
 const optionsSchema = z.object({
   request: z.record(z.string(), z.string()).optional(),
@@ -30,6 +30,7 @@ export const headersHandler = defineHandler<Options>({
       await next();
 
       if (options.response || options.remove_response) {
+        ensureMutableResponseHeaders(c);
         options.remove_response?.forEach((k) => c.res.headers.delete(k));
         if (options.response) {
           for (const [k, v] of Object.entries(options.response)) {

--- a/packages/proxy/src/data-plane/handlers/rewrite-cookies.ts
+++ b/packages/proxy/src/data-plane/handlers/rewrite-cookies.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import { defineHandler } from "../registry";
+import { ensureMutableResponseHeaders } from "./util";
 
 const optionsSchema = z.object({
   // Hostname on the upstream whose Domain= attribute should be rewritten.
@@ -46,8 +47,7 @@ export const rewriteCookiesHandler = defineHandler<Options>({
         "i",
       );
 
-      // Mutate c.res.headers in place — reassigning c.res would trigger
-      // Hono's header-merge behavior and clobber the rewrite.
+      ensureMutableResponseHeaders(c);
       c.res.headers.delete("set-cookie");
       for (const cookie of setCookies) {
         c.res.headers.append(

--- a/packages/proxy/src/data-plane/handlers/rewrite-location.ts
+++ b/packages/proxy/src/data-plane/handlers/rewrite-location.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import { defineHandler } from "../registry";
+import { ensureMutableResponseHeaders } from "./util";
 
 const optionsSchema = z.object({
   upstream_origin: z.string().optional(),
@@ -38,8 +39,7 @@ export const rewriteLocationHandler = defineHandler<Options>({
       const requestUrl = new URL(c.req.url);
       const requestOrigin = `${requestUrl.protocol}//${requestUrl.host}`;
       const updatedLocation = `${requestOrigin}${parsedLocation.pathname}${parsedLocation.search}${parsedLocation.hash}`;
-      // Mutate headers in place — Hono's `c.res = …` setter merges old
-      // headers over new ones, which would clobber our rewrite.
+      ensureMutableResponseHeaders(c);
       c.res.headers.set("location", updatedLocation);
     };
   },

--- a/packages/proxy/src/data-plane/handlers/util.ts
+++ b/packages/proxy/src/data-plane/handlers/util.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
 
 const PROXY_REQ_KEY = "__authhero_proxy_request__";
+const MUTABILITY_PROBE = "x-authhero-proxy-mutability-probe";
 
 export function setProxyRequest(c: Context, req: Request): void {
   c.set(PROXY_REQ_KEY as never, req);
@@ -19,4 +20,26 @@ export function mutateRequestHeaders(
   const headers = new Headers(current.headers);
   fn(headers);
   setProxyRequest(c, new Request(current, { headers }));
+}
+
+// Cloudflare Workers (and Miniflare) hand back `Response` objects from
+// `fetch()` whose headers are immutable — any `set`/`append`/`delete` throws
+// `TypeError: Can't modify immutable headers.` Response-phase handlers that
+// rewrite headers after `await next()` must call this first to swap `c.res`
+// for a copy whose headers we own. Hono's own `c.res =` setter merges the
+// previous response's headers into the replacement (it reads the old headers,
+// which is allowed, and writes to the new ones), so the swap is value-safe.
+export function ensureMutableResponseHeaders(c: Context): void {
+  const current = c.res;
+  try {
+    current.headers.append(MUTABILITY_PROBE, "1");
+    current.headers.delete(MUTABILITY_PROBE);
+    return;
+  } catch {
+    c.res = new Response(current.body, {
+      status: current.status,
+      statusText: current.statusText,
+      headers: new Headers(current.headers),
+    });
+  }
 }

--- a/packages/proxy/test/data-plane.spec.ts
+++ b/packages/proxy/test/data-plane.spec.ts
@@ -448,3 +448,241 @@ describe("data plane router", () => {
     expect(res.headers.get("location")).toBe("https://customer.com/dest");
   });
 });
+
+// Cloudflare Workers / Miniflare hand back `Response` objects from `fetch()`
+// whose headers are immutable — any `set`/`append`/`delete` throws
+// `TypeError: Can't modify immutable headers.` Hono's own `app.request(...)`
+// path (used above) creates Response objects in-process with mutable headers,
+// so the rest of the suite can't catch this. These tests simulate the Workers
+// constraint by wrapping the fetch-returned Response so its header mutators
+// throw, then run each response-phase handler through the chain and assert
+// the rewrite lands (i.e. the handler hit `ensureMutableResponseHeaders` first
+// instead of crashing the worker).
+function freezeResponseHeaders(res: Response): Response {
+  const throwImmutable = () => {
+    throw new TypeError("Can't modify immutable headers.");
+  };
+  for (const method of ["set", "append", "delete"] as const) {
+    Object.defineProperty(res.headers, method, {
+      value: throwImmutable,
+      configurable: true,
+      writable: false,
+    });
+  }
+  return res;
+}
+
+describe("data plane router — Workers immutable response headers", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rewrite_location does not crash when upstream headers are immutable", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      freezeResponseHeaders(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://upstream.example.com/dest" },
+        }),
+      ),
+    );
+
+    const app = createProxyDataPlaneRouter({
+      data: makeAdapter({
+        tenant_id: "t1",
+        custom_domain_id: "cd1",
+        domain: "customer.com",
+        routes: [
+          route({
+            match: { path: "/*" },
+            handlers: [
+              {
+                type: "rewrite_location",
+                options: { upstream_origin: "https://upstream.example.com" },
+              },
+              {
+                type: "http",
+                options: { upstream_url: "https://upstream.example.com" },
+              },
+            ],
+          }),
+        ],
+      }),
+      cacheTtlMs: 0,
+    });
+
+    const res = await app.request("https://customer.com/foo", {
+      headers: { host: "customer.com" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://customer.com/dest");
+  });
+
+  it("rewrite_cookies does not crash when upstream headers are immutable", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      freezeResponseHeaders(
+        new Response("ok", {
+          status: 200,
+          headers: {
+            "Set-Cookie":
+              "sid=abc; Path=/; Domain=upstream.example.com; HttpOnly",
+          },
+        }),
+      ),
+    );
+
+    const app = createProxyDataPlaneRouter({
+      data: makeAdapter({
+        tenant_id: "t1",
+        custom_domain_id: "cd1",
+        domain: "customer.com",
+        routes: [
+          route({
+            match: { path: "/*" },
+            handlers: [
+              {
+                type: "rewrite_cookies",
+                options: { upstream_host: "upstream.example.com" },
+              },
+              {
+                type: "http",
+                options: { upstream_url: "https://upstream.example.com" },
+              },
+            ],
+          }),
+        ],
+      }),
+      cacheTtlMs: 0,
+    });
+
+    const res = await app.request("https://customer.com/", {
+      headers: { host: "customer.com" },
+    });
+    expect(res.status).toBe(200);
+    const cookie =
+      res.headers.getSetCookie?.()[0] ?? res.headers.get("set-cookie");
+    expect(cookie).toContain("Domain=customer.com");
+    expect(cookie).not.toContain("Domain=upstream.example.com");
+  });
+
+  it("headers (response branch) does not crash when upstream headers are immutable", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      freezeResponseHeaders(
+        new Response("ok", {
+          status: 200,
+          headers: { "X-Powered-By": "leak", "X-Keep": "yes" },
+        }),
+      ),
+    );
+
+    const app = createProxyDataPlaneRouter({
+      data: makeAdapter({
+        tenant_id: "t1",
+        custom_domain_id: "cd1",
+        domain: "customer.com",
+        routes: [
+          route({
+            match: { path: "/*" },
+            handlers: [
+              {
+                type: "headers",
+                options: {
+                  response: { "X-Frame-Options": "DENY" },
+                  remove_response: ["X-Powered-By"],
+                },
+              },
+              {
+                type: "http",
+                options: { upstream_url: "https://upstream.example.com" },
+              },
+            ],
+          }),
+        ],
+      }),
+      cacheTtlMs: 0,
+    });
+
+    const res = await app.request("https://customer.com/", {
+      headers: { host: "customer.com" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-frame-options")).toBe("DENY");
+    expect(res.headers.get("x-powered-by")).toBeNull();
+    expect(res.headers.get("x-keep")).toBe("yes");
+  });
+
+  it("cors (response branch) does not crash when upstream headers are immutable", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      freezeResponseHeaders(new Response("ok", { status: 200 })),
+    );
+
+    const app = createProxyDataPlaneRouter({
+      data: makeAdapter({
+        tenant_id: "t1",
+        custom_domain_id: "cd1",
+        domain: "customer.com",
+        routes: [
+          route({
+            match: { path: "/*" },
+            handlers: [
+              {
+                type: "cors",
+                options: { origins: ["https://app.example"] },
+              },
+              {
+                type: "http",
+                options: { upstream_url: "https://upstream.example.com" },
+              },
+            ],
+          }),
+        ],
+      }),
+      cacheTtlMs: 0,
+    });
+
+    const res = await app.request("https://customer.com/", {
+      headers: { host: "customer.com", origin: "https://app.example" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://app.example",
+    );
+  });
+
+  it("cache does not crash when upstream headers are immutable", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      freezeResponseHeaders(new Response("ok", { status: 200 })),
+    );
+
+    const app = createProxyDataPlaneRouter({
+      data: makeAdapter({
+        tenant_id: "t1",
+        custom_domain_id: "cd1",
+        domain: "customer.com",
+        routes: [
+          route({
+            match: { path: "/*" },
+            handlers: [
+              {
+                type: "cache",
+                options: { ttl_seconds: 60 },
+              },
+              {
+                type: "http",
+                options: { upstream_url: "https://upstream.example.com" },
+              },
+            ],
+          }),
+        ],
+      }),
+      cacheTtlMs: 0,
+    });
+
+    const res = await app.request("https://customer.com/", {
+      headers: { host: "customer.com" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60");
+  });
+});

--- a/packages/ui-widget/src/components.d.ts
+++ b/packages/ui-widget/src/components.d.ts
@@ -6,293 +6,423 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { FormComponent, RuntimeComponent, UiScreen } from "./types/components";
-import { AuthParams, ButtonClickEventDetail, CompleteEventDetail, ErrorEventDetail, LinkClickEventDetail, NavigateEventDetail, StatePersistence, SubmitEventDetail } from "./components/authhero-widget/authhero-widget";
+import {
+  AuthParams,
+  ButtonClickEventDetail,
+  CompleteEventDetail,
+  ErrorEventDetail,
+  LinkClickEventDetail,
+  NavigateEventDetail,
+  StatePersistence,
+  SubmitEventDetail,
+} from "./components/authhero-widget/authhero-widget";
 import { WidgetBranding, WidgetTheme } from "./utils/branding";
 export { FormComponent, RuntimeComponent, UiScreen } from "./types/components";
-export { AuthParams, ButtonClickEventDetail, CompleteEventDetail, ErrorEventDetail, LinkClickEventDetail, NavigateEventDetail, StatePersistence, SubmitEventDetail } from "./components/authhero-widget/authhero-widget";
+export {
+  AuthParams,
+  ButtonClickEventDetail,
+  CompleteEventDetail,
+  ErrorEventDetail,
+  LinkClickEventDetail,
+  NavigateEventDetail,
+  StatePersistence,
+  SubmitEventDetail,
+} from "./components/authhero-widget/authhero-widget";
 export { WidgetBranding, WidgetTheme } from "./utils/branding";
 export namespace Components {
-    interface AuthheroNode {
-        /**
-          * The component configuration to render. Follows Auth0 Forms component schema.
-         */
-        "component": FormComponent | RuntimeComponent;
-        /**
-          * Whether the component is disabled.
-          * @default false
-         */
-        "disabled": boolean;
-        /**
-          * Current value for field components.
-         */
-        "value"?: string;
-    }
-    interface AuthheroWidget {
-        /**
-          * API endpoint to fetch the initial screen from. If provided, the widget will fetch the screen on load. Can include {screenId} placeholder which will be replaced with the current screen. Example: "/u2/screen/{screenId}" or "https://auth.example.com/u2/screen/{screenId}"
-         */
-        "apiUrl"?: string;
-        /**
-          * OAuth/OIDC parameters for social login redirects. Can be passed as a JSON string or object.
-         */
-        "authParams"?: AuthParams | string;
-        /**
-          * Whether the widget should handle navigation automatically. When true, social login buttons redirect, links navigate, etc. When false, only events are emitted.
-          * @default false (same as autoSubmit when not specified)
-         */
-        "autoNavigate"?: boolean;
-        /**
-          * Whether the widget should automatically submit forms to the action URL. When false (default), the widget only emits events and the consuming application handles all HTTP requests. When true, the widget handles form submission and screen updates.
-          * @default false
-         */
-        "autoSubmit": boolean;
-        /**
-          * Base URL for all API calls. Used when widget is embedded on a different domain. If not provided, relative URLs are used. Example: "https://auth.example.com"
-         */
-        "baseUrl"?: string;
-        /**
-          * Branding configuration from AuthHero API. Controls logo, primary color, and page background. Can be passed as a JSON string or object.
-         */
-        "branding"?: WidgetBranding | string;
-        /**
-          * Whether the widget is in a loading state.
-          * @default false
-         */
-        "loading": boolean;
-        /**
-          * The UI screen configuration from the server. Can be passed as a JSON string or object. Follows Auth0 Forms component schema.
-         */
-        "screen"?: UiScreen | string;
-        /**
-          * Current screen ID. Used with apiUrl to fetch screen configuration. When statePersistence is 'url', this is synced with the URL.
-         */
-        "screenId"?: string;
-        /**
-          * Login session state token. Required for social login and maintaining session.
-         */
-        "state"?: string;
-        /**
-          * Where to persist state and screen ID. - 'url': Updates URL path/query (default for standalone pages) - 'session': Uses sessionStorage (for embedded widgets) - 'memory': No persistence, state only in memory
-          * @default 'memory'
-         */
-        "statePersistence": StatePersistence;
-        /**
-          * Storage key prefix for session/local storage persistence.
-          * @default 'authhero_widget'
-         */
-        "storageKey": string;
-        /**
-          * Theme configuration from AuthHero API. Controls colors, borders, fonts, and layout. Can be passed as a JSON string or object.
-         */
-        "theme"?: WidgetTheme | string;
-    }
+  interface AuthheroNode {
+    /**
+     * The component configuration to render. Follows Auth0 Forms component schema.
+     */
+    component: FormComponent | RuntimeComponent;
+    /**
+     * Whether the component is disabled.
+     * @default false
+     */
+    disabled: boolean;
+    /**
+     * Current value for field components.
+     */
+    value?: string;
+  }
+  interface AuthheroWidget {
+    /**
+     * API endpoint to fetch the initial screen from. If provided, the widget will fetch the screen on load. Can include {screenId} placeholder which will be replaced with the current screen. Example: "/u2/screen/{screenId}" or "https://auth.example.com/u2/screen/{screenId}"
+     */
+    apiUrl?: string;
+    /**
+     * OAuth/OIDC parameters for social login redirects. Can be passed as a JSON string or object.
+     */
+    authParams?: AuthParams | string;
+    /**
+     * Whether the widget should handle navigation automatically. When true, social login buttons redirect, links navigate, etc. When false, only events are emitted.
+     * @default false (same as autoSubmit when not specified)
+     */
+    autoNavigate?: boolean;
+    /**
+     * Whether the widget should automatically submit forms to the action URL. When false (default), the widget only emits events and the consuming application handles all HTTP requests. When true, the widget handles form submission and screen updates.
+     * @default false
+     */
+    autoSubmit: boolean;
+    /**
+     * Base URL for all API calls. Used when widget is embedded on a different domain. If not provided, relative URLs are used. Example: "https://auth.example.com"
+     */
+    baseUrl?: string;
+    /**
+     * Branding configuration from AuthHero API. Controls logo, primary color, and page background. Can be passed as a JSON string or object.
+     */
+    branding?: WidgetBranding | string;
+    /**
+     * Whether the widget is in a loading state.
+     * @default false
+     */
+    loading: boolean;
+    /**
+     * The UI screen configuration from the server. Can be passed as a JSON string or object. Follows Auth0 Forms component schema.
+     */
+    screen?: UiScreen | string;
+    /**
+     * Current screen ID. Used with apiUrl to fetch screen configuration. When statePersistence is 'url', this is synced with the URL.
+     */
+    screenId?: string;
+    /**
+     * Login session state token. Required for social login and maintaining session.
+     */
+    state?: string;
+    /**
+     * Where to persist state and screen ID. - 'url': Updates URL path/query (default for standalone pages) - 'session': Uses sessionStorage (for embedded widgets) - 'memory': No persistence, state only in memory
+     * @default 'memory'
+     */
+    statePersistence: StatePersistence;
+    /**
+     * Storage key prefix for session/local storage persistence.
+     * @default 'authhero_widget'
+     */
+    storageKey: string;
+    /**
+     * Theme configuration from AuthHero API. Controls colors, borders, fonts, and layout. Can be passed as a JSON string or object.
+     */
+    theme?: WidgetTheme | string;
+  }
 }
 export interface AuthheroNodeCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLAuthheroNodeElement;
+  detail: T;
+  target: HTMLAuthheroNodeElement;
 }
 export interface AuthheroWidgetCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLAuthheroWidgetElement;
+  detail: T;
+  target: HTMLAuthheroWidgetElement;
 }
 declare global {
-    interface HTMLAuthheroNodeElementEventMap {
-        "fieldChange": { id: string; value: string };
-        "buttonClick": {
-    id: string;
-    type: string;
-    value?: string;
+  interface HTMLAuthheroNodeElementEventMap {
+    fieldChange: { id: string; value: string };
+    buttonClick: {
+      id: string;
+      type: string;
+      value?: string;
+    };
+  }
+  interface HTMLAuthheroNodeElement
+    extends Components.AuthheroNode, HTMLStencilElement {
+    addEventListener<K extends keyof HTMLAuthheroNodeElementEventMap>(
+      type: K,
+      listener: (
+        this: HTMLAuthheroNodeElement,
+        ev: AuthheroNodeCustomEvent<HTMLAuthheroNodeElementEventMap[K]>,
+      ) => any,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener<K extends keyof DocumentEventMap>(
+      type: K,
+      listener: (this: Document, ev: DocumentEventMap[K]) => any,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener<K extends keyof HTMLElementEventMap>(
+      type: K,
+      listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof HTMLAuthheroNodeElementEventMap>(
+      type: K,
+      listener: (
+        this: HTMLAuthheroNodeElement,
+        ev: AuthheroNodeCustomEvent<HTMLAuthheroNodeElementEventMap[K]>,
+      ) => any,
+      options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof DocumentEventMap>(
+      type: K,
+      listener: (this: Document, ev: DocumentEventMap[K]) => any,
+      options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof HTMLElementEventMap>(
+      type: K,
+      listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+      options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions,
+    ): void;
+  }
+  var HTMLAuthheroNodeElement: {
+    prototype: HTMLAuthheroNodeElement;
+    new (): HTMLAuthheroNodeElement;
   };
-    }
-    interface HTMLAuthheroNodeElement extends Components.AuthheroNode, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLAuthheroNodeElementEventMap>(type: K, listener: (this: HTMLAuthheroNodeElement, ev: AuthheroNodeCustomEvent<HTMLAuthheroNodeElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLAuthheroNodeElementEventMap>(type: K, listener: (this: HTMLAuthheroNodeElement, ev: AuthheroNodeCustomEvent<HTMLAuthheroNodeElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-    }
-    var HTMLAuthheroNodeElement: {
-        prototype: HTMLAuthheroNodeElement;
-        new (): HTMLAuthheroNodeElement;
-    };
-    interface HTMLAuthheroWidgetElementEventMap {
-        "formSubmit": SubmitEventDetail;
-        "buttonClick": ButtonClickEventDetail;
-        "linkClick": LinkClickEventDetail;
-        "navigate": NavigateEventDetail;
-        "flowComplete": CompleteEventDetail;
-        "flowError": ErrorEventDetail;
-        "screenChange": UiScreen;
-    }
-    interface HTMLAuthheroWidgetElement extends Components.AuthheroWidget, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLAuthheroWidgetElementEventMap>(type: K, listener: (this: HTMLAuthheroWidgetElement, ev: AuthheroWidgetCustomEvent<HTMLAuthheroWidgetElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLAuthheroWidgetElementEventMap>(type: K, listener: (this: HTMLAuthheroWidgetElement, ev: AuthheroWidgetCustomEvent<HTMLAuthheroWidgetElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-    }
-    var HTMLAuthheroWidgetElement: {
-        prototype: HTMLAuthheroWidgetElement;
-        new (): HTMLAuthheroWidgetElement;
-    };
-    interface HTMLElementTagNameMap {
-        "authhero-node": HTMLAuthheroNodeElement;
-        "authhero-widget": HTMLAuthheroWidgetElement;
-    }
+  interface HTMLAuthheroWidgetElementEventMap {
+    formSubmit: SubmitEventDetail;
+    buttonClick: ButtonClickEventDetail;
+    linkClick: LinkClickEventDetail;
+    navigate: NavigateEventDetail;
+    flowComplete: CompleteEventDetail;
+    flowError: ErrorEventDetail;
+    screenChange: UiScreen;
+  }
+  interface HTMLAuthheroWidgetElement
+    extends Components.AuthheroWidget, HTMLStencilElement {
+    addEventListener<K extends keyof HTMLAuthheroWidgetElementEventMap>(
+      type: K,
+      listener: (
+        this: HTMLAuthheroWidgetElement,
+        ev: AuthheroWidgetCustomEvent<HTMLAuthheroWidgetElementEventMap[K]>,
+      ) => any,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener<K extends keyof DocumentEventMap>(
+      type: K,
+      listener: (this: Document, ev: DocumentEventMap[K]) => any,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener<K extends keyof HTMLElementEventMap>(
+      type: K,
+      listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof HTMLAuthheroWidgetElementEventMap>(
+      type: K,
+      listener: (
+        this: HTMLAuthheroWidgetElement,
+        ev: AuthheroWidgetCustomEvent<HTMLAuthheroWidgetElementEventMap[K]>,
+      ) => any,
+      options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof DocumentEventMap>(
+      type: K,
+      listener: (this: Document, ev: DocumentEventMap[K]) => any,
+      options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof HTMLElementEventMap>(
+      type: K,
+      listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+      options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions,
+    ): void;
+  }
+  var HTMLAuthheroWidgetElement: {
+    prototype: HTMLAuthheroWidgetElement;
+    new (): HTMLAuthheroWidgetElement;
+  };
+  interface HTMLElementTagNameMap {
+    "authhero-node": HTMLAuthheroNodeElement;
+    "authhero-widget": HTMLAuthheroWidgetElement;
+  }
 }
 declare namespace LocalJSX {
-    interface AuthheroNode {
-        /**
-          * The component configuration to render. Follows Auth0 Forms component schema.
-         */
-        "component": FormComponent | RuntimeComponent;
-        /**
-          * Whether the component is disabled.
-          * @default false
-         */
-        "disabled"?: boolean;
-        /**
-          * Emitted when a button is clicked.
-         */
-        "onButtonClick"?: (event: AuthheroNodeCustomEvent<{
-    id: string;
-    type: string;
+  interface AuthheroNode {
+    /**
+     * The component configuration to render. Follows Auth0 Forms component schema.
+     */
+    component: FormComponent | RuntimeComponent;
+    /**
+     * Whether the component is disabled.
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * Emitted when a button is clicked.
+     */
+    onButtonClick?: (
+      event: AuthheroNodeCustomEvent<{
+        id: string;
+        type: string;
+        value?: string;
+      }>,
+    ) => void;
+    /**
+     * Emitted when a field value changes.
+     */
+    onFieldChange?: (
+      event: AuthheroNodeCustomEvent<{ id: string; value: string }>,
+    ) => void;
+    /**
+     * Current value for field components.
+     */
     value?: string;
-  }>) => void;
-        /**
-          * Emitted when a field value changes.
-         */
-        "onFieldChange"?: (event: AuthheroNodeCustomEvent<{ id: string; value: string }>) => void;
-        /**
-          * Current value for field components.
-         */
-        "value"?: string;
-    }
-    interface AuthheroWidget {
-        /**
-          * API endpoint to fetch the initial screen from. If provided, the widget will fetch the screen on load. Can include {screenId} placeholder which will be replaced with the current screen. Example: "/u2/screen/{screenId}" or "https://auth.example.com/u2/screen/{screenId}"
-         */
-        "apiUrl"?: string;
-        /**
-          * OAuth/OIDC parameters for social login redirects. Can be passed as a JSON string or object.
-         */
-        "authParams"?: AuthParams | string;
-        /**
-          * Whether the widget should handle navigation automatically. When true, social login buttons redirect, links navigate, etc. When false, only events are emitted.
-          * @default false (same as autoSubmit when not specified)
-         */
-        "autoNavigate"?: boolean;
-        /**
-          * Whether the widget should automatically submit forms to the action URL. When false (default), the widget only emits events and the consuming application handles all HTTP requests. When true, the widget handles form submission and screen updates.
-          * @default false
-         */
-        "autoSubmit"?: boolean;
-        /**
-          * Base URL for all API calls. Used when widget is embedded on a different domain. If not provided, relative URLs are used. Example: "https://auth.example.com"
-         */
-        "baseUrl"?: string;
-        /**
-          * Branding configuration from AuthHero API. Controls logo, primary color, and page background. Can be passed as a JSON string or object.
-         */
-        "branding"?: WidgetBranding | string;
-        /**
-          * Whether the widget is in a loading state.
-          * @default false
-         */
-        "loading"?: boolean;
-        /**
-          * Emitted when a non-submit button is clicked (social login, back, etc.). The consuming application decides what to do based on id/type/value.
-         */
-        "onButtonClick"?: (event: AuthheroWidgetCustomEvent<ButtonClickEventDetail>) => void;
-        /**
-          * Emitted when auth flow completes with a redirect URL. The consuming application can redirect or extract the code.
-         */
-        "onFlowComplete"?: (event: AuthheroWidgetCustomEvent<CompleteEventDetail>) => void;
-        /**
-          * Emitted when an error occurs.
-         */
-        "onFlowError"?: (event: AuthheroWidgetCustomEvent<ErrorEventDetail>) => void;
-        /**
-          * Emitted when the form is submitted. The consuming application should handle the submission unless autoSubmit is true.
-         */
-        "onFormSubmit"?: (event: AuthheroWidgetCustomEvent<SubmitEventDetail>) => void;
-        /**
-          * Emitted when a link is clicked. The consuming application decides how to handle navigation.
-         */
-        "onLinkClick"?: (event: AuthheroWidgetCustomEvent<LinkClickEventDetail>) => void;
-        /**
-          * Emitted when the widget wants to navigate (e.g., after successful auth). The consuming application decides how to handle navigation.
-         */
-        "onNavigate"?: (event: AuthheroWidgetCustomEvent<NavigateEventDetail>) => void;
-        /**
-          * Emitted when the screen changes.
-         */
-        "onScreenChange"?: (event: AuthheroWidgetCustomEvent<UiScreen>) => void;
-        /**
-          * The UI screen configuration from the server. Can be passed as a JSON string or object. Follows Auth0 Forms component schema.
-         */
-        "screen"?: UiScreen | string;
-        /**
-          * Current screen ID. Used with apiUrl to fetch screen configuration. When statePersistence is 'url', this is synced with the URL.
-         */
-        "screenId"?: string;
-        /**
-          * Login session state token. Required for social login and maintaining session.
-         */
-        "state"?: string;
-        /**
-          * Where to persist state and screen ID. - 'url': Updates URL path/query (default for standalone pages) - 'session': Uses sessionStorage (for embedded widgets) - 'memory': No persistence, state only in memory
-          * @default 'memory'
-         */
-        "statePersistence"?: StatePersistence;
-        /**
-          * Storage key prefix for session/local storage persistence.
-          * @default 'authhero_widget'
-         */
-        "storageKey"?: string;
-        /**
-          * Theme configuration from AuthHero API. Controls colors, borders, fonts, and layout. Can be passed as a JSON string or object.
-         */
-        "theme"?: WidgetTheme | string;
-    }
+  }
+  interface AuthheroWidget {
+    /**
+     * API endpoint to fetch the initial screen from. If provided, the widget will fetch the screen on load. Can include {screenId} placeholder which will be replaced with the current screen. Example: "/u2/screen/{screenId}" or "https://auth.example.com/u2/screen/{screenId}"
+     */
+    apiUrl?: string;
+    /**
+     * OAuth/OIDC parameters for social login redirects. Can be passed as a JSON string or object.
+     */
+    authParams?: AuthParams | string;
+    /**
+     * Whether the widget should handle navigation automatically. When true, social login buttons redirect, links navigate, etc. When false, only events are emitted.
+     * @default false (same as autoSubmit when not specified)
+     */
+    autoNavigate?: boolean;
+    /**
+     * Whether the widget should automatically submit forms to the action URL. When false (default), the widget only emits events and the consuming application handles all HTTP requests. When true, the widget handles form submission and screen updates.
+     * @default false
+     */
+    autoSubmit?: boolean;
+    /**
+     * Base URL for all API calls. Used when widget is embedded on a different domain. If not provided, relative URLs are used. Example: "https://auth.example.com"
+     */
+    baseUrl?: string;
+    /**
+     * Branding configuration from AuthHero API. Controls logo, primary color, and page background. Can be passed as a JSON string or object.
+     */
+    branding?: WidgetBranding | string;
+    /**
+     * Whether the widget is in a loading state.
+     * @default false
+     */
+    loading?: boolean;
+    /**
+     * Emitted when a non-submit button is clicked (social login, back, etc.). The consuming application decides what to do based on id/type/value.
+     */
+    onButtonClick?: (
+      event: AuthheroWidgetCustomEvent<ButtonClickEventDetail>,
+    ) => void;
+    /**
+     * Emitted when auth flow completes with a redirect URL. The consuming application can redirect or extract the code.
+     */
+    onFlowComplete?: (
+      event: AuthheroWidgetCustomEvent<CompleteEventDetail>,
+    ) => void;
+    /**
+     * Emitted when an error occurs.
+     */
+    onFlowError?: (event: AuthheroWidgetCustomEvent<ErrorEventDetail>) => void;
+    /**
+     * Emitted when the form is submitted. The consuming application should handle the submission unless autoSubmit is true.
+     */
+    onFormSubmit?: (
+      event: AuthheroWidgetCustomEvent<SubmitEventDetail>,
+    ) => void;
+    /**
+     * Emitted when a link is clicked. The consuming application decides how to handle navigation.
+     */
+    onLinkClick?: (
+      event: AuthheroWidgetCustomEvent<LinkClickEventDetail>,
+    ) => void;
+    /**
+     * Emitted when the widget wants to navigate (e.g., after successful auth). The consuming application decides how to handle navigation.
+     */
+    onNavigate?: (
+      event: AuthheroWidgetCustomEvent<NavigateEventDetail>,
+    ) => void;
+    /**
+     * Emitted when the screen changes.
+     */
+    onScreenChange?: (event: AuthheroWidgetCustomEvent<UiScreen>) => void;
+    /**
+     * The UI screen configuration from the server. Can be passed as a JSON string or object. Follows Auth0 Forms component schema.
+     */
+    screen?: UiScreen | string;
+    /**
+     * Current screen ID. Used with apiUrl to fetch screen configuration. When statePersistence is 'url', this is synced with the URL.
+     */
+    screenId?: string;
+    /**
+     * Login session state token. Required for social login and maintaining session.
+     */
+    state?: string;
+    /**
+     * Where to persist state and screen ID. - 'url': Updates URL path/query (default for standalone pages) - 'session': Uses sessionStorage (for embedded widgets) - 'memory': No persistence, state only in memory
+     * @default 'memory'
+     */
+    statePersistence?: StatePersistence;
+    /**
+     * Storage key prefix for session/local storage persistence.
+     * @default 'authhero_widget'
+     */
+    storageKey?: string;
+    /**
+     * Theme configuration from AuthHero API. Controls colors, borders, fonts, and layout. Can be passed as a JSON string or object.
+     */
+    theme?: WidgetTheme | string;
+  }
 
-    interface AuthheroNodeAttributes {
-        "value": string;
-        "disabled": boolean;
-    }
-    interface AuthheroWidgetAttributes {
-        "screen": UiScreen | string;
-        "apiUrl": string;
-        "baseUrl": string;
-        "state": string;
-        "screenId": string;
-        "authParams": AuthParams | string;
-        "statePersistence": StatePersistence;
-        "storageKey": string;
-        "branding": WidgetBranding | string;
-        "theme": WidgetTheme | string;
-        "loading": boolean;
-        "autoSubmit": boolean;
-        "autoNavigate": boolean;
-    }
+  interface AuthheroNodeAttributes {
+    value: string;
+    disabled: boolean;
+  }
+  interface AuthheroWidgetAttributes {
+    screen: UiScreen | string;
+    apiUrl: string;
+    baseUrl: string;
+    state: string;
+    screenId: string;
+    authParams: AuthParams | string;
+    statePersistence: StatePersistence;
+    storageKey: string;
+    branding: WidgetBranding | string;
+    theme: WidgetTheme | string;
+    loading: boolean;
+    autoSubmit: boolean;
+    autoNavigate: boolean;
+  }
 
-    interface IntrinsicElements {
-        "authhero-node": Omit<AuthheroNode, keyof AuthheroNodeAttributes> & { [K in keyof AuthheroNode & keyof AuthheroNodeAttributes]?: AuthheroNode[K] } & { [K in keyof AuthheroNode & keyof AuthheroNodeAttributes as `attr:${K}`]?: AuthheroNodeAttributes[K] } & { [K in keyof AuthheroNode & keyof AuthheroNodeAttributes as `prop:${K}`]?: AuthheroNode[K] };
-        "authhero-widget": Omit<AuthheroWidget, keyof AuthheroWidgetAttributes> & { [K in keyof AuthheroWidget & keyof AuthheroWidgetAttributes]?: AuthheroWidget[K] } & { [K in keyof AuthheroWidget & keyof AuthheroWidgetAttributes as `attr:${K}`]?: AuthheroWidgetAttributes[K] } & { [K in keyof AuthheroWidget & keyof AuthheroWidgetAttributes as `prop:${K}`]?: AuthheroWidget[K] };
-    }
+  interface IntrinsicElements {
+    "authhero-node": Omit<AuthheroNode, keyof AuthheroNodeAttributes> & {
+      [K in keyof AuthheroNode &
+        keyof AuthheroNodeAttributes]?: AuthheroNode[K];
+    } & {
+      [K in keyof AuthheroNode &
+        keyof AuthheroNodeAttributes as `attr:${K}`]?: AuthheroNodeAttributes[K];
+    } & {
+      [K in keyof AuthheroNode &
+        keyof AuthheroNodeAttributes as `prop:${K}`]?: AuthheroNode[K];
+    };
+    "authhero-widget": Omit<AuthheroWidget, keyof AuthheroWidgetAttributes> & {
+      [K in keyof AuthheroWidget &
+        keyof AuthheroWidgetAttributes]?: AuthheroWidget[K];
+    } & {
+      [K in keyof AuthheroWidget &
+        keyof AuthheroWidgetAttributes as `attr:${K}`]?: AuthheroWidgetAttributes[K];
+    } & {
+      [K in keyof AuthheroWidget &
+        keyof AuthheroWidgetAttributes as `prop:${K}`]?: AuthheroWidget[K];
+    };
+  }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-    export namespace JSX {
-        interface IntrinsicElements {
-            "authhero-node": LocalJSX.IntrinsicElements["authhero-node"] & JSXBase.HTMLAttributes<HTMLAuthheroNodeElement>;
-            "authhero-widget": LocalJSX.IntrinsicElements["authhero-widget"] & JSXBase.HTMLAttributes<HTMLAuthheroWidgetElement>;
-        }
+  export namespace JSX {
+    interface IntrinsicElements {
+      "authhero-node": LocalJSX.IntrinsicElements["authhero-node"] &
+        JSXBase.HTMLAttributes<HTMLAuthheroNodeElement>;
+      "authhero-widget": LocalJSX.IntrinsicElements["authhero-widget"] &
+        JSXBase.HTMLAttributes<HTMLAuthheroWidgetElement>;
     }
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI: two-step client creation (app type picker) and contextual hiding of fields
  * Admin UI: banner and read-only behavior for externally managed (CIMD) clients
  * Custom domains: upload PEM certificate/private key via management API and Admin “Certificate” tab
  * Tenant flag to enable Client ID Metadata Document (CIMD) flow

* **Bug Fixes**
  * Proxy: avoid crashes on immutable response headers (Cloudflare Workers)

* **Documentation**
  * Added CIMD and custom domain certificate upload docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->