### PR TITLE
Add grant type and organization to events

### DIFF
--- a/.changeset/credentials-exchange-org-grant-type.md
+++ b/.changeset/credentials-exchange-org-grant-type.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Expose `organization` and `grant_type` on the `onExecuteCredentialsExchange` hook event. Both values are already in scope at the call site, but `grant_type` was hardcoded to `""` and `organization` was never forwarded. This unblocks org-scoped custom claims (e.g. `azp`/`vendor_id` derived from the organization passed to a `client_credentials` exchange). The `display_name` field on `HookEvent.organization` is now optional — at most call sites only `{id, name}` is available, and existing hook consumers already had to handle the whole `organization` field being undefined.

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -170,6 +170,7 @@ export async function createAuthTokens(
     organization,
     permissions,
     impersonatingUser,
+    grantType,
   } = params;
 
   // OIDC Core §2: auth_time is REQUIRED in the ID Token whenever max_age was
@@ -382,7 +383,8 @@ export async function createAuthTokens(
           url: ctx.req.url,
         },
         scope: authParams.scope || "",
-        grant_type: "",
+        grant_type: grantType ?? "",
+        organization,
         connection:
           connectionInfo ||
           (connectionName
@@ -460,7 +462,8 @@ export async function createAuthTokens(
           url: ctx.req?.url || "",
         },
         scope: authParams.scope || "",
-        grant_type: "",
+        grant_type: grantType ?? "",
+        organization,
         connection:
           connectionInfo ||
           (connectionName

--- a/packages/authhero/src/types/Hooks.ts
+++ b/packages/authhero/src/types/Hooks.ts
@@ -138,7 +138,7 @@ export type HookEvent = {
   organization?: {
     id: string;
     name: string;
-    display_name: string;
+    display_name?: string;
     metadata?: Record<string, unknown>;
   };
   resource_server?: {

--- a/packages/authhero/test/hooks/credentials-exchange.spec.ts
+++ b/packages/authhero/test/hooks/credentials-exchange.spec.ts
@@ -55,6 +55,51 @@ describe("client-credentials-hooks", () => {
     });
   });
 
+  it("should expose grant_type and organization on the event for client_credentials", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    const organization = await env.data.organizations.create("tenantId", {
+      name: "cc-org",
+      display_name: "Client Credentials Org",
+    });
+
+    let capturedEvent: HookEvent | undefined;
+    env.hooks = {
+      onExecuteCredentialsExchange: async (
+        event: HookEvent,
+        _api: OnExecuteCredentialsExchangeAPI,
+      ) => {
+        capturedEvent = event;
+      },
+    };
+
+    const response = await oauthClient.oauth.token.$post(
+      {
+        form: {
+          grant_type: "client_credentials",
+          client_id: "clientId",
+          client_secret: "clientSecret",
+          audience: "https://example.com",
+          organization: organization.id,
+        },
+      },
+      {
+        headers: {
+          "tenant-id": "tenantId",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent!.grant_type).toBe("client_credentials");
+    expect(capturedEvent!.organization).toMatchObject({
+      id: organization.id,
+      name: organization.name,
+    });
+  });
+
   it("should include connection info in the event for user-based flows", async () => {
     const { oauthApp, env, getSentEmails } = await getTestServer({
       testTenantLanguage: "en",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `organization` and `grant_type` are now exposed in the `onExecuteCredentialsExchange` hook event.

* **Bug Fixes**
  * `grant_type` is now properly forwarded instead of defaulting to an empty string.
  * `organization` parameter is now properly forwarded in credentials-exchange hooks.
  * `organization.display_name` is now optional in hook events.

* **Tests**
  * Added test coverage for client credentials flow with organization parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->