### PR TITLE
keep login sessions alive

### DIFF
--- a/.changeset/session-keeps-login-session-alive.md
+++ b/.changeset/session-keeps-login-session-alive.md
@@ -1,0 +1,11 @@
+---
+"@authhero/kysely-adapter": patch
+"@authhero/drizzle": patch
+---
+
+Keep the parent `login_session` alive when a session is created or renewed.
+Previously only `refresh_tokens` extended their `login_session`'s expiry, so a
+long-lived session could outlive its `login_session` and be orphaned when
+cleanup reaped the `login_session`. `sessions.create` and `sessions.update` now
+bump the parent `login_session`'s `expires_at` (never shortening), mirroring the
+`refresh_tokens` behavior.

--- a/packages/adapter-interfaces/src/adapters/Sessions.ts
+++ b/packages/adapter-interfaces/src/adapters/Sessions.ts
@@ -6,9 +6,26 @@ export interface ListSesssionsResponse extends Totals {
 }
 
 export interface SessionsAdapter {
+  /**
+   * ADAPTER RESPONSIBILITY (footgun): when a session is created with an
+   * `expires_at`/`idle_expires_at`, the adapter MUST extend the parent
+   * `login_session` (referenced by `login_session_id`) so it lives at least as
+   * long as the session — never shortening it (only bump when the session's
+   * expiry is further out than the login_session's current expiry).
+   *
+   * If an adapter skips this, a long-lived session outlives its login_session
+   * and gets orphaned when cleanup reaps the login_session. The bump must be
+   * atomic with the insert. See `refreshTokens` for the equivalent contract.
+   */
   create: (tenant_id: string, session: SessionInsert) => Promise<Session>;
   get: (tenant_id: string, id: string) => Promise<Session | null>;
   list(tenantId: string, params?: ListParams): Promise<ListSesssionsResponse>;
+  /**
+   * ADAPTER RESPONSIBILITY (footgun): when an update moves `expires_at`/
+   * `idle_expires_at` forward (session renewal), the adapter MUST extend the
+   * parent `login_session` the same way `create` does (never shortening). See
+   * the note on `create` above.
+   */
   update: (
     tenant_id: string,
     id: string,

--- a/packages/authhero/test/authentication-flows/sessionLoginSessionBump.spec.ts
+++ b/packages/authhero/test/authentication-flows/sessionLoginSessionBump.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { Context } from "hono";
+import { createFrontChannelAuthResponse } from "../../src/authentication-flows/common";
+import { getTestServer } from "../helpers/test-server";
+import { Bindings, Variables } from "../../src/types";
+import { getEnrichedClient } from "../../src/helpers/client";
+import { AuthorizationResponseType } from "@authhero/adapter-interfaces";
+
+/**
+ * Flow-level (adapter-independent) guarantee: when the login flow creates a new
+ * session that outlives its login_session, the login_session expiry must be
+ * extended so it isn't reaped while a live session still references it. This is
+ * the orphaned-session bug observed in production.
+ */
+describe("login flow keeps login_session alive when creating a session", () => {
+  it("extends the login_session expiry to outlive a newly created session", async () => {
+    const { env } = await getTestServer();
+
+    // Tenant with long session lifetimes so the created session outlives the
+    // short-lived login_session below.
+    await env.data.tenants.update("tenantId", {
+      session_lifetime: 24 * 30, // 30 days (hours)
+      idle_session_lifetime: 24 * 7, // 7 days (hours)
+    });
+
+    const ctx = {
+      env,
+      var: { tenant_id: "tenantId" },
+      req: {
+        header: () => {},
+        query: () => {},
+        queries: () => {},
+      },
+      header: () => null,
+    } as unknown as Context<{ Bindings: Bindings; Variables: Variables }>;
+
+    // Short-lived login_session (5 minutes)
+    const loginSession = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 1000 * 60 * 5).toISOString(),
+      csrf_token: "csrfToken",
+      authParams: {
+        client_id: "clientId",
+        username: "foo@example.com",
+        scope: "openid",
+        audience: "http://example.com",
+        redirect_uri: "http://example.com/callback",
+      },
+    });
+
+    const expiresBefore = new Date(loginSession.expires_at).getTime();
+
+    const client = await getEnrichedClient(env, "clientId");
+    const user = await env.data.users.get("tenantId", "email|userId");
+    if (!client || !user) {
+      throw new Error("Client or user not found");
+    }
+
+    const response = (await createFrontChannelAuthResponse(ctx, {
+      authParams: {
+        client_id: "clientId",
+        response_type: AuthorizationResponseType.CODE,
+        scope: "openid",
+        redirect_uri: "http://example.com/callback",
+      },
+      client,
+      user,
+      loginSession,
+    })) as Response;
+
+    expect(response.status).toEqual(302);
+
+    const updatedLoginSession = await env.data.loginSessions.get(
+      "tenantId",
+      loginSession.id,
+    );
+    expect(updatedLoginSession?.session_id).toBeTruthy();
+
+    // The created session lives for ~7-30 days, so the login_session must have
+    // been extended well past its original 5-minute expiry.
+    const createdSession = await env.data.sessions.get(
+      "tenantId",
+      updatedLoginSession!.session_id!,
+    );
+    const sessionExpiry = Math.max(
+      createdSession?.expires_at
+        ? new Date(createdSession.expires_at).getTime()
+        : 0,
+      createdSession?.idle_expires_at
+        ? new Date(createdSession.idle_expires_at).getTime()
+        : 0,
+    );
+
+    const expiresAfter = new Date(updatedLoginSession!.expires_at).getTime();
+    expect(expiresAfter).toBeGreaterThan(expiresBefore);
+    expect(expiresAfter).toBeGreaterThanOrEqual(sessionExpiry);
+  });
+});

--- a/packages/authhero/test/authentication-flows/sessionLoginSessionBump.spec.ts
+++ b/packages/authhero/test/authentication-flows/sessionLoginSessionBump.spec.ts
@@ -81,6 +81,9 @@ describe("login flow keeps login_session alive when creating a session", () => {
       "tenantId",
       updatedLoginSession!.session_id!,
     );
+    // Guard the expiry math below: without this the `?? 0` fallbacks would let a
+    // missing child session pass the comparison vacuously.
+    expect(createdSession).toBeTruthy();
     const sessionExpiry = Math.max(
       createdSession?.expires_at
         ? new Date(createdSession.expires_at).getTime()

--- a/packages/authhero/test/routes/auth-api/token.spec.ts
+++ b/packages/authhero/test/routes/auth-api/token.spec.ts
@@ -1557,6 +1557,61 @@ describe("token", () => {
       ).toBeGreaterThanOrEqual(new Date(idle_expires_at).getTime());
     });
 
+    it("still exchanges when login_id points at a deleted login_session (orphaned)", async () => {
+      // Prod produced refresh tokens whose login_id references a login_session
+      // that cleanup later removed (FKs aren't enforced on Vitess). The exchange
+      // must treat the login_session as optional — validity is governed by the
+      // refresh_token row itself. The only degradation is a missing session
+      // cookie / auth_connection fallback. Guard against a future regression
+      // that turns a dangling login_id into a hard failure.
+      const { oauthApp, env } = await getTestServer();
+      const client = testClient(oauthApp, env);
+
+      const idle_expires_at = new Date(
+        Date.now() + 1000 * 60 * 60,
+      ).toISOString();
+
+      await env.data.refreshTokens.create("tenantId", {
+        id: "orphanedRefreshToken",
+        // login_session "doesNotExist" is never created.
+        login_id: "doesNotExist",
+        user_id: "email|userId",
+        client_id: "clientId",
+        resource_servers: [{ audience: "http://example.com", scopes: "openid" }],
+        device: {
+          last_ip: "",
+          initial_ip: "",
+          last_user_agent: "",
+          initial_user_agent: "",
+          initial_asn: "",
+          last_asn: "",
+        },
+        rotating: false,
+        idle_expires_at,
+        expires_at: idle_expires_at,
+      });
+
+      const response = await client.oauth.token.$post(
+        // @ts-expect-error - testClient type requires both form and json
+        {
+          form: {
+            grant_type: "refresh_token",
+            refresh_token: "orphanedRefreshToken",
+            client_id: "clientId",
+          },
+        },
+        { headers: { "tenant-id": "tenantId" } },
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as TokenResponse;
+      expect(body).toMatchObject({
+        access_token: expect.any(String),
+        refresh_token: expect.any(String),
+        id_token: expect.any(String),
+      });
+    });
+
     it("should extend login_session expires_at when refresh token is exchanged", async () => {
       const { oauthApp, env } = await getTestServer();
       const client = testClient(oauthApp, env);

--- a/packages/drizzle/src/adapters/sessions.ts
+++ b/packages/drizzle/src/adapters/sessions.ts
@@ -1,7 +1,7 @@
-import { eq, and, count as countFn, asc, desc } from "drizzle-orm";
+import { eq, and, lt, count as countFn, asc, desc, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { Session, ListParams } from "@authhero/adapter-interfaces";
-import { sessions } from "../schema/sqlite";
+import { sessions, loginSessions } from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import { convertDatesToAdapter, isoToDbDate } from "../helpers/dates";
 import { buildLuceneFilter } from "../helpers/filter";
@@ -56,6 +56,13 @@ function sqlToSession(row: any): Session {
   });
 }
 
+function maxExpiry(
+  a: number | null | undefined,
+  b: number | null | undefined,
+): number {
+  return Math.max(a ?? 0, b ?? 0);
+}
+
 export function createSessionsAdapter(db: DrizzleDb) {
   return {
     async create(tenant_id: string, session: any): Promise<Session> {
@@ -82,7 +89,42 @@ export function createSessionsAdapter(db: DrizzleDb) {
         revoked_at_ts: isoToDbDate(session.revoked_at),
       };
 
-      await db.insert(sessions).values(values);
+      // Use manual BEGIN/COMMIT/ROLLBACK because Drizzle's built-in
+      // db.transaction() doesn't support async callbacks with better-sqlite3.
+      // TODO: switch to db.batch() in a follow-up PR — interactive
+      // BEGIN/COMMIT does not provide atomicity on D1 (async driver).
+      await db.run(sql`BEGIN`);
+      try {
+        await db.insert(sessions).values(values);
+
+        const newLoginSessionExpiry = maxExpiry(
+          values.expires_at_ts,
+          values.idle_expires_at_ts,
+        );
+        if (newLoginSessionExpiry > 0 && values.login_session_id) {
+          // Keep the parent login_session alive at least as long as this
+          // session. The `expires_at_ts < ?` predicate makes this "never
+          // shorten" atomic, mirroring refreshTokens.create.
+          await db
+            .update(loginSessions)
+            .set({
+              expires_at_ts: newLoginSessionExpiry,
+              updated_at_ts: now,
+            })
+            .where(
+              and(
+                eq(loginSessions.tenant_id, tenant_id),
+                eq(loginSessions.id, values.login_session_id),
+                lt(loginSessions.expires_at_ts, newLoginSessionExpiry),
+              ),
+            );
+        }
+
+        await db.run(sql`COMMIT`);
+      } catch (err) {
+        await db.run(sql`ROLLBACK`);
+        throw err;
+      }
 
       return sqlToSession({ ...values, tenant_id });
     },
@@ -134,6 +176,36 @@ export function createSessionsAdapter(db: DrizzleDb) {
         .set(updateData)
         .where(and(eq(sessions.tenant_id, tenant_id), eq(sessions.id, id)))
         .returning();
+
+      // When a session is renewed (its expiry slides forward), keep the parent
+      // login_session alive at least as long. Best-effort and idempotent
+      // (WHERE expires_at_ts < new), mirroring the create path. Only fires when
+      // an expiry field is actually being updated.
+      const newLoginSessionExpiry = maxExpiry(
+        updateData.expires_at_ts,
+        updateData.idle_expires_at_ts,
+      );
+      const updatedSession = results[0];
+      if (newLoginSessionExpiry > 0 && updatedSession) {
+        const loginSessionId =
+          session.login_session_id ?? updatedSession.login_session_id;
+        if (loginSessionId) {
+          await db
+            .update(loginSessions)
+            .set({
+              expires_at_ts: newLoginSessionExpiry,
+              updated_at_ts: Date.now(),
+            })
+            .where(
+              and(
+                eq(loginSessions.tenant_id, tenant_id),
+                eq(loginSessions.id, loginSessionId),
+                lt(loginSessions.expires_at_ts, newLoginSessionExpiry),
+              ),
+            )
+            .catch(() => {});
+        }
+      }
 
       return results.length > 0;
     },

--- a/packages/drizzle/test/adapters/sessionLoginSessionBump.test.ts
+++ b/packages/drizzle/test/adapters/sessionLoginSessionBump.test.ts
@@ -104,4 +104,33 @@ describe("sessions adapter keeps parent login_session alive", () => {
     const after = await data.loginSessions.get("tenantId", loginSession.id);
     expect(after?.expires_at).toEqual(renewedExpiry);
   });
+
+  it("never shortens an already-longer login_session when a session is renewed (update)", async () => {
+    const renewedExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 5,
+    ).toISOString(); // 5d
+    const longExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 30,
+    ).toISOString(); // 30d — already longer than the renewed session
+
+    const loginSession = await createLoginSession(longExpiry);
+
+    await data.sessions.create("tenantId", {
+      id: "session1",
+      user_id: "email|userId",
+      login_session_id: loginSession.id,
+      expires_at: renewedExpiry,
+      idle_expires_at: renewedExpiry,
+      device: device(),
+      clients: ["clientId"],
+    });
+
+    // Renewing to a shorter idle expiry must not pull the parent back in time.
+    await data.sessions.update("tenantId", "session1", {
+      idle_expires_at: renewedExpiry,
+    });
+
+    const after = await data.loginSessions.get("tenantId", loginSession.id);
+    expect(after?.expires_at).toEqual(longExpiry);
+  });
 });

--- a/packages/drizzle/test/adapters/sessionLoginSessionBump.test.ts
+++ b/packages/drizzle/test/adapters/sessionLoginSessionBump.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+
+function device() {
+  return {
+    last_ip: "",
+    initial_ip: "",
+    last_user_agent: "",
+    initial_user_agent: "",
+    initial_asn: "",
+    last_asn: "",
+  };
+}
+
+describe("sessions adapter keeps parent login_session alive", () => {
+  let data: ReturnType<typeof getTestServer>["data"];
+
+  beforeEach(async () => {
+    const server = getTestServer();
+    data = server.data;
+
+    await data.tenants.create({ id: "tenantId", name: "Test Tenant" });
+  });
+
+  async function createLoginSession(expiresAt: string) {
+    return data.loginSessions.create("tenantId", {
+      csrf_token: "csrf",
+      authParams: { client_id: "clientId" },
+      expires_at: expiresAt,
+      state: "pending",
+    });
+  }
+
+  it("extends login_session.expires_at to match the session's longest expiry on create", async () => {
+    const shortExpiry = new Date(Date.now() + 1000 * 60 * 60).toISOString(); // 1h
+    const absoluteExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 7,
+    ).toISOString(); // 7d
+    const idleExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 3,
+    ).toISOString(); // 3d
+
+    const loginSession = await createLoginSession(shortExpiry);
+
+    await data.sessions.create("tenantId", {
+      id: "session1",
+      user_id: "email|userId",
+      login_session_id: loginSession.id,
+      expires_at: absoluteExpiry,
+      idle_expires_at: idleExpiry,
+      device: device(),
+      clients: ["clientId"],
+    });
+
+    const after = await data.loginSessions.get("tenantId", loginSession.id);
+    expect(after?.expires_at).toEqual(absoluteExpiry);
+  });
+
+  it("never shortens an already-longer login_session on create", async () => {
+    const longExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 30,
+    ).toISOString(); // 30d
+    const shortExpiry = new Date(Date.now() + 1000 * 60 * 60).toISOString(); // 1h
+
+    const loginSession = await createLoginSession(longExpiry);
+
+    await data.sessions.create("tenantId", {
+      id: "session1",
+      user_id: "email|userId",
+      login_session_id: loginSession.id,
+      expires_at: shortExpiry,
+      idle_expires_at: shortExpiry,
+      device: device(),
+      clients: ["clientId"],
+    });
+
+    const after = await data.loginSessions.get("tenantId", loginSession.id);
+    expect(after?.expires_at).toEqual(longExpiry);
+  });
+
+  it("extends login_session.expires_at when a session is renewed (update)", async () => {
+    const initialExpiry = new Date(Date.now() + 1000 * 60 * 60).toISOString(); // 1h
+    const renewedExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 5,
+    ).toISOString(); // 5d
+
+    const loginSession = await createLoginSession(initialExpiry);
+
+    await data.sessions.create("tenantId", {
+      id: "session1",
+      user_id: "email|userId",
+      login_session_id: loginSession.id,
+      expires_at: initialExpiry,
+      idle_expires_at: initialExpiry,
+      device: device(),
+      clients: ["clientId"],
+    });
+
+    // Renew without passing login_session_id — adapter resolves it from the row.
+    await data.sessions.update("tenantId", "session1", {
+      idle_expires_at: renewedExpiry,
+    });
+
+    const after = await data.loginSessions.get("tenantId", loginSession.id);
+    expect(after?.expires_at).toEqual(renewedExpiry);
+  });
+});

--- a/packages/kysely/src/sessions/create.ts
+++ b/packages/kysely/src/sessions/create.ts
@@ -31,23 +31,50 @@ export function create(db: Kysely<Database>) {
       clients,
       ...sessionWithoutDates
     } = session;
-    await db
-      .insertInto("sessions")
-      .values({
-        ...sessionWithoutDates,
-        tenant_id,
-        created_at_ts: now,
-        updated_at_ts: now,
-        authenticated_at_ts: now,
-        last_interaction_at_ts: now,
-        expires_at_ts: isoToDbDate(expires_at),
-        idle_expires_at_ts: isoToDbDate(idle_expires_at),
-        used_at_ts: isoToDbDate(used_at),
-        revoked_at_ts: isoToDbDate(revoked_at),
-        device: JSON.stringify(device),
-        clients: JSON.stringify(clients),
-      })
-      .execute();
+
+    const expiresAtTs = isoToDbDate(expires_at);
+    const idleExpiresAtTs = isoToDbDate(idle_expires_at);
+    // Keep the parent login_session alive at least as long as this session's
+    // furthest-out expiry. See the "never shorten" predicate below.
+    const newLoginSessionExpiry = Math.max(expiresAtTs ?? 0, idleExpiresAtTs ?? 0);
+
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .insertInto("sessions")
+        .values({
+          ...sessionWithoutDates,
+          tenant_id,
+          created_at_ts: now,
+          updated_at_ts: now,
+          authenticated_at_ts: now,
+          last_interaction_at_ts: now,
+          expires_at_ts: expiresAtTs,
+          idle_expires_at_ts: idleExpiresAtTs,
+          used_at_ts: isoToDbDate(used_at),
+          revoked_at_ts: isoToDbDate(revoked_at),
+          device: JSON.stringify(device),
+          clients: JSON.stringify(clients),
+        })
+        .execute();
+
+      if (newLoginSessionExpiry > 0 && session.login_session_id) {
+        // Keep the parent login_session alive at least as long as this session.
+        // The `expires_at_ts < ?` predicate makes this "never shorten" atomic,
+        // mirroring refreshTokens.create. Without it, a long-lived session can
+        // outlive its login_session and get orphaned when cleanup reaps the
+        // login_session.
+        await trx
+          .updateTable("login_sessions")
+          .set({
+            expires_at_ts: newLoginSessionExpiry,
+            updated_at_ts: now,
+          })
+          .where("tenant_id", "=", tenant_id)
+          .where("id", "=", session.login_session_id)
+          .where("expires_at_ts", "<", newLoginSessionExpiry)
+          .execute();
+      }
+    });
 
     return createdSession;
   };

--- a/packages/kysely/src/sessions/update.ts
+++ b/packages/kysely/src/sessions/update.ts
@@ -5,19 +5,25 @@ import { isoToDbDate } from "../utils/dateConversion";
 
 export function update(db: Kysely<Database>) {
   return async (tenant_id: string, id: string, session: Partial<Session>) => {
+    const now = Date.now();
+
     // Convert ISO date strings to bigint timestamps for DB
     const sqlSession: Record<string, unknown> = {
-      updated_at_ts: Date.now(),
+      updated_at_ts: now,
       device: session.device ? JSON.stringify(session.device) : undefined,
       clients: session.clients ? JSON.stringify(session.clients) : undefined,
     };
 
     // Convert date fields if provided
+    let expiresAtTs: number | null | undefined;
+    let idleExpiresAtTs: number | null | undefined;
     if (session.expires_at !== undefined) {
-      sqlSession.expires_at_ts = isoToDbDate(session.expires_at);
+      expiresAtTs = isoToDbDate(session.expires_at);
+      sqlSession.expires_at_ts = expiresAtTs;
     }
     if (session.idle_expires_at !== undefined) {
-      sqlSession.idle_expires_at_ts = isoToDbDate(session.idle_expires_at);
+      idleExpiresAtTs = isoToDbDate(session.idle_expires_at);
+      sqlSession.idle_expires_at_ts = idleExpiresAtTs;
     }
     if (session.authenticated_at !== undefined) {
       sqlSession.authenticated_at_ts = isoToDbDate(session.authenticated_at);
@@ -48,6 +54,40 @@ export function update(db: Kysely<Database>) {
       .where("tenant_id", "=", tenant_id)
       .where("sessions.id", "=", id)
       .execute();
+
+    // When a session is renewed (its expiry slides forward), keep the parent
+    // login_session alive at least as long. Best-effort and idempotent
+    // (WHERE expires_at_ts < new), mirroring refreshTokens.update — so it works
+    // even when this update runs inside an outer transaction (e.g. logout) and
+    // a failure never rejects the caller. Only fires when an expiry field moved.
+    const newLoginSessionExpiry = Math.max(
+      expiresAtTs ?? 0,
+      idleExpiresAtTs ?? 0,
+    );
+    if (newLoginSessionExpiry > 0) {
+      // Resolve the parent login_session via the session row when the caller
+      // didn't pass it, so we avoid an extra round trip. The `expires_at_ts < ?`
+      // predicate keeps the "never shorten" check atomic at the statement level.
+      const loginSessionId =
+        session.login_session_id ??
+        db
+          .selectFrom("sessions")
+          .select("login_session_id")
+          .where("tenant_id", "=", tenant_id)
+          .where("id", "=", id);
+
+      await db
+        .updateTable("login_sessions")
+        .set({
+          expires_at_ts: newLoginSessionExpiry,
+          updated_at_ts: now,
+        })
+        .where("tenant_id", "=", tenant_id)
+        .where("id", "=", loginSessionId)
+        .where("expires_at_ts", "<", newLoginSessionExpiry)
+        .execute()
+        .catch(() => {});
+    }
 
     return !!results.length;
   };

--- a/packages/kysely/test/cleanup.spec.ts
+++ b/packages/kysely/test/cleanup.spec.ts
@@ -533,11 +533,10 @@ describe("sessionCleanup", () => {
     expect(loginSessions.length).toEqual(0);
   });
 
-  it("should remove expired login sessions regardless of active sessions", async () => {
-    // Grace period is 1 week, so use 2 weeks ago for expired records
-    const twoWeeksAgo = new Date(
-      Date.now() - 1000 * 60 * 60 * 24 * 14,
-    ).toISOString();
+  it("keeps a login_session alive while it has an active session", async () => {
+    // An active session must keep its parent login_session alive: sessions.create
+    // bumps the login_session's expiry so cleanup never orphans the session by
+    // reaping the login_session it still references.
     const oneHourFromNow = new Date(Date.now() + 1000 * 60 * 60).toISOString();
 
     const { data, db } = await getTestServer();
@@ -617,13 +616,13 @@ describe("sessionCleanup", () => {
       user_id: "email|user1",
     });
 
-    // Expired login session is deleted (in the new model, its expires_at
-    // would have been extended on renewal if the session was still active)
+    // Creating the active session bumped the (previously expired) login_session
+    // forward, so cleanup retains it — the session is never orphaned.
     const loginSessions = await db
       .selectFrom("login_sessions")
       .selectAll()
       .execute();
-    expect(loginSessions.length).toEqual(0);
+    expect(loginSessions.length).toEqual(1);
 
     // The non-expired session should still exist
     const sessions = await db.selectFrom("sessions").selectAll().execute();

--- a/packages/kysely/test/sessions/loginSessionBump.spec.ts
+++ b/packages/kysely/test/sessions/loginSessionBump.spec.ts
@@ -5,7 +5,9 @@ import {
   LoginSessionState,
 } from "@authhero/adapter-interfaces";
 
-async function seedTenantAndClient(data: any) {
+type TestData = Awaited<ReturnType<typeof getTestServer>>["data"];
+
+async function seedTenantAndClient(data: TestData) {
   await data.tenants.create({
     id: "tenantId",
     friendly_name: "Test Tenant",
@@ -37,7 +39,7 @@ async function seedTenantAndClient(data: any) {
   });
 }
 
-async function createLoginSession(data: any, expiresAt: string) {
+async function createLoginSession(data: TestData, expiresAt: string) {
   return data.loginSessions.create("tenantId", {
     csrf_token: "csrf",
     authParams: {

--- a/packages/kysely/test/sessions/loginSessionBump.spec.ts
+++ b/packages/kysely/test/sessions/loginSessionBump.spec.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+import {
+  AuthorizationResponseType,
+  LoginSessionState,
+} from "@authhero/adapter-interfaces";
+
+async function seedTenantAndClient(data: any) {
+  await data.tenants.create({
+    id: "tenantId",
+    friendly_name: "Test Tenant",
+    audience: "https://example.com",
+    sender_email: "login@example.com",
+    sender_name: "SenderName",
+  });
+
+  await data.clients.create("tenantId", {
+    client_id: "clientId",
+    client_secret: "clientSecret",
+    name: "Test Client",
+    callbacks: ["https://example.com/callback"],
+    allowed_logout_urls: ["https://example.com/callback"],
+    web_origins: ["https://example.com"],
+    client_metadata: {},
+  });
+
+  await data.users.create("tenantId", {
+    email: "foo@example.com",
+    email_verified: true,
+    name: "Test User",
+    nickname: "Test User",
+    picture: "https://example.com/test.png",
+    connection: "email",
+    provider: "email",
+    is_social: false,
+    user_id: "email|userId",
+  });
+}
+
+async function createLoginSession(data: any, expiresAt: string) {
+  return data.loginSessions.create("tenantId", {
+    csrf_token: "csrf",
+    authParams: {
+      client_id: "clientId",
+      response_type: AuthorizationResponseType.CODE,
+      scope: "openid offline_access",
+    },
+    expires_at: expiresAt,
+    state: LoginSessionState.PENDING,
+  });
+}
+
+function device() {
+  return {
+    last_ip: "",
+    initial_ip: "",
+    last_user_agent: "",
+    initial_user_agent: "",
+    initial_asn: "",
+    last_asn: "",
+  };
+}
+
+describe("sessions adapter keeps parent login_session alive", () => {
+  it("extends login_session.expires_at to match the session's longest expiry on create", async () => {
+    const { data } = await getTestServer();
+    await seedTenantAndClient(data);
+
+    const shortExpiry = new Date(Date.now() + 1000 * 60 * 60).toISOString(); // 1h
+    const absoluteExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 7,
+    ).toISOString(); // 7d
+    const idleExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 3,
+    ).toISOString(); // 3d
+
+    const loginSession = await createLoginSession(data, shortExpiry);
+
+    await data.sessions.create("tenantId", {
+      id: "session1",
+      user_id: "email|userId",
+      login_session_id: loginSession.id,
+      expires_at: absoluteExpiry,
+      idle_expires_at: idleExpiry,
+      device: device(),
+      clients: ["clientId"],
+    });
+
+    const after = await data.loginSessions.get("tenantId", loginSession.id);
+    // Bumped to max(expires_at, idle_expires_at) = absoluteExpiry
+    expect(after?.expires_at).toEqual(absoluteExpiry);
+  });
+
+  it("never shortens an already-longer login_session on create", async () => {
+    const { data } = await getTestServer();
+    await seedTenantAndClient(data);
+
+    const longExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 30,
+    ).toISOString(); // 30d
+    const shortExpiry = new Date(Date.now() + 1000 * 60 * 60).toISOString(); // 1h
+
+    const loginSession = await createLoginSession(data, longExpiry);
+
+    await data.sessions.create("tenantId", {
+      id: "session1",
+      user_id: "email|userId",
+      login_session_id: loginSession.id,
+      expires_at: shortExpiry,
+      idle_expires_at: shortExpiry,
+      device: device(),
+      clients: ["clientId"],
+    });
+
+    const after = await data.loginSessions.get("tenantId", loginSession.id);
+    expect(after?.expires_at).toEqual(longExpiry);
+  });
+
+  it("extends login_session.expires_at when a session is renewed (update)", async () => {
+    const { data } = await getTestServer();
+    await seedTenantAndClient(data);
+
+    const initialExpiry = new Date(Date.now() + 1000 * 60 * 60).toISOString(); // 1h
+    const renewedExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 5,
+    ).toISOString(); // 5d
+
+    const loginSession = await createLoginSession(data, initialExpiry);
+
+    await data.sessions.create("tenantId", {
+      id: "session1",
+      user_id: "email|userId",
+      login_session_id: loginSession.id,
+      expires_at: initialExpiry,
+      idle_expires_at: initialExpiry,
+      device: device(),
+      clients: ["clientId"],
+    });
+
+    // Renew the session — slide its idle expiry forward without passing
+    // login_session_id, so the adapter must resolve it from the session row.
+    await data.sessions.update("tenantId", "session1", {
+      idle_expires_at: renewedExpiry,
+    });
+
+    const after = await data.loginSessions.get("tenantId", loginSession.id);
+    expect(after?.expires_at).toEqual(renewedExpiry);
+  });
+
+  it("never shortens the login_session on a session update", async () => {
+    const { data } = await getTestServer();
+    await seedTenantAndClient(data);
+
+    const longExpiry = new Date(
+      Date.now() + 1000 * 60 * 60 * 24 * 30,
+    ).toISOString(); // 30d
+    const shortExpiry = new Date(Date.now() + 1000 * 60 * 60).toISOString(); // 1h
+
+    const loginSession = await createLoginSession(data, longExpiry);
+
+    await data.sessions.create("tenantId", {
+      id: "session1",
+      user_id: "email|userId",
+      login_session_id: loginSession.id,
+      expires_at: shortExpiry,
+      idle_expires_at: shortExpiry,
+      device: device(),
+      clients: ["clientId"],
+    });
+
+    await data.sessions.update("tenantId", "session1", {
+      idle_expires_at: shortExpiry,
+    });
+
+    const after = await data.loginSessions.get("tenantId", loginSession.id);
+    expect(after?.expires_at).toEqual(longExpiry);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session creation and renewal now extend the parent login session when the child session’s expiry is later, preventing unintended cleanup/orphaning.
  * Parent login sessions are never shortened by later (shorter) session activity.
  * Token refresh continues to work even when a refresh token references a missing/deleted login session.

* **Tests**
  * Added/updated tests covering session “login session bump” on create and renewal, cleanup behavior, and the refresh-token exchange scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->