### PR TITLE
fix custom domain issues

### DIFF
--- a/.changeset/custom-domain-patch-schema.md
+++ b/.changeset/custom-domain-patch-schema.md
@@ -1,0 +1,6 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": patch
+---
+
+Tighten PATCH `/api/v2/custom-domains/{id}` to match Auth0: only `tls_policy`, `custom_client_ip_header`, and `domain_metadata` (the authhero extension) are accepted. Previously the route accepted a partial of the full schema, which made round-trips (GET → modify → PATCH) fail with `Payload validation error` once clients sent immutable fields like `custom_domain_id`, `domain`, `primary`, `status`, `type`, etc. Adds an exported `customDomainUpdateSchema` for clients to bind to.

--- a/.changeset/proxy-control-plane-multi-issuer.md
+++ b/.changeset/proxy-control-plane-multi-issuer.md
@@ -1,0 +1,9 @@
+---
+"authhero": minor
+---
+
+Proxy control-plane now accepts bearer tokens whose `iss` is either the canonical `env.ISSUER` or the host the request actually arrived on (`x-forwarded-host`, falling back to the request URL host). This fixes 401s when the `@authhero/proxy` data plane calls the control plane on a tenant subdomain (e.g. `sesamy.token.sesamy.com`) or a registered custom domain (e.g. `login.parcferme.no`), where the minted token's `iss` matches the calling host rather than the canonical issuer.
+
+JWKS is now fetched per-issuer from `<iss>/.well-known/jwks.json`, after the `iss` is allow-listed — this prevents a forged `iss` from steering the verifier to an attacker-controlled JWKS.
+
+**Breaking config change** (`proxyControlPlane`): the `jwksUrl` option is removed. The JWKS URL is now derived from the verified `iss` per request. Callers that route JWKS fetches through a service binding can continue to do so via `jwksFetch?: (url: string) => Promise<Response>` — the URL is now the per-issuer URL, so the override must handle multiple hosts.

--- a/apps/admin/src/auth0DataProvider.ts
+++ b/apps/admin/src/auth0DataProvider.ts
@@ -1913,9 +1913,32 @@ export default (
       }
 
       if (resource === "custom-domains") {
+        // Auth0 PATCH /custom-domains/{id} only accepts tls_policy and
+        // custom_client_ip_header; domain_metadata is authhero's extension.
+        // Everything else (custom_domain_id, domain, primary, status, type,
+        // origin_domain_name, verification) is read-only and the server
+        // rejects the body if those are present alongside null sentinels.
+        const data = cleanParams.data as Record<string, unknown>;
+        const patch: Record<string, unknown> = {};
+        if (typeof data.tls_policy === "string" && data.tls_policy !== "") {
+          patch.tls_policy = data.tls_policy;
+        }
+        if (
+          typeof data.custom_client_ip_header === "string" &&
+          data.custom_client_ip_header !== ""
+        ) {
+          patch.custom_client_ip_header = data.custom_client_ip_header;
+        }
+        if (
+          data.domain_metadata !== undefined &&
+          data.domain_metadata !== null
+        ) {
+          patch.domain_metadata = data.domain_metadata;
+        }
+
         const result = await (managementClient as any).customDomains.update(
           params.id as string,
-          cleanParams.data,
+          patch,
         );
         return {
           data: {

--- a/packages/adapter-interfaces/src/types/CustomDomain.ts
+++ b/packages/adapter-interfaces/src/types/CustomDomain.ts
@@ -52,6 +52,22 @@ export default customDomainSchema;
 
 export type CustomDomain = z.infer<typeof customDomainSchema>;
 
+/**
+ * Body schema for PATCH /custom-domains/{id}. Matches Auth0: only the
+ * mutable fields are accepted (tls_policy, custom_client_ip_header), plus
+ * authhero's domain_metadata extension used to drive SSL method / CA on
+ * the underlying CDN adapter.
+ */
+export const customDomainUpdateSchema = customDomainInsertSchema
+  .pick({
+    tls_policy: true,
+    custom_client_ip_header: true,
+    domain_metadata: true,
+  })
+  .strict();
+
+export type CustomDomainUpdate = z.infer<typeof customDomainUpdateSchema>;
+
 export const customDomainWithTenantIdSchema = customDomainSchema.extend({
   tenant_id: z.string(),
 });

--- a/packages/authhero/src/routes/management-api/custom-domains.ts
+++ b/packages/authhero/src/routes/management-api/custom-domains.ts
@@ -6,6 +6,7 @@ import {
   customDomainCertificateUploadSchema,
   customDomainInsertSchema,
   customDomainSchema,
+  customDomainUpdateSchema,
   LogTypes,
 } from "@authhero/adapter-interfaces";
 import { logMessage } from "../../helpers/logging";
@@ -166,7 +167,7 @@ const patchById = defineRoute({
       body: {
         content: {
           "application/json": {
-            schema: z.object(customDomainSchema.shape).partial(),
+            schema: customDomainUpdateSchema,
           },
         },
       },

--- a/packages/authhero/src/routes/proxy-control-plane/index.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/index.ts
@@ -50,19 +50,10 @@ export interface ProxyControlPlaneOptions {
   resolveHost: (host: string) => Promise<ResolvedHost | null>;
 
   /**
-   * URL of the JWKS document used to verify control-plane bearer tokens.
-   *
-   * Tokens MUST be signed by a key in this JWKS, carry an `iss` matching
-   * the runtime `env.ISSUER` (strict URL equality after trailing-slash
-   * normalization), and include the `proxy:resolve_host` scope.
-   */
-  jwksUrl: string;
-
-  /**
-   * Optional fetch override for `jwksUrl`. Defaults to global `fetch`.
-   * Hosts on Cloudflare Workers can pass
-   * `(url) => env.JWKS_SERVICE.fetch(url)` to route through a service
-   * binding instead of the public network.
+   * Optional fetch override for the per-issuer JWKS document. Called with
+   * the derived URL (`<iss>/.well-known/jwks.json`); defaults to global
+   * `fetch`. Hosts on Cloudflare Workers can route specific hosts through a
+   * service binding by inspecting the URL and dispatching accordingly.
    */
   jwksFetch?: (url: string) => Promise<Response>;
 
@@ -93,9 +84,12 @@ function extractBearerToken(request: Request): string | null {
  * `POST /sync` for tenant shards to replicate custom_domains / proxy_routes
  * mutations. Mount under `/api/v2/proxy/control-plane`.
  *
- * Authentication is built in: requests must carry a `Bearer` JWT signed by
- * a key published at `options.jwksUrl`, with `iss` matching the runtime
- * `env.ISSUER` and scope `proxy:resolve_host`.
+ * Authentication is built in: requests must carry a `Bearer` JWT whose `iss`
+ * is either the runtime `env.ISSUER` or the host the request actually
+ * arrived on (`x-forwarded-host` or the request URL's host). The verifier
+ * then fetches `<iss>/.well-known/jwks.json` to validate the signature, so
+ * each accepted host must publish its own JWKS at that path. Tokens must
+ * also carry the `proxy:resolve_host` scope.
  */
 export function createProxyControlPlaneApp(
   options: ProxyControlPlaneOptions,
@@ -103,16 +97,29 @@ export function createProxyControlPlaneApp(
   const app = new Hono<{ Bindings: Bindings }>();
 
   async function authenticate(c: {
-    req: { raw: Request };
+    req: { raw: Request; header(name: string): string | undefined; url: string };
     env: Bindings;
   }): Promise<{ ok: true } | { ok: false; reason: string }> {
     const token = extractBearerToken(c.req.raw);
     if (!token) return { ok: false, reason: "missing bearer token" };
+
+    // Accept either the canonical ISSUER (legacy callers) or the host the
+    // request actually landed on. The latter covers both tenant subdomains
+    // (e.g. `sesamy.token.sesamy.com`) and registered custom domains
+    // fronted by `@authhero/proxy` (e.g. `login.parcferme.no`) — both
+    // collapse to "iss equals the request host" because only authhero can
+    // mint tokens signed by a key in that host's JWKS.
+    const inboundHost =
+      c.req.header("x-forwarded-host") ?? new URL(c.req.url).host;
+    const inboundIssuer = `https://${inboundHost}/`;
+    const expectedIssuers = Array.from(
+      new Set([c.env.ISSUER, inboundIssuer]),
+    );
+
     return verifyControlPlaneToken({
       token,
-      jwksUrl: options.jwksUrl,
       jwksFetch: options.jwksFetch,
-      expectedIssuer: c.env.ISSUER,
+      expectedIssuers,
       requiredScope: PROXY_RESOLVE_HOST_SCOPE,
     });
   }

--- a/packages/authhero/src/routes/proxy-control-plane/verify.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/verify.ts
@@ -47,14 +47,21 @@ export type VerifyControlPlaneTokenResult =
 export interface VerifyControlPlaneTokenOptions {
   /** Compact JWS to verify. */
   token: string;
-  /** JWKS document URL. */
-  jwksUrl: string;
   /** Optional fetch override — defaults to global `fetch`. */
   jwksFetch?: (url: string) => Promise<Response>;
-  /** Expected `iss` claim (compared via {@link isAllowedIssuer}). */
-  expectedIssuer: string;
+  /**
+   * Set of acceptable `iss` claim values. Comparison is strict URL equality
+   * (after trailing-slash normalization) via {@link isAllowedIssuer}. The
+   * verifier fetches the per-issuer JWKS from `<iss>/.well-known/jwks.json`,
+   * so any host you list here must publish its own JWKS at that path.
+   */
+  expectedIssuers: string[];
   /** Required `scope` (space-separated). Defaults to `proxy:resolve_host`. */
   requiredScope?: string;
+}
+
+function deriveJwksUrl(iss: string): string {
+  return new URL("/.well-known/jwks.json", iss).href;
 }
 
 /**
@@ -65,17 +72,22 @@ export interface VerifyControlPlaneTokenOptions {
  * Accepted algs: RS256/384/512, ES256/384/512. The JWK's `alg` must match
  * the token header's `alg`. The token must carry the configured required
  * scope (`proxy:resolve_host` by default) and an `iss` that strictly equals
- * `expectedIssuer` after URL normalization.
+ * one of `expectedIssuers` after URL normalization. The JWKS document is
+ * fetched from `<iss>/.well-known/jwks.json` AFTER the `iss` is allow-listed,
+ * so an attacker cannot redirect the verifier to a JWKS they control.
  */
 export async function verifyControlPlaneToken(
   options: VerifyControlPlaneTokenOptions,
 ): Promise<VerifyControlPlaneTokenResult> {
-  const { token, jwksUrl, jwksFetch, expectedIssuer } = options;
+  const { token, jwksFetch, expectedIssuers } = options;
   const requiredScope = options.requiredScope ?? PROXY_RESOLVE_HOST_SCOPE;
 
   let header: { alg?: unknown; kid?: unknown };
+  let unverifiedPayload: { iss?: unknown };
   try {
-    header = decode(token).header as { alg?: unknown; kid?: unknown };
+    const decoded = decode(token);
+    header = decoded.header as { alg?: unknown; kid?: unknown };
+    unverifiedPayload = decoded.payload as { iss?: unknown };
   } catch {
     return { ok: false, reason: "malformed token" };
   }
@@ -86,6 +98,19 @@ export async function verifyControlPlaneToken(
     return { ok: false, reason: "missing kid" };
   }
 
+  // Allow-list the issuer BEFORE fetching anything: this is what prevents a
+  // forged token from steering the JWKS fetch to an attacker-controlled host.
+  if (
+    typeof unverifiedPayload.iss !== "string" ||
+    !expectedIssuers.some((expected) =>
+      isAllowedIssuer(unverifiedPayload.iss as string, expected),
+    )
+  ) {
+    return { ok: false, reason: "issuer mismatch" };
+  }
+  const iss = unverifiedPayload.iss;
+
+  const jwksUrl = deriveJwksUrl(iss);
   const fetchFn = jwksFetch ?? fetch;
   let jwksRes: Response;
   try {
@@ -128,21 +153,13 @@ export async function verifyControlPlaneToken(
     return { ok: false, reason: "key import failed" };
   }
 
-  let verifiedPayload: { iss?: unknown; scope?: unknown };
+  let verifiedPayload: { scope?: unknown };
   try {
     verifiedPayload = (await verify(token, cryptoKey, alg)) as {
-      iss?: unknown;
       scope?: unknown;
     };
   } catch {
     return { ok: false, reason: "signature verification failed" };
-  }
-
-  if (
-    typeof verifiedPayload.iss !== "string" ||
-    !isAllowedIssuer(verifiedPayload.iss, expectedIssuer)
-  ) {
-    return { ok: false, reason: "issuer mismatch" };
   }
 
   const scopeClaim = verifiedPayload.scope;

--- a/packages/authhero/src/types/AuthHeroConfig.ts
+++ b/packages/authhero/src/types/AuthHeroConfig.ts
@@ -323,25 +323,23 @@ export interface AuthHeroConfig {
    * which returns the cross-tenant `ResolvedHost` for the given hostname.
    *
    * Authentication is opinionated and built in: incoming requests must
-   * carry a `Bearer` JWT signed by a key in `jwksUrl`, with `iss` matching
-   * the runtime `env.ISSUER` (strict URL equality after trailing-slash
-   * normalization) and the `proxy:resolve_host` scope. The matching
-   * client-side helper is `createHttpProxyAdapter` in `@authhero/proxy`.
+   * carry a `Bearer` JWT whose `iss` is either the runtime `env.ISSUER`
+   * or the host the request landed on (tenant subdomain or registered
+   * custom domain). The verifier fetches `<iss>/.well-known/jwks.json` to
+   * validate the signature, so each accepted host must publish its own
+   * JWKS at that path. Tokens must also carry the `proxy:resolve_host`
+   * scope. The matching client-side helper is `createHttpProxyAdapter`
+   * in `@authhero/proxy`.
    */
   proxyControlPlane?: {
     resolveHost: (
       host: string,
     ) => Promise<import("@authhero/proxy").ResolvedHost | null>;
     /**
-     * JWKS document URL used to verify the bearer token. On a single-shard
-     * deployment this is typically `${env.ISSUER}/.well-known/jwks.json`.
-     */
-    jwksUrl: string;
-    /**
-     * Optional fetch override for `jwksUrl`. Defaults to global `fetch`.
-     * Hosts on Cloudflare Workers can pass
-     * `(url) => env.JWKS_SERVICE.fetch(url)` to route through a service
-     * binding instead of the public network.
+     * Optional fetch override for the per-issuer JWKS document. Called
+     * with the derived URL (`<iss>/.well-known/jwks.json`); defaults to
+     * global `fetch`. Hosts on Cloudflare Workers can route specific
+     * hosts through a service binding by inspecting the URL.
      */
     jwksFetch?: (url: string) => Promise<Response>;
     /**

--- a/packages/authhero/test/routes/proxy-control-plane/sync.spec.ts
+++ b/packages/authhero/test/routes/proxy-control-plane/sync.spec.ts
@@ -233,7 +233,6 @@ describe("POST /sync route", () => {
     const keyset = await createTestKeyset();
     const app = createProxyControlPlaneApp({
       resolveHost: async () => null,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
       applySyncEvents,
     });
@@ -344,7 +343,6 @@ describe("GET /hosts/:host route", () => {
     const keyset = await createTestKeyset();
     const app = createProxyControlPlaneApp({
       resolveHost: async () => null,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
     });
     const res = await app.request(
@@ -359,7 +357,6 @@ describe("GET /hosts/:host route", () => {
     const keyset = await createTestKeyset();
     const app = createProxyControlPlaneApp({
       resolveHost: async () => null,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
     });
     const auth = await bearer(keyset);
@@ -381,7 +378,6 @@ describe("GET /hosts/:host route", () => {
     };
     const app = createProxyControlPlaneApp({
       resolveHost: async () => resolved,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
     });
     const auth = await bearer(keyset);
@@ -392,5 +388,83 @@ describe("GET /hosts/:host route", () => {
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual(resolved);
+  });
+
+  it("accepts a token whose iss matches a tenant-subdomain x-forwarded-host", async () => {
+    // Caller proxies through to the control plane on a tenant subdomain.
+    // The token was minted by that subdomain (iss = subdomain), so the
+    // verifier must accept it even though it doesn't match env.ISSUER.
+    const tenantHost = "sesamy.token.sesamy.com";
+    const tenantIssuer = `https://${tenantHost}/`;
+    const tenantKeyset = await createTestKeyset({
+      jwksUrl: `https://${tenantHost}/.well-known/jwks.json`,
+    });
+    const app = createProxyControlPlaneApp({
+      resolveHost: async () => ({
+        tenant_id: "sesamy",
+        custom_domain_id: "cd-1",
+        domain: "login.parcferme.no",
+        routes: [],
+      }),
+      jwksFetch: tenantKeyset.jwksFetch,
+    });
+    const auth = await bearer(tenantKeyset, { iss: tenantIssuer });
+    const res = await app.request(
+      "/hosts/login.parcferme.no",
+      {
+        headers: { authorization: auth, "x-forwarded-host": tenantHost },
+      },
+      envWithIssuer(),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a token whose iss matches a custom-domain x-forwarded-host", async () => {
+    // End-user-visible custom domain (e.g. a publisher's login host) fronts
+    // the proxy → control plane call. The token's iss is the custom domain,
+    // its JWKS lives there, and the verifier should accept it.
+    const customHost = "login.parcferme.no";
+    const customIssuer = `https://${customHost}/`;
+    const customKeyset = await createTestKeyset({
+      jwksUrl: `https://${customHost}/.well-known/jwks.json`,
+    });
+    const app = createProxyControlPlaneApp({
+      resolveHost: async () => ({
+        tenant_id: "tenant-1",
+        custom_domain_id: "cd-1",
+        domain: customHost,
+        routes: [],
+      }),
+      jwksFetch: customKeyset.jwksFetch,
+    });
+    const auth = await bearer(customKeyset, { iss: customIssuer });
+    const res = await app.request(
+      `/hosts/${customHost}`,
+      {
+        headers: { authorization: auth, "x-forwarded-host": customHost },
+      },
+      envWithIssuer(),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a token whose iss matches neither env.ISSUER nor the inbound host", async () => {
+    const keyset = await createTestKeyset();
+    const app = createProxyControlPlaneApp({
+      resolveHost: async () => null,
+      jwksFetch: keyset.jwksFetch,
+    });
+    const auth = await bearer(keyset, { iss: "https://attacker.example/" });
+    const res = await app.request(
+      "/hosts/auth.example.com",
+      {
+        headers: {
+          authorization: auth,
+          "x-forwarded-host": "sesamy.token.sesamy.com",
+        },
+      },
+      envWithIssuer(),
+    );
+    expect(res.status).toBe(401);
   });
 });

--- a/packages/authhero/test/routes/proxy-control-plane/verify.spec.ts
+++ b/packages/authhero/test/routes/proxy-control-plane/verify.spec.ts
@@ -53,7 +53,7 @@ describe("isAllowedIssuer", () => {
 });
 
 describe("verifyControlPlaneToken", () => {
-  it("accepts a well-formed token with the right issuer + scope", async () => {
+  it("accepts a well-formed token whose iss matches the only expected issuer", async () => {
     const keyset = await createTestKeyset();
     const token = await keyset.sign({
       payload: {
@@ -64,15 +64,71 @@ describe("verifyControlPlaneToken", () => {
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
-      expectedIssuer: ISSUER,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toEqual({ ok: true });
   });
 
-  it("rejects when iss has a different subdomain", async () => {
+  it("accepts a token whose iss matches a tenant subdomain in expectedIssuers (per-host JWKS)", async () => {
+    // Each host publishes its own JWKS. Build a keyset rooted at the
+    // subdomain so the derived JWKS URL (`<iss>/.well-known/jwks.json`)
+    // routes to that keyset's signer.
+    const tenantIssuer = "https://sesamy.token.sesamy.com/";
+    const tenantKeyset = await createTestKeyset({
+      jwksUrl: "https://sesamy.token.sesamy.com/.well-known/jwks.json",
+    });
+    const token = await tenantKeyset.sign({
+      payload: { iss: tenantIssuer, scope: PROXY_RESOLVE_HOST_SCOPE },
+    });
+    const result = await verifyControlPlaneToken({
+      token,
+      jwksFetch: tenantKeyset.jwksFetch,
+      expectedIssuers: ["https://token.sesamy.com/", tenantIssuer],
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("derives the JWKS URL from iss — a token signed for issuer A is rejected when JWKS for B has no matching kid", async () => {
+    // Two hosts, two keysets — issuing host's kid is NOT in the other
+    // host's JWKS. The verifier must fetch from the iss-derived URL, so
+    // forging an iss-host claim cannot reuse a different host's keys.
+    const hostA = "https://a.example.test/";
+    const hostB = "https://b.example.test/";
+    const ksA = await createTestKeyset({
+      kid: "kid-a",
+      jwksUrl: "https://a.example.test/.well-known/jwks.json",
+    });
+    const ksB = await createTestKeyset({
+      kid: "kid-b",
+      jwksUrl: "https://b.example.test/.well-known/jwks.json",
+    });
+    // Compose a fetcher that knows both hosts.
+    const fetcher = async (url: string): Promise<Response> => {
+      if (url.startsWith("https://a.example.test/")) return ksA.jwksFetch(url);
+      if (url.startsWith("https://b.example.test/")) return ksB.jwksFetch(url);
+      return new Response("not found", { status: 404 });
+    };
+    // Token claims iss = hostB but is signed by ksA (kid-a). The verifier
+    // fetches host B's JWKS, which only has kid-b → "unknown kid".
+    const token = await ksA.sign({
+      payload: { iss: hostB, scope: PROXY_RESOLVE_HOST_SCOPE },
+    });
+    const result = await verifyControlPlaneToken({
+      token,
+      jwksFetch: fetcher,
+      expectedIssuers: [hostA, hostB],
+    });
+    expect(result).toMatchObject({ ok: false, reason: "unknown kid" });
+  });
+
+  it("rejects when iss is not in expectedIssuers (before any JWKS fetch)", async () => {
     const keyset = await createTestKeyset();
+    let fetchCalls = 0;
+    const fetcher = async (url: string): Promise<Response> => {
+      fetchCalls += 1;
+      return keyset.jwksFetch(url);
+    };
     const token = await keyset.sign({
       payload: {
         iss: "https://evil.example.test/",
@@ -81,11 +137,13 @@ describe("verifyControlPlaneToken", () => {
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: keyset.jwksUrl,
-      jwksFetch: keyset.jwksFetch,
-      expectedIssuer: ISSUER,
+      jwksFetch: fetcher,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toMatchObject({ ok: false, reason: "issuer mismatch" });
+    // Critical: an unallowed iss must NOT trigger a JWKS fetch — that's
+    // how host allow-listing prevents SSRF / attacker-controlled JWKS.
+    expect(fetchCalls).toBe(0);
   });
 
   it("rejects when iss is on a different path under the same host", async () => {
@@ -98,9 +156,8 @@ describe("verifyControlPlaneToken", () => {
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
-      expectedIssuer: ISSUER,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toMatchObject({ ok: false, reason: "issuer mismatch" });
   });
@@ -115,9 +172,8 @@ describe("verifyControlPlaneToken", () => {
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
-      expectedIssuer: ISSUER,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toMatchObject({
       ok: false,
@@ -133,9 +189,8 @@ describe("verifyControlPlaneToken", () => {
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
-      expectedIssuer: ISSUER,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toMatchObject({ ok: false, reason: "unsupported alg" });
   });
@@ -148,9 +203,8 @@ describe("verifyControlPlaneToken", () => {
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
-      expectedIssuer: ISSUER,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toMatchObject({ ok: false, reason: "missing kid" });
   });
@@ -163,27 +217,22 @@ describe("verifyControlPlaneToken", () => {
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
-      expectedIssuer: ISSUER,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toMatchObject({ ok: false, reason: "unknown kid" });
   });
 
   it("rejects when the jwk's published alg disagrees with the header alg", async () => {
     const keyset = await createTestKeyset({ alg: "RS256" });
-    // Token is signed RS256 (real), but the JWKS publishes alg=RS384 for the
-    // same kid. The verifier must not let a key be reused under a different
-    // alg even if the kid matches.
     const token = await keyset.sign({
       payload: { iss: ISSUER, scope: PROXY_RESOLVE_HOST_SCOPE },
       jwkAlg: "RS384",
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: keyset.jwksFetch,
-      expectedIssuer: ISSUER,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toMatchObject({
       ok: false,
@@ -194,16 +243,13 @@ describe("verifyControlPlaneToken", () => {
   it("rejects a token signed by a different key (signature failure)", async () => {
     const goodKeyset = await createTestKeyset({ kid: "kid-good" });
     const evilKeyset = await createTestKeyset({ kid: "kid-good" });
-    // Evil signer mints a token claiming the good kid; the good JWKS has a
-    // different public key for that kid, so the signature won't verify.
     const token = await evilKeyset.sign({
       payload: { iss: ISSUER, scope: PROXY_RESOLVE_HOST_SCOPE },
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: goodKeyset.jwksUrl,
       jwksFetch: goodKeyset.jwksFetch,
-      expectedIssuer: ISSUER,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toMatchObject({
       ok: false,
@@ -223,9 +269,8 @@ describe("verifyControlPlaneToken", () => {
     });
     const result = await verifyControlPlaneToken({
       token,
-      jwksUrl: keyset.jwksUrl,
       jwksFetch: fetcher,
-      expectedIssuer: ISSUER,
+      expectedIssuers: [ISSUER],
     });
     expect(result).toEqual({ ok: true });
     expect(calls).toBe(1);

--- a/packages/cloudflare/src/customDomains/index.ts
+++ b/packages/cloudflare/src/customDomains/index.ts
@@ -202,18 +202,30 @@ export function createCustomDomainsAdapter(
       // Fall back to the DB-authoritative record when Cloudflare is
       // unreachable or returns an unparseable response. status, verification,
       // and domain_metadata are mirrored on every create/update, so the DB
-      // row is enough to render this domain.
+      // row is enough to render this domain. We log the reason loudly so
+      // stale-data symptoms can be traced via `wrangler tail` instead of
+      // silently rotting in production.
       let body: unknown;
       try {
         body = await getClient(config)
           .get(`/custom_hostnames/${encodeURIComponent(domain_id)}`)
           .json();
-      } catch {
+      } catch (err) {
+        console.warn(
+          `[custom-domains] CF fetch failed for ${domain_id} (tenant=${tenant_id}); returning stale DB row:`,
+          err instanceof Error ? err.message : err,
+        );
         return customDomain;
       }
 
       const parsed = customDomainResponseSchema.safeParse(body);
       if (!parsed.success || !parsed.data.success) {
+        console.warn(
+          `[custom-domains] CF response unparseable for ${domain_id} (tenant=${tenant_id}); returning stale DB row.`,
+          parsed.success
+            ? { cfErrors: parsed.data.errors }
+            : { zodIssues: parsed.error.issues, body },
+        );
         return customDomain;
       }
 
@@ -226,8 +238,23 @@ export function createCustomDomainsAdapter(
         throw new HTTPException(404);
       }
 
-      // Merge the database data with the Cloudflare data
-      return mapCustomDomainResponse({ ...customDomain, ...result });
+      const merged = mapCustomDomainResponse({ ...customDomain, ...result });
+
+      // Mirror the fresh Cloudflare state back to the DB so list() and the
+      // next get() reflect reality. Only write if something actually changed
+      // to avoid pointless updated_at churn.
+      if (
+        merged.status !== customDomain.status ||
+        JSON.stringify(merged.verification) !==
+          JSON.stringify(customDomain.verification)
+      ) {
+        await config.customDomainAdapter.update(tenant_id, domain_id, {
+          status: merged.status,
+          verification: merged.verification,
+        });
+      }
+
+      return merged;
     },
     getByDomain: async (domain: string) => {
       // This is used for tenant id resolution and needs to be fast


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Custom domain PATCH endpoint now accepts only `tls_policy`, `custom_client_ip_header`, and `domain_metadata` fields; updates with immutable fields will be rejected.
  * Proxy control plane configuration: `proxyControlPlane.jwksUrl` option removed; JWKS URL is now derived per request based on verified issuer.

* **New Features**
  * Multi-issuer support: proxy control plane now accepts bearer tokens from canonical issuer or tenant subdomains/custom domain hosts.

* **Improvements**
  * Custom domain status and verification syncing now more efficient, updating database only when values change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->