### PR TITLE
Update tod wfp version tracking

### DIFF
--- a/.changeset/mutable-response-helper.md
+++ b/.changeset/mutable-response-helper.md
@@ -1,0 +1,9 @@
+---
+"authhero": patch
+---
+
+Stop "Can't modify immutable headers." 500s when middleware annotates a received response.
+
+A response returned from a `fetch()` / Workers-for-Platforms dispatch / Cache API / R2 carries an immutable header guard. Any middleware that writes a header after `next()` — CORS, Server-Timing, the `Preference-Applied` writer — threw `TypeError: Can't modify immutable headers.` (a 500) when handed such a response. This surfaced on the management API once WFP tenant requests began being dispatched to their own worker, but applied to any received response flowing through those middlewares.
+
+Adds a shared `toMutableResponse(res)` / `ensureMutableResponse(c)` helper (exported from the package entry) that re-wraps a received response into one with mutable headers — cheap and deterministic, so it replaces the scattered try/catch re-wrap. The CORS, Server-Timing, and Prefer middlewares now normalize before writing, and a 101/WebSocket upgrade is left untouched.

--- a/.changeset/wfp-dispatch-error-reporting.md
+++ b/.changeset/wfp-dispatch-error-reporting.md
@@ -1,0 +1,13 @@
+---
+"@authhero/cloudflare-adapter": patch
+---
+
+Make WFP dispatch failures legible instead of opaque control-plane 500s.
+
+`createWfpForwardMiddleware` previously let a failed dispatch throw straight up: a tenant worker missing from the namespace, or one that failed to boot, surfaced as a generic `{"message":"Internal Server Error"}` that named neither the tenant nor the script. Debugging meant guessing which `wrangler tail` to attach.
+
+Now the middleware:
+
+- Catches dispatch-level throws and returns a structured, tenant-scoped error — `503 wfp_worker_not_found` when the tenant's script isn't in the dispatch namespace, `502 wfp_dispatch_failed` otherwise — carrying the same `X-Authhero-Error: <code>` header convention the tenant worker uses, plus the cause logged on the control plane.
+- Logs any dispatched `5xx` with the tenant id, script name, and the tenant worker's own `X-Authhero-Error` code (when present), so an opaque worker 500 is at least traceable from the control plane.
+- Tags every dispatched response with `X-Wfp-Tenant` so an operator can tell, from the response alone, that a request was served by a tenant worker and which one.

--- a/.changeset/wfp-version-tracking-upgrade.md
+++ b/.changeset/wfp-version-tracking-upgrade.md
@@ -1,0 +1,29 @@
+---
+"authhero": minor
+"@authhero/adapter-interfaces": minor
+"@authhero/cloudflare-adapter": minor
+"@authhero/kysely-adapter": minor
+"@authhero/drizzle": minor
+---
+
+Track WFP tenant code + database versions on the control plane, and add an upgrade path.
+
+The tenant row now records what a Workers-for-Platforms tenant is running so the
+control plane can detect drift and drive upgrades:
+
+- New `database_version` field (the latest migration applied — the schema
+  version the deployed bundle targets), alongside the existing
+  `worker_version` and `bundle_configuration` fields, which are now actually
+  populated.
+- `createCloudflareWfpD1Provisioner` gains `bundleConfiguration` and
+  `workerVersion` options (supplied by the operator at build time) and returns
+  all three versions in its `ProvisionResult`. The provisioning hook writes them
+  back to the tenant row.
+- `createWfpTenantProvisioningHook` gains `onUpgrade(tenantId)`: re-uploads the
+  current bundle, reconciles any pending migrations, re-runs the defaults seed,
+  and rewrites the recorded versions (marking `provisioning_state` `pending`
+  while in flight, `ready`/`failed` on completion).
+- New `POST /api/v2/tenants/{id}/redeploy` management endpoint (control-plane
+  only), wired via the new `tenantUpgrade` init option, triggers the upgrade and
+  returns the refreshed tenant. Returns `501` when no upgrade handler is
+  configured.

--- a/apps/admin/src/TenantsApp.tsx
+++ b/apps/admin/src/TenantsApp.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
-import { Resource } from "ra-core";
+import { CustomRoutes, Resource } from "ra-core";
+import { Route } from "react-router-dom";
 import { Admin } from "@/components/admin";
 import { getAuthProvider, createAuth0Client } from "./authProvider";
 import { getDataprovider, resolveApiBase } from "./dataProvider";
 import { getConfigValue, getBasePath } from "./utils/runtimeConfig";
 import { TenantsList } from "./resources/tenants/list";
 import { TenantsCreate } from "./resources/tenants/create";
+import { TenantMembers } from "./resources/tenants/members";
 import { Loader2 } from "lucide-react";
 
 interface TenantsAppProps {
@@ -102,6 +104,12 @@ export function TenantsApp({ initialDomain, onAuthComplete }: TenantsAppProps) {
       requireAuth={false}
     >
       <Resource name="tenants" list={TenantsList} create={TenantsCreate} />
+      <Resource name="organization-members" />
+      <Resource name="organization-invitations" />
+      <Resource name="users" />
+      <CustomRoutes>
+        <Route path="/tenants/:tenantId/members" element={<TenantMembers />} />
+      </CustomRoutes>
     </Admin>
   );
 }

--- a/apps/admin/src/resources/organizations/tabs/inviteMember.test.ts
+++ b/apps/admin/src/resources/organizations/tabs/inviteMember.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { buildInvitationPayload } from "./inviteMember";
+
+const base = {
+  organizationId: "org_1",
+  clientId: "client_123",
+  email: "new.user@example.com",
+  sendInvitationEmail: true,
+};
+
+describe("buildInvitationPayload", () => {
+  it("includes the organization id, client id and invitee email", () => {
+    expect(buildInvitationPayload(base)).toMatchObject({
+      organization_id: "org_1",
+      client_id: "client_123",
+      invitee: { email: "new.user@example.com" },
+      send_invitation_email: true,
+    });
+  });
+
+  it("sends an empty inviter object when no name is provided", () => {
+    // The backend requires a non-null inviter object even without a name.
+    expect(buildInvitationPayload(base).inviter).toEqual({});
+  });
+
+  it("includes the inviter name when provided", () => {
+    expect(
+      buildInvitationPayload({ ...base, inviterName: "Ada Lovelace" }).inviter,
+    ).toEqual({ name: "Ada Lovelace" });
+  });
+
+  it("trims surrounding whitespace from the email", () => {
+    expect(
+      buildInvitationPayload({ ...base, email: "  spaced@example.com  " })
+        .invitee.email,
+    ).toBe("spaced@example.com");
+  });
+
+  it("propagates send_invitation_email = false", () => {
+    expect(
+      buildInvitationPayload({ ...base, sendInvitationEmail: false })
+        .send_invitation_email,
+    ).toBe(false);
+  });
+});

--- a/apps/admin/src/resources/organizations/tabs/inviteMember.ts
+++ b/apps/admin/src/resources/organizations/tabs/inviteMember.ts
@@ -1,0 +1,26 @@
+export interface InvitationPayloadInput {
+  organizationId: string;
+  clientId: string;
+  email: string;
+  inviterName?: string;
+  sendInvitationEmail: boolean;
+}
+
+/**
+ * Builds the request body for `POST /organizations/{id}/invitations`.
+ *
+ * The backend requires a non-null `inviter` object (its `name` is optional) and
+ * a `client_id` used to build the acceptance link. The email is trimmed to
+ * match what the user sees in the input.
+ */
+export function buildInvitationPayload(input: InvitationPayloadInput) {
+  const { organizationId, clientId, email, inviterName, sendInvitationEmail } =
+    input;
+  return {
+    organization_id: organizationId,
+    client_id: clientId,
+    invitee: { email: email.trim() },
+    inviter: inviterName ? { name: inviterName } : {},
+    send_invitation_email: sendInvitationEmail,
+  };
+}

--- a/apps/admin/src/resources/organizations/tabs/members-tab.tsx
+++ b/apps/admin/src/resources/organizations/tabs/members-tab.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   RecordContextProvider,
   useDataProvider,
@@ -505,6 +511,11 @@ function InviteMemberButton({ clientId }: { clientId: string }) {
   const [email, setEmail] = useState("");
   const [sendEmail, setSendEmail] = useState(true);
   const [busy, setBusy] = useState(false);
+  // Synchronous in-flight lock. `busy` drives the disabled UI state, but a
+  // state update doesn't settle before a rapid second Enter press re-enters
+  // `handleInvite`, so the `busy` check alone can't prevent a duplicate
+  // (non-idempotent) invite create. This ref flips immediately.
+  const inFlight = useRef(false);
 
   const handleClose = () => {
     setOpen(false);
@@ -513,7 +524,8 @@ function InviteMemberButton({ clientId }: { clientId: string }) {
   };
 
   const handleInvite = async () => {
-    if (!organizationId || !email.trim()) return;
+    if (inFlight.current || busy || !organizationId || !email.trim()) return;
+    inFlight.current = true;
     setBusy(true);
     try {
       await dataProvider.create("organization-invitations", {
@@ -532,6 +544,7 @@ function InviteMemberButton({ clientId }: { clientId: string }) {
       notify("Error sending invitation", { type: "error" });
     } finally {
       setBusy(false);
+      inFlight.current = false;
     }
   };
 
@@ -559,6 +572,7 @@ function InviteMemberButton({ clientId }: { clientId: string }) {
             type="email"
             placeholder="name@example.com"
             value={email}
+            disabled={busy}
             onChange={(e) => setEmail(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
@@ -747,7 +761,7 @@ export function MembersTab({
             </DataTable.Col>
           </DataTable>
         </ReferenceManyField>
-        {inviteClientId ? <PendingInvitations /> : null}
+        <PendingInvitations />
       </div>
     </OrganizationIdContext.Provider>
   );

--- a/apps/admin/src/resources/organizations/tabs/members-tab.tsx
+++ b/apps/admin/src/resources/organizations/tabs/members-tab.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import {
+  RecordContextProvider,
   useDataProvider,
+  useGetIdentity,
   useNotify,
   useRecordContext,
   useRefresh,
 } from "ra-core";
 import { useParams } from "react-router-dom";
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { Mail, Pencil, Plus, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -25,6 +27,7 @@ import {
   ReferenceManyField,
 } from "@/components/admin";
 import { getUserAvatarColor, getUserAvatarSeed } from "@/utils/userAvatar";
+import { buildInvitationPayload } from "./inviteMember";
 
 interface UserSummary {
   id: string | number;
@@ -52,8 +55,21 @@ interface MemberRecord {
   roles?: RoleSummary[];
 }
 
+/**
+ * Lets the members UI be driven either by the organization edit route param
+ * (`/organizations/:id`) or by an explicit organization id passed to
+ * `<MembersTab organizationId={...} />` (e.g. the control-plane tenant view).
+ */
+const OrganizationIdContext = createContext<string | undefined>(undefined);
+
+function useOrganizationId() {
+  const contextValue = useContext(OrganizationIdContext);
+  const { id } = useParams();
+  return contextValue ?? id;
+}
+
 function AddMemberButton() {
-  const { id: organizationId } = useParams();
+  const organizationId = useOrganizationId();
   const dataProvider = useDataProvider();
   const notify = useNotify();
   const refresh = useRefresh();
@@ -222,7 +238,7 @@ function MemberAvatarCell() {
 
 function RemoveMemberCell() {
   const record = useRecordContext<MemberRecord>();
-  const { id: organizationId } = useParams();
+  const organizationId = useOrganizationId();
   const dataProvider = useDataProvider();
   const notify = useNotify();
   const refresh = useRefresh();
@@ -316,7 +332,7 @@ function MemberRolesCell() {
 
 function EditMemberRolesCell() {
   const record = useRecordContext<MemberRecord>();
-  const { id: organizationId } = useParams();
+  const organizationId = useOrganizationId();
   const dataProvider = useDataProvider();
   const notify = useNotify();
   const refresh = useRefresh();
@@ -470,44 +486,281 @@ function EditMemberRolesCell() {
   );
 }
 
-export function MembersTab() {
+interface InvitationRecord {
+  id: string;
+  organization_id: string;
+  invitee?: { email?: string };
+  inviter?: { name?: string };
+  created_at?: string;
+  expires_at?: string;
+}
+
+function InviteMemberButton({ clientId }: { clientId: string }) {
+  const organizationId = useOrganizationId();
+  const dataProvider = useDataProvider();
+  const notify = useNotify();
+  const refresh = useRefresh();
+  const { identity } = useGetIdentity();
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [sendEmail, setSendEmail] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const handleClose = () => {
+    setOpen(false);
+    setEmail("");
+    setSendEmail(true);
+  };
+
+  const handleInvite = async () => {
+    if (!organizationId || !email.trim()) return;
+    setBusy(true);
+    try {
+      await dataProvider.create("organization-invitations", {
+        data: buildInvitationPayload({
+          organizationId,
+          clientId,
+          email,
+          inviterName: identity?.fullName,
+          sendInvitationEmail: sendEmail,
+        }),
+      });
+      notify(`Invitation sent to ${email.trim()}`, { type: "success" });
+      handleClose();
+      refresh();
+    } catch {
+      notify("Error sending invitation", { type: "error" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!organizationId) return null;
+
   return (
-    <div className="flex flex-col gap-4">
-      <div>
-        <AddMemberButton />
-      </div>
+    <>
+      <Button type="button" variant="outline" onClick={() => setOpen(true)}>
+        <Mail className="h-4 w-4 mr-1" />
+        Invite by email
+      </Button>
+      <Dialog
+        open={open}
+        onOpenChange={(o) => (o ? setOpen(true) : handleClose())}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Invite a new member</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Invite someone who doesn&apos;t have an account yet. They&apos;ll
+            receive a link to join this tenant.
+          </p>
+          <Input
+            type="email"
+            placeholder="name@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleInvite();
+              }
+            }}
+          />
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={sendEmail}
+              onCheckedChange={(c) => setSendEmail(c === true)}
+            />
+            Send invitation email
+          </label>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button onClick={handleInvite} disabled={busy || !email.trim()}>
+              Send invitation
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function InvitationEmailCell() {
+  const record = useRecordContext<InvitationRecord>();
+  if (!record) return null;
+  return (
+    <span className="text-sm">
+      {record.invitee?.email ?? (
+        <span className="text-muted-foreground">—</span>
+      )}
+    </span>
+  );
+}
+
+function InvitationExpiresCell() {
+  const record = useRecordContext<InvitationRecord>();
+  if (!record?.expires_at) return null;
+  const formatted = new Date(record.expires_at).toLocaleDateString();
+  return <span className="text-sm text-muted-foreground">{formatted}</span>;
+}
+
+function RevokeInvitationCell() {
+  const record = useRecordContext<InvitationRecord>();
+  const organizationId = useOrganizationId();
+  const dataProvider = useDataProvider();
+  const notify = useNotify();
+  const refresh = useRefresh();
+  const [busy, setBusy] = useState(false);
+
+  if (!record || !organizationId) return null;
+
+  const handleRevoke = async () => {
+    setBusy(true);
+    try {
+      await dataProvider.delete("organization-invitations", {
+        id: record.id,
+        previousData: { id: record.id, organization_id: organizationId },
+      });
+      notify("Invitation revoked", { type: "success" });
+      refresh();
+    } catch {
+      notify("Error revoking invitation", { type: "error" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      aria-label="Revoke invitation"
+      disabled={busy}
+      onClick={(e) => {
+        e.stopPropagation();
+        handleRevoke();
+      }}
+    >
+      <Trash2 className="h-4 w-4" />
+    </Button>
+  );
+}
+
+function PendingInvitations() {
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-sm font-medium">Pending invitations</h3>
       <ReferenceManyField
-        reference="organization-members"
+        reference="organization-invitations"
         target="organization_id"
-        sort={{ field: "email", order: "ASC" }}
+        sort={{ field: "created_at", order: "DESC" }}
         pagination={<ListPagination />}
         empty={
-          <p className="text-sm text-muted-foreground py-4">
-            No members in this organization
+          <p className="text-sm text-muted-foreground py-2">
+            No pending invitations
           </p>
         }
       >
-        <DataTable
-          rowClick={(_, __, record) => `/users/${record.user_id}`}
-          bulkActionButtons={false}
-        >
-          <DataTable.Col label="">
-            <MemberAvatarCell />
+        <DataTable bulkActionButtons={false}>
+          <DataTable.Col label="Email">
+            <InvitationEmailCell />
           </DataTable.Col>
-          <DataTable.Col source="email" />
-          <DataTable.Col source="name" />
-          <DataTable.Col source="user_id" label="User ID" />
-          <DataTable.Col label="Roles">
-            <MemberRolesCell />
+          <DataTable.Col label="Expires">
+            <InvitationExpiresCell />
           </DataTable.Col>
           <DataTable.Col label="">
-            <div className="flex items-center justify-end gap-1">
-              <EditMemberRolesCell />
-              <RemoveMemberCell />
+            <div className="flex items-center justify-end">
+              <RevokeInvitationCell />
             </div>
           </DataTable.Col>
         </DataTable>
       </ReferenceManyField>
     </div>
   );
+}
+
+interface MembersTabProps {
+  /**
+   * Organization to manage. When omitted, the organization is taken from the
+   * `/organizations/:id` route param (the organization edit page). When
+   * provided, a minimal record context is supplied so `ReferenceManyField` can
+   * resolve its `organization_id` target outside of an organization record.
+   */
+  organizationId?: string;
+  /**
+   * When set, enables email invitations for users who don't have an account
+   * yet. The client id is used to build the invitation link, so it must be a
+   * client in the tenant that owns this organization.
+   */
+  inviteClientId?: string;
+}
+
+export function MembersTab({
+  organizationId: orgIdProp,
+  inviteClientId,
+}: MembersTabProps = {}) {
+  const { id: routeId } = useParams();
+  const organizationId = orgIdProp ?? routeId;
+
+  const content = (
+    <OrganizationIdContext.Provider value={organizationId}>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap gap-2">
+          <AddMemberButton />
+          {inviteClientId ? (
+            <InviteMemberButton clientId={inviteClientId} />
+          ) : null}
+        </div>
+        <ReferenceManyField
+          reference="organization-members"
+          target="organization_id"
+          sort={{ field: "email", order: "ASC" }}
+          pagination={<ListPagination />}
+          empty={
+            <p className="text-sm text-muted-foreground py-4">
+              No members in this organization
+            </p>
+          }
+        >
+          <DataTable
+            rowClick={(_, __, record) => `/users/${record.user_id}`}
+            bulkActionButtons={false}
+          >
+            <DataTable.Col label="">
+              <MemberAvatarCell />
+            </DataTable.Col>
+            <DataTable.Col source="email" />
+            <DataTable.Col source="name" />
+            <DataTable.Col source="user_id" label="User ID" />
+            <DataTable.Col label="Roles">
+              <MemberRolesCell />
+            </DataTable.Col>
+            <DataTable.Col label="">
+              <div className="flex items-center justify-end gap-1">
+                <EditMemberRolesCell />
+                <RemoveMemberCell />
+              </div>
+            </DataTable.Col>
+          </DataTable>
+        </ReferenceManyField>
+        {inviteClientId ? <PendingInvitations /> : null}
+      </div>
+    </OrganizationIdContext.Provider>
+  );
+
+  // When driven by an explicit org id we render outside an organization record
+  // context, so provide a minimal one for ReferenceManyField's target lookup.
+  if (orgIdProp) {
+    return (
+      <RecordContextProvider value={{ id: orgIdProp }}>
+        {content}
+      </RecordContextProvider>
+    );
+  }
+
+  return content;
 }

--- a/apps/admin/src/resources/tenants/list.tsx
+++ b/apps/admin/src/resources/tenants/list.tsx
@@ -1,6 +1,9 @@
 import { useId } from "react";
+import { Link } from "react-router-dom";
 import { useRecordContext } from "ra-core";
+import { Users } from "lucide-react";
 import { BadgeField, DataTable, List, TextInput } from "@/components/admin";
+import { Button } from "@/components/ui/button";
 import { getBasePath } from "@/utils/runtimeConfig";
 
 type TenantRecord = {
@@ -25,10 +28,7 @@ function ProvisioningStateField() {
   const errorId = useId();
   const error = record?.provisioning_error;
   return (
-    <span
-      title={error}
-      aria-describedby={error ? errorId : undefined}
-    >
+    <span title={error} aria-describedby={error ? errorId : undefined}>
       <BadgeField
         source="provisioning_state"
         defaultValue={state}
@@ -40,6 +40,24 @@ function ProvisioningStateField() {
         </span>
       ) : null}
     </span>
+  );
+}
+
+function MembersLinkCell() {
+  const record = useRecordContext<TenantRecord>();
+  if (!record) return null;
+  return (
+    <Button
+      asChild
+      variant="outline"
+      size="sm"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Link to={`/tenants/${String(record.id)}/members`}>
+        <Users className="h-4 w-4 mr-1" />
+        Members
+      </Link>
+    </Button>
   );
 }
 
@@ -68,6 +86,9 @@ export function TenantsList() {
         </DataTable.Col>
         <DataTable.Col source="audience" />
         <DataTable.Col source="support_url" label="Support URL" />
+        <DataTable.Col label="">
+          <MembersLinkCell />
+        </DataTable.Col>
       </DataTable>
     </List>
   );

--- a/apps/admin/src/resources/tenants/list.tsx
+++ b/apps/admin/src/resources/tenants/list.tsx
@@ -53,7 +53,7 @@ function MembersLinkCell() {
       size="sm"
       onClick={(e) => e.stopPropagation()}
     >
-      <Link to={`/tenants/${String(record.id)}/members`}>
+      <Link to={`${getBasePath()}/${String(record.id)}/members`}>
         <Users className="h-4 w-4 mr-1" />
         Members
       </Link>

--- a/apps/admin/src/resources/tenants/members.tsx
+++ b/apps/admin/src/resources/tenants/members.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useDataProvider } from "ra-core";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { MembersTab } from "../organizations/tabs/members-tab";
+import { findOrganizationForTenant } from "./orgLookup";
+import {
+  getClientIdFromStorage,
+  getSelectedDomainFromStorage,
+} from "@/utils/domainUtils";
+
+interface OrganizationRecord {
+  id: string;
+  name?: string;
+  display_name?: string;
+}
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ready"; org: OrganizationRecord }
+  | { status: "missing" }
+  | { status: "error" };
+
+/**
+ * Control-plane view for managing who can access a child tenant.
+ *
+ * Each child tenant is mirrored by an organization on the control-plane tenant
+ * where `organization.name === tenant.id`. Granting/removing access is done by
+ * managing that organization's membership and roles, which this page does by
+ * resolving the organization from the tenant id and reusing `<MembersTab />`.
+ */
+export function TenantMembers() {
+  const { tenantId } = useParams();
+  const dataProvider = useDataProvider();
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  // The invitation link is issued for the control-plane admin client so an
+  // invited user can accept and sign in to the admin. Falls back to undefined,
+  // which simply hides the invite UI (members can still be added directly).
+  const inviteClientId =
+    getClientIdFromStorage(getSelectedDomainFromStorage()) || undefined;
+
+  useEffect(() => {
+    if (!tenantId) return;
+    let cancelled = false;
+    setState({ status: "loading" });
+
+    dataProvider
+      .getList<OrganizationRecord>("organizations", {
+        pagination: { page: 1, perPage: 100 },
+        sort: { field: "name", order: "ASC" },
+        filter: { q: tenantId },
+      })
+      .then(({ data }) => {
+        if (cancelled) return;
+        const org = findOrganizationForTenant(data, tenantId);
+        setState(org ? { status: "ready", org } : { status: "missing" });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ status: "error" });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId, dataProvider]);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div>
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/tenants">
+            <ArrowLeft className="h-4 w-4 mr-1" />
+            Back to tenants
+          </Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Members of {tenantId}</CardTitle>
+          <CardDescription>
+            People with access to this tenant. Add or remove members and assign
+            roles to control what they can do.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {state.status === "loading" ? (
+            <div className="flex items-center gap-2 py-8 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Loading members…</span>
+            </div>
+          ) : state.status === "ready" ? (
+            <MembersTab
+              organizationId={state.org.id}
+              inviteClientId={inviteClientId}
+            />
+          ) : state.status === "missing" ? (
+            <p className="py-8 text-sm text-muted-foreground">
+              Team management isn&apos;t enabled for this tenant yet. No
+              organization exists for it on the control plane.
+            </p>
+          ) : (
+            <p className="py-8 text-sm text-destructive">
+              Could not load members for this tenant. Check that you have access
+              to manage it and try again.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/admin/src/resources/tenants/members.tsx
+++ b/apps/admin/src/resources/tenants/members.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/card";
 import { MembersTab } from "../organizations/tabs/members-tab";
 import { findOrganizationForTenant } from "./orgLookup";
+import { getBasePath } from "@/utils/runtimeConfig";
 import {
   getClientIdFromStorage,
   getSelectedDomainFromStorage,
@@ -53,21 +54,43 @@ export function TenantMembers() {
     let cancelled = false;
     setState({ status: "loading" });
 
-    dataProvider
-      .getList<OrganizationRecord>("organizations", {
-        pagination: { page: 1, perPage: 100 },
-        sort: { field: "name", order: "ASC" },
-        filter: { q: tenantId },
-      })
-      .then(({ data }) => {
-        if (cancelled) return;
-        const org = findOrganizationForTenant(data, tenantId);
-        setState(org ? { status: "ready", org } : { status: "missing" });
-      })
-      .catch(() => {
+    // `q` is a fuzzy search, so the exact tenant→organization match isn't
+    // guaranteed to land on the first page. Iterate pages until the exact
+    // match is found or every matching organization has been checked —
+    // otherwise a tenant can be wrongly reported as "missing" when its
+    // organization sits on a later page of a large fuzzy result set.
+    (async () => {
+      const perPage = 100;
+      try {
+        for (let page = 1; ; page++) {
+          const { data, total } =
+            await dataProvider.getList<OrganizationRecord>("organizations", {
+              pagination: { page, perPage },
+              sort: { field: "name", order: "ASC" },
+              filter: { q: tenantId },
+            });
+          if (cancelled) return;
+
+          const org = findOrganizationForTenant(data, tenantId);
+          if (org) {
+            setState({ status: "ready", org });
+            return;
+          }
+
+          const seen = page * perPage;
+          const exhausted =
+            data.length < perPage ||
+            (typeof total === "number" && seen >= total);
+          if (exhausted) {
+            setState({ status: "missing" });
+            return;
+          }
+        }
+      } catch {
         if (cancelled) return;
         setState({ status: "error" });
-      });
+      }
+    })();
 
     return () => {
       cancelled = true;
@@ -78,7 +101,7 @@ export function TenantMembers() {
     <div className="flex flex-col gap-4 p-4">
       <div>
         <Button asChild variant="ghost" size="sm">
-          <Link to="/tenants">
+          <Link to={getBasePath()}>
             <ArrowLeft className="h-4 w-4 mr-1" />
             Back to tenants
           </Link>

--- a/apps/admin/src/resources/tenants/orgLookup.test.ts
+++ b/apps/admin/src/resources/tenants/orgLookup.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { findOrganizationForTenant } from "./orgLookup";
+
+const orgs = [
+  { id: "org_1", name: "acme-staging" },
+  { id: "org_2", name: "acme" },
+  { id: "org_3", name: "globex" },
+];
+
+describe("findOrganizationForTenant", () => {
+  it("returns the org whose name equals the tenant id", () => {
+    expect(findOrganizationForTenant(orgs, "globex")?.id).toBe("org_3");
+  });
+
+  it("matches exactly, never a similarly-named prefix", () => {
+    // "acme" must resolve to the exact org, not "acme-staging"
+    expect(findOrganizationForTenant(orgs, "acme")?.id).toBe("org_2");
+  });
+
+  it("matches case-insensitively when the tenant id differs in case", () => {
+    expect(findOrganizationForTenant(orgs, "ACME")?.id).toBe("org_2");
+  });
+
+  it("matches case-insensitively when the org name differs in case", () => {
+    expect(
+      findOrganizationForTenant([{ id: "org_x", name: "Kvartal" }], "kvartal")
+        ?.id,
+    ).toBe("org_x");
+  });
+
+  it("returns undefined when no org matches", () => {
+    expect(findOrganizationForTenant(orgs, "initech")).toBeUndefined();
+  });
+
+  it("ignores organizations without a name", () => {
+    expect(
+      findOrganizationForTenant<{ id: string; name?: string }>(
+        [{ id: "org_y" }],
+        "anything",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for an empty list", () => {
+    expect(findOrganizationForTenant([], "acme")).toBeUndefined();
+  });
+});

--- a/apps/admin/src/resources/tenants/orgLookup.ts
+++ b/apps/admin/src/resources/tenants/orgLookup.ts
@@ -1,0 +1,14 @@
+/**
+ * Resolves the control-plane organization that represents a child tenant.
+ *
+ * Each child tenant is mirrored by an organization on the control-plane tenant
+ * whose `name` equals the tenant id. Matching is case-insensitive and exact so
+ * a tenant id like `acme` never resolves to a similarly-named `acme-staging`.
+ */
+export function findOrganizationForTenant<T extends { name?: string }>(
+  organizations: readonly T[],
+  tenantId: string,
+): T | undefined {
+  const target = tenantId.toLowerCase();
+  return organizations.find((o) => (o.name ?? "").toLowerCase() === target);
+}

--- a/apps/admin/src/resources/tenants/orgLookup.ts
+++ b/apps/admin/src/resources/tenants/orgLookup.ts
@@ -10,5 +10,7 @@ export function findOrganizationForTenant<T extends { name?: string }>(
   tenantId: string,
 ): T | undefined {
   const target = tenantId.toLowerCase();
-  return organizations.find((o) => (o.name ?? "").toLowerCase() === target);
+  return organizations.find(
+    (o) => typeof o.name === "string" && o.name.toLowerCase() === target,
+  );
 }

--- a/packages/adapter-interfaces/src/adapters/Tenants.ts
+++ b/packages/adapter-interfaces/src/adapters/Tenants.ts
@@ -19,6 +19,7 @@ export interface CreateTenantParams {
   provisioning_state_changed_at?: string;
   bundle_configuration?: string;
   worker_version?: string;
+  database_version?: string;
   worker_script_name?: string;
   storage_kind?: "own_d1" | "existing_d1" | "shared_planetscale";
   d1_database_id?: string;

--- a/packages/adapter-interfaces/src/types/Tenant.ts
+++ b/packages/adapter-interfaces/src/types/Tenant.ts
@@ -235,6 +235,16 @@ export const tenantInsertSchema = z.object({
   // `storage_kind` plus `d1_database_id` determine the data backend the
   // tenant worker is bound to.
   //
+  // Versioning — the three fields below record what the tenant is currently
+  // running so the control plane can detect drift and drive upgrades:
+  //   - `bundle_configuration` — the worker image / variant name.
+  //   - `worker_version` — the release tag (or git SHA) of the deployed bundle,
+  //     supplied by the operator at build time.
+  //   - `database_version` — the name of the latest migration applied to the
+  //     tenant's database, i.e. the schema version the deployed bundle targets.
+  // A redeploy/upgrade re-uploads the current bundle, reconciles pending
+  // migrations, and rewrites all three.
+  //
   // `provisioning_state` tracks the async provision flow for `wfp` tenants.
   // Shared tenants are `ready` immediately.
   deployment_type: z.enum(["shared", "wfp"]).default("shared").optional(),
@@ -246,6 +256,7 @@ export const tenantInsertSchema = z.object({
   provisioning_state_changed_at: z.string().optional(),
   bundle_configuration: z.string().max(64).optional(),
   worker_version: z.string().max(64).optional(),
+  database_version: z.string().max(64).optional(),
   worker_script_name: z.string().max(255).optional(),
   storage_kind: z
     .enum(["own_d1", "existing_d1", "shared_planetscale"])

--- a/packages/authhero/src/helpers/mutable-response.ts
+++ b/packages/authhero/src/helpers/mutable-response.ts
@@ -1,0 +1,43 @@
+/**
+ * Normalizing a response so middleware can write headers onto it.
+ *
+ * A response that the worker *received* — from `fetch()`, a Workers-for-Platforms
+ * dispatch (`DISPATCHER.get(name).fetch()`), the Cache API, or R2 — carries an
+ * *immutable* header guard. Calling `headers.set()` / `headers.append()` on it
+ * throws `TypeError: Can't modify immutable headers.`. Responses built in-worker
+ * (`c.json()`, `c.text()`, `new Response(...)`) are mutable.
+ *
+ * Any middleware that annotates the response after `next()` (CORS, Server-Timing,
+ * `Preference-Applied`, …) must therefore tolerate an immutable response. Rather
+ * than guard each write with a try/catch, normalize once: re-wrapping is cheap
+ * (the body stream is passed through, not copied) and deterministic, so there is
+ * nothing to detect.
+ */
+
+/**
+ * Return a response whose headers are mutable. A received response is re-wrapped
+ * into a fresh `Response` (which has the mutable "response" header guard); an
+ * already-mutable response is re-wrapped too, harmlessly, preserving every header
+ * already set on it.
+ *
+ * A `101 Switching Protocols` upgrade is returned untouched: it carries a
+ * `webSocket` handle that reconstruction would drop, breaking the upgrade. Its
+ * headers stay immutable, so callers must not write to an upgrade response.
+ */
+export function toMutableResponse(res: Response): Response {
+  if (res.status === 101 || "webSocket" in res) return res;
+  return new Response(res.body, res);
+}
+
+/**
+ * Ensure `c.res` is safe to write headers onto, re-wrapping a received
+ * (immutable) response in place. Typed structurally so it accepts any Hono
+ * `Context` regardless of its `Bindings`/`Variables` generics.
+ *
+ * Note the 101 carve-out in {@link toMutableResponse}: for an upgrade response
+ * this is a no-op and the headers remain immutable, so a caller that may face a
+ * 101 must still skip its header writes for it.
+ */
+export function ensureMutableResponse(c: { res: Response }): void {
+  c.res = toMutableResponse(c.res);
+}

--- a/packages/authhero/src/helpers/server-timing.ts
+++ b/packages/authhero/src/helpers/server-timing.ts
@@ -81,6 +81,12 @@ export const serverTimingMiddleware: MiddlewareHandler<{
   }
 
   if (mode === "client" || mode === "both") {
+    // A 101 / WebSocket upgrade response can't be normalized to a mutable
+    // response (its `webSocket` handle can't survive reconstruction) and a
+    // header write on it throws — leave upgrade responses untouched.
+    const isUpgrade = ctx.res.status === 101 || "webSocket" in ctx.res;
+    if (isUpgrade) return;
+
     const allowlist = ctx.env.SERVER_TIMING_IPS;
     if (!allowlist || isIpAllowed(ctx.get("ip"), allowlist)) {
       // The response may have come back from a dispatch/`fetch()` with immutable

--- a/packages/authhero/src/helpers/server-timing.ts
+++ b/packages/authhero/src/helpers/server-timing.ts
@@ -2,6 +2,7 @@ import { Context, MiddlewareHandler } from "hono";
 import { CacheAdapter, DataAdapters } from "@authhero/adapter-interfaces";
 import { Bindings, Variables } from "../types";
 import { getAdapterMethodNames } from "./adapter-methods";
+import { ensureMutableResponse } from "./mutable-response";
 
 type TimingCtx = Context<{ Bindings: Bindings; Variables: Variables }>;
 
@@ -82,6 +83,9 @@ export const serverTimingMiddleware: MiddlewareHandler<{
   if (mode === "client" || mode === "both") {
     const allowlist = ctx.env.SERVER_TIMING_IPS;
     if (!allowlist || isIpAllowed(ctx.get("ip"), allowlist)) {
+      // The response may have come back from a dispatch/`fetch()` with immutable
+      // headers — normalize before writing.
+      ensureMutableResponse(ctx);
       const existing = ctx.res.headers.get("Server-Timing");
       ctx.res.headers.set(
         "Server-Timing",

--- a/packages/authhero/src/index.ts
+++ b/packages/authhero/src/index.ts
@@ -23,6 +23,10 @@ export * from "./adapters";
 export * from "./email-services";
 export { waitUntil } from "./helpers/wait-until";
 export {
+  toMutableResponse,
+  ensureMutableResponse,
+} from "./helpers/mutable-response";
+export {
   cleanupUserSessions,
   cleanupSessions,
 } from "./helpers/user-session-cleanup";

--- a/packages/authhero/src/middlewares/apply-config.ts
+++ b/packages/authhero/src/middlewares/apply-config.ts
@@ -44,6 +44,10 @@ export function applyConfigMiddleware(
       ctx.env.webhookInvoker = config.webhookInvoker;
     }
 
+    if (config.tenantUpgrade) {
+      ctx.env.tenantUpgrade = config.tenantUpgrade;
+    }
+
     if (config.outbox) {
       ctx.env.outbox = config.outbox;
     }

--- a/packages/authhero/src/middlewares/prefer.ts
+++ b/packages/authhero/src/middlewares/prefer.ts
@@ -1,5 +1,6 @@
 import { MiddlewareHandler } from "hono";
 import { Variables } from "../types/Variables";
+import { ensureMutableResponse } from "../helpers/mutable-response";
 
 export const PREFER_TOKENS = ["include-linked"] as const;
 export type PreferToken = (typeof PREFER_TOKENS)[number];
@@ -43,6 +44,8 @@ export const preferMiddleware: MiddlewareHandler<{ Variables: Variables }> =
     await next();
 
     if (applied.size > 0) {
+      // The response may be a received (immutable) one — normalize before write.
+      ensureMutableResponse(ctx);
       ctx.res.headers.set(
         "Preference-Applied",
         Array.from(applied).join(", "),

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -215,8 +215,15 @@ export default function create(config: AuthHeroConfig) {
           return;
         }
 
-        // Try to get tenant ID from context (set by tenant middleware)
-        const tenantId = ctx.var.tenant_id || ctx.req.header("tenant-id");
+        // Try to get tenant ID from context (set by tenant middleware), then
+        // the legacy `tenant-id` header, then — for subdomain/custom-domain
+        // addressing where neither is present (e.g. a host-routed request
+        // `tenantDispatch` returned early for) — fall back to the request
+        // host, mirroring the preflight path above.
+        const tenantId =
+          ctx.var.tenant_id ||
+          ctx.req.header("tenant-id") ||
+          (await resolveTenantIdFromHost(ctx));
         if (tenantId) {
           const clients = await managementAdapter.clients.list(tenantId, {});
           const allWebOrigins = clients.clients.flatMap(

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -37,6 +37,7 @@ import {
   serverTimingMiddleware,
 } from "../../helpers/server-timing";
 import { applyConfigMiddleware } from "../../middlewares/apply-config";
+import { ensureMutableResponse } from "../../helpers/mutable-response";
 import { tenantMiddleware } from "../../middlewares/tenant";
 import { clientInfoMiddleware } from "../../middlewares/client-info";
 import { preferMiddleware } from "../../middlewares/prefer";
@@ -196,37 +197,34 @@ export default function create(config: AuthHeroConfig) {
     // A response produced by `fetch()` / Workers-for-Platforms dispatch (the
     // `tenantDispatch` middleware mounted below), or any proxied / cached / R2
     // response, carries an *immutable* header guard — appending or setting a
-    // header on it throws "Can't modify immutable headers." Re-wrap such a
-    // response into a fresh Response, which has the mutable "response" guard,
-    // before writing any CORS/Vary header. Done once here so both the
-    // unconditional `Vary` append and `setCorsHeaders` below operate on a
-    // mutable response. A 101 upgrade (carries a `webSocket` handle) is left
-    // untouched — it never flows through this management API anyway.
-    if (ctx.res.status !== 101 && !("webSocket" in ctx.res)) {
-      try {
-        ctx.res.headers.append("Vary", "Origin");
-      } catch {
-        ctx.res = new Response(ctx.res.body, ctx.res);
-        ctx.res.headers.append("Vary", "Origin");
-      }
-    }
+    // header on it throws "Can't modify immutable headers." Normalize once to a
+    // mutable response so both the `Vary` append and `setCorsHeaders` below are
+    // safe. A 101 upgrade is left immutable by the helper (its `webSocket` handle
+    // can't survive reconstruction), so skip the header writes for it — it never
+    // flows through this management API anyway.
+    ensureMutableResponse(ctx);
+    const isUpgrade = ctx.res.status === 101 || "webSocket" in ctx.res;
 
-    if (origin) {
-      // Check static allowedOrigins first
-      if (config.allowedOrigins?.includes(origin)) {
-        setCorsHeaders(origin);
-        return;
-      }
+    if (!isUpgrade) {
+      ctx.res.headers.append("Vary", "Origin");
 
-      // Try to get tenant ID from context (set by tenant middleware)
-      const tenantId = ctx.var.tenant_id || ctx.req.header("tenant-id");
-      if (tenantId) {
-        const clients = await managementAdapter.clients.list(tenantId, {});
-        const allWebOrigins = clients.clients.flatMap(
-          (client) => client.web_origins || [],
-        );
-        if (allWebOrigins.includes(origin)) {
+      if (origin) {
+        // Check static allowedOrigins first
+        if (config.allowedOrigins?.includes(origin)) {
           setCorsHeaders(origin);
+          return;
+        }
+
+        // Try to get tenant ID from context (set by tenant middleware)
+        const tenantId = ctx.var.tenant_id || ctx.req.header("tenant-id");
+        if (tenantId) {
+          const clients = await managementAdapter.clients.list(tenantId, {});
+          const allWebOrigins = clients.clients.flatMap(
+            (client) => client.web_origins || [],
+          );
+          if (allWebOrigins.includes(origin)) {
+            setCorsHeaders(origin);
+          }
         }
       }
     }

--- a/packages/authhero/src/routes/management-api/tenants.ts
+++ b/packages/authhero/src/routes/management-api/tenants.ts
@@ -147,10 +147,100 @@ const patchSettings = defineRoute({
   },
 });
 
+// Re-provision ("upgrade") a WFP tenant onto the control plane's current
+// worker bundle + migrations. Control-plane-only: the acting tenant (resolved
+// from the `tenant-id` header) must be the control plane — which both scopes
+// the operation to operators and guarantees `tenantDispatch` did not forward
+// this request to a tenant worker (it never forwards control-plane traffic).
+// The target tenant is named by the `{id}` path param. Drives
+// `config.tenantUpgrade`; returns 501 when no upgrade handler is configured.
+const redeployTenant = defineRoute({
+  route: createRoute({
+    tags: ["tenants"],
+    method: "post",
+    path: "/{id}/redeploy",
+    request: {
+      params: z.object({
+        id: z.string(),
+      }),
+      headers: z.object({
+        "tenant-id": z.string().optional(),
+      }),
+    },
+    security: [
+      {
+        Bearer: ["update:tenants"],
+      },
+    ],
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: tenantSchema,
+          },
+        },
+        description: "Upgraded tenant settings",
+      },
+    },
+  }),
+  handler: async (ctx) => {
+    if (!isControlPlaneTenant(ctx, ctx.var.tenant_id)) {
+      throw new HTTPException(403, {
+        message: "Tenant upgrades can only be triggered from the control plane",
+      });
+    }
+
+    if (!ctx.env.tenantUpgrade) {
+      throw new HTTPException(501, {
+        message: "Tenant upgrades are not configured for this deployment",
+      });
+    }
+
+    const { id } = ctx.req.valid("param");
+
+    const existingTenant = await ctx.env.data.tenants.get(id);
+    if (!existingTenant) {
+      throw new HTTPException(404, {
+        message: "Tenant not found",
+      });
+    }
+
+    try {
+      await ctx.env.tenantUpgrade(id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new HTTPException(500, {
+        message: `Tenant upgrade failed: ${message}`,
+      });
+    }
+
+    const upgradedTenant = await ctx.env.data.tenants.get(id);
+    if (!upgradedTenant) {
+      throw new HTTPException(500, {
+        message: "Failed to retrieve upgraded tenant",
+      });
+    }
+
+    await logMessage(ctx, id, {
+      type: LogTypes.SUCCESS_API_OPERATION,
+      description: "Redeploy tenant",
+      targetType: "tenant",
+      targetId: id,
+      beforeState: existingTenant as Record<string, unknown>,
+      afterState: upgradedTenant as Record<string, unknown>,
+    });
+
+    return ctx.json({
+      ...upgradedTenant,
+      is_control_plane: isControlPlaneTenant(ctx, id),
+    });
+  },
+});
+
 export const tenantRoutes = new OpenAPIHono<{
   Bindings: Bindings;
   Variables: Variables;
-}>().openapiRoutes([getSettings, patchSettings] as const);
+}>().openapiRoutes([getSettings, patchSettings, redeployTenant] as const);
 
 // True when the current tenant is the deployment's control plane. In
 // multi-tenant deployments `multiTenancyConfig.controlPlaneTenantId` names the

--- a/packages/authhero/src/routes/management-api/tenants.ts
+++ b/packages/authhero/src/routes/management-api/tenants.ts
@@ -63,7 +63,14 @@ const patchSettings = defineRoute({
       body: {
         content: {
           "application/json": {
-            schema: z.object(tenantInsertSchema.shape).partial(),
+            // `database_version` tracks the schema migration the tenant's
+            // deployed bundle targets — it's reconciled by the provisioner,
+            // not something a client may set. Omit it from the externally
+            // patchable settings so it can't be written through patchSettings.
+            schema: z
+              .object(tenantInsertSchema.shape)
+              .omit({ database_version: true })
+              .partial(),
           },
         },
       },
@@ -205,12 +212,21 @@ const redeployTenant = defineRoute({
       });
     }
 
+    // Only WFP-provisioned tenants have their own worker/D1 to redeploy. A
+    // shared tenant has nothing to upgrade and would otherwise fail deeper in
+    // the provisioning hook — reject it here with a clear client error.
+    if (existingTenant.deployment_type !== "wfp") {
+      throw new HTTPException(400, {
+        message: "Only WFP-provisioned tenants can be redeployed",
+      });
+    }
+
     try {
       await ctx.env.tenantUpgrade(id);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      console.error("Tenant upgrade failed", { tenantId: id, err });
       throw new HTTPException(500, {
-        message: `Tenant upgrade failed: ${message}`,
+        message: "Tenant upgrade failed",
       });
     }
 

--- a/packages/authhero/src/types/AuthHeroConfig.ts
+++ b/packages/authhero/src/types/AuthHeroConfig.ts
@@ -409,6 +409,28 @@ export interface AuthHeroConfig {
   tenantDispatch?: MiddlewareHandler;
 
   /**
+   * Optional handler that re-provisions (upgrades) an existing WFP tenant onto
+   * the control plane's current worker bundle + migrations. When set, the
+   * management API exposes `POST /api/v2/tenants/{id}/redeploy` (control-plane
+   * only), which invokes this handler and returns the refreshed tenant row with
+   * its updated `worker_version` / `bundle_configuration` / `database_version`.
+   *
+   * Kept as a generic `(tenantId) => Promise<void>` so authhero core carries no
+   * Cloudflare / dispatch-namespace dependency. Wire it to
+   * `@authhero/cloudflare-adapter`'s provisioning hook:
+   *
+   * @example
+   * ```typescript
+   * const hook = createWfpTenantProvisioningHook({ provisioner, tenants });
+   * const { app } = init({
+   *   dataAdapter,
+   *   tenantUpgrade: hook.onUpgrade,
+   * });
+   * ```
+   */
+  tenantUpgrade?: (tenantId: string) => Promise<void>;
+
+  /**
    * Optional powered-by logo to display at the bottom left of the login widget.
    * This is only configurable in code, not stored in the database.
    *

--- a/packages/authhero/src/types/Bindings.ts
+++ b/packages/authhero/src/types/Bindings.ts
@@ -68,6 +68,11 @@ export type Bindings = {
   // Set via init({ webhookInvoker: ... })
   webhookInvoker?: WebhookInvoker;
 
+  // Optional handler to upgrade (re-provision) a WFP tenant onto the current
+  // bundle + migrations. Set via init({ tenantUpgrade: hook.onUpgrade }).
+  // Drives POST /api/v2/tenants/{id}/redeploy.
+  tenantUpgrade?: (tenantId: string) => Promise<void>;
+
   // Optional transactional outbox configuration
   // Set via init({ outbox: { enabled: true } })
   outbox?: OutboxConfig;

--- a/packages/authhero/test/helpers/mutable-response.spec.ts
+++ b/packages/authhero/test/helpers/mutable-response.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  toMutableResponse,
+  ensureMutableResponse,
+} from "../../src/helpers/mutable-response";
+
+/**
+ * Simulate a response received from `fetch()` / a dispatch namespace: its
+ * headers throw on any mutation, exactly like the runtime's immutable guard.
+ */
+function immutableResponse(body: string | null, status = 200): Response {
+  const res = new Response(body, { status });
+  const throwImmutable = () => {
+    throw new TypeError("Can't modify immutable headers.");
+  };
+  for (const method of ["append", "set", "delete"] as const) {
+    Object.defineProperty(res.headers, method, {
+      value: throwImmutable,
+      configurable: true,
+    });
+  }
+  return res;
+}
+
+describe("toMutableResponse", () => {
+  it("re-wraps an immutable response so its headers can be written", async () => {
+    const res = toMutableResponse(immutableResponse("hello"));
+
+    expect(() => res.headers.set("X-Test", "1")).not.toThrow();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello");
+  });
+
+  it("preserves status, body, and existing headers", async () => {
+    const original = new Response("body", {
+      status: 503,
+      headers: { "X-Existing": "kept" },
+    });
+    const res = toMutableResponse(original);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("X-Existing")).toBe("kept");
+    expect(await res.text()).toBe("body");
+  });
+
+  it("is safe on a null-body status (204/304)", () => {
+    const res = toMutableResponse(immutableResponse(null, 204));
+    expect(res.status).toBe(204);
+    expect(() => res.headers.set("X-Test", "1")).not.toThrow();
+  });
+
+  it("leaves a WebSocket upgrade untouched (same reference)", () => {
+    // A 101 Response can't be constructed in undici (status must be >= 200), but
+    // the carve-out's real trigger is the `webSocket` handle reconstruction would
+    // drop — simulate that.
+    const upgrade = new Response(null, { status: 200 });
+    Object.defineProperty(upgrade, "webSocket", { value: {} });
+    expect(toMutableResponse(upgrade)).toBe(upgrade);
+  });
+});
+
+describe("ensureMutableResponse", () => {
+  it("replaces c.res with a writable response in place", () => {
+    const c = { res: immutableResponse("x") };
+    ensureMutableResponse(c);
+    expect(() => c.res.headers.set("X-Test", "1")).not.toThrow();
+  });
+
+  it("is idempotent and preserves headers written between calls", () => {
+    const c = { res: immutableResponse("x") };
+    ensureMutableResponse(c);
+    c.res.headers.set("X-First", "1");
+    ensureMutableResponse(c);
+    c.res.headers.set("X-Second", "2");
+    expect(c.res.headers.get("X-First")).toBe("1");
+    expect(c.res.headers.get("X-Second")).toBe("2");
+  });
+});

--- a/packages/authhero/test/helpers/test-server.ts
+++ b/packages/authhero/test/helpers/test-server.ts
@@ -70,6 +70,9 @@ type getEnvParams = {
   // Optional middleware mounted inside the management API after the CORS
   // middleware (the `config.tenantDispatch` integration point).
   tenantDispatch?: import("hono").MiddlewareHandler;
+  // Optional handler driving POST /tenants/{id}/redeploy (the
+  // `config.tenantUpgrade` integration point).
+  tenantUpgrade?: (tenantId: string) => Promise<void>;
   // Optional static CORS allow-list passed through to `init`.
   allowedOrigins?: string[];
 };
@@ -279,6 +282,7 @@ export async function getTestServer(
       : {}),
     ...(args.codeExecutor ? { codeExecutor: args.codeExecutor } : {}),
     ...(args.tenantDispatch ? { tenantDispatch: args.tenantDispatch } : {}),
+    ...(args.tenantUpgrade ? { tenantUpgrade: args.tenantUpgrade } : {}),
     ...(args.allowedOrigins ? { allowedOrigins: args.allowedOrigins } : {}),
   });
   return {

--- a/packages/authhero/test/routes/management-api/tenant-dispatch.spec.ts
+++ b/packages/authhero/test/routes/management-api/tenant-dispatch.spec.ts
@@ -50,6 +50,58 @@ describe("management-api tenantDispatch", () => {
     expect(response.headers.get("Vary")).toContain("Origin");
   });
 
+  it("applies CORS to an immutable dispatched response without throwing", async () => {
+    // A real dispatch / `fetch()` response carries immutable headers. If the CORS
+    // (or any post-`next()`) middleware writes onto it without normalizing first,
+    // it throws "Can't modify immutable headers." and the request 500s. This
+    // forward returns such a response to prove the management chain re-wraps it.
+    const immutableForward: MiddlewareHandler = async (c, next) => {
+      const tenantId = c.req.header("tenant-id");
+      if (tenantId && tenantId !== "control-plane") {
+        const res = new Response(`forwarded:${tenantId}`, {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+        const throwImmutable = () => {
+          throw new TypeError("Can't modify immutable headers.");
+        };
+        for (const method of ["append", "set", "delete"] as const) {
+          Object.defineProperty(res.headers, method, {
+            value: throwImmutable,
+            configurable: true,
+          });
+        }
+        return res;
+      }
+      return next();
+    };
+
+    const { managementApp, env } = await getTestServer({
+      tenantDispatch: immutableForward,
+      allowedOrigins: ["https://admin.example.com"],
+    });
+
+    const response = await managementApp.request(
+      "/clients",
+      {
+        method: "GET",
+        headers: {
+          Origin: "https://admin.example.com",
+          "tenant-id": "acme",
+        },
+      },
+      env,
+    );
+
+    // No 500: the immutable response was normalized before CORS wrote headers.
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("forwarded:acme");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://admin.example.com",
+    );
+    expect(response.headers.get("Vary")).toContain("Origin");
+  });
+
   it("falls through to the local pipeline when not dispatched", async () => {
     const { managementApp, env } = await getTestServer({
       tenantDispatch: fakeForward,

--- a/packages/authhero/test/routes/management-api/tenant-redeploy.spec.ts
+++ b/packages/authhero/test/routes/management-api/tenant-redeploy.spec.ts
@@ -49,6 +49,67 @@ describe("management-api POST /tenants/{id}/redeploy", () => {
     });
   });
 
+  it("returns 403 when the caller is not the control plane", async () => {
+    const calls: string[] = [];
+    const { app, env } = await getTestServer({
+      tenantUpgrade: async (tenantId: string) => {
+        calls.push(tenantId);
+      },
+    });
+
+    // Point the control plane at a different tenant so the acting tenant
+    // ("tenantId", from the header) is no longer the control plane.
+    (env.data as any).multiTenancyConfig = {
+      controlPlaneTenantId: "control_plane",
+    };
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/redeploy",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(403);
+    // The handler short-circuits before invoking the upgrade.
+    expect(calls).toEqual([]);
+  });
+
+  it("returns 400 when the target tenant is not WFP-provisioned", async () => {
+    const calls: string[] = [];
+    const { app, env } = await getTestServer({
+      tenantUpgrade: async (tenantId: string) => {
+        calls.push(tenantId);
+      },
+    });
+
+    // The fixture tenant defaults to a shared deployment — make it explicit.
+    await env.data.tenants.update("tenantId", { deployment_type: "shared" });
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/redeploy",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+    // Rejected before any upgrade work happens.
+    expect(calls).toEqual([]);
+  });
+
   it("returns 501 when no upgrade handler is configured", async () => {
     const { app, env } = await getTestServer();
 
@@ -101,6 +162,9 @@ describe("management-api POST /tenants/{id}/redeploy", () => {
       },
     });
 
+    // Only WFP tenants pass the deployment-type gate and reach the handler.
+    await env.data.tenants.update("tenantId", { deployment_type: "wfp" });
+
     const token = await getAdminToken();
     const response = await app.request(
       "/api/v2/tenants/tenantId/redeploy",
@@ -115,6 +179,7 @@ describe("management-api POST /tenants/{id}/redeploy", () => {
     );
 
     expect(response.status).toBe(500);
-    expect(await response.text()).toContain("upload failed");
+    // The internal error is logged server-side, not leaked to the client.
+    expect(await response.text()).toContain("Tenant upgrade failed");
   });
 });

--- a/packages/authhero/test/routes/management-api/tenant-redeploy.spec.ts
+++ b/packages/authhero/test/routes/management-api/tenant-redeploy.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { getAdminToken } from "../../helpers/token";
+import { getTestServer } from "../../helpers/test-server";
+
+// Driven through the full `app` (mounting the management API at /api/v2) rather
+// than `managementApp` directly: the management onError deliberately rethrows
+// 5xx to the parent app, so the 501/500 cases only resolve to a Response when
+// the parent app's onError is in the chain.
+describe("management-api POST /tenants/{id}/redeploy", () => {
+  it("invokes tenantUpgrade and returns the refreshed tenant", async () => {
+    const calls: string[] = [];
+    const { app, env } = await getTestServer({
+      tenantUpgrade: async (tenantId: string) => {
+        calls.push(tenantId);
+        // Simulate the hook writing the new versions back.
+        await env.data.tenants.update(tenantId, {
+          deployment_type: "wfp",
+          worker_version: "v2.0.0",
+          database_version: "0002_add_y.sql",
+          provisioning_state: "ready",
+        });
+      },
+    });
+
+    // The fixture tenant "tenantId" is the upgrade target.
+    await env.data.tenants.update("tenantId", { deployment_type: "wfp" });
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/redeploy",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["tenantId"]);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      id: "tenantId",
+      worker_version: "v2.0.0",
+      database_version: "0002_add_y.sql",
+      provisioning_state: "ready",
+    });
+  });
+
+  it("returns 501 when no upgrade handler is configured", async () => {
+    const { app, env } = await getTestServer();
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/redeploy",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(501);
+  });
+
+  it("returns 404 when the target tenant does not exist", async () => {
+    const calls: string[] = [];
+    const { app, env } = await getTestServer({
+      tenantUpgrade: async (tenantId: string) => {
+        calls.push(tenantId);
+      },
+    });
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/does-not-exist/redeploy",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(404);
+    // The handler short-circuits before invoking the upgrade.
+    expect(calls).toEqual([]);
+  });
+
+  it("surfaces a 500 when the upgrade handler throws", async () => {
+    const { app, env } = await getTestServer({
+      tenantUpgrade: async () => {
+        throw new Error("upload failed");
+      },
+    });
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/redeploy",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.text()).toContain("upload failed");
+  });
+});

--- a/packages/cloudflare/src/wfp-provisioner/provisioner.ts
+++ b/packages/cloudflare/src/wfp-provisioner/provisioner.ts
@@ -301,7 +301,20 @@ export function createCloudflareWfpD1Provisioner(
       //    — CF processes each set independently.
       await uploadSecrets(scriptName, tenantId);
 
-      return { d1DatabaseId: databaseId, scriptName, d1Name };
+      // The schema version this bundle targets is the last migration in the
+      // configured list (they apply in array order). `undefined` when no
+      // migrations are configured.
+      const lastMigration = options.migrations[options.migrations.length - 1];
+      const databaseVersion = lastMigration?.name;
+
+      return {
+        d1DatabaseId: databaseId,
+        scriptName,
+        d1Name,
+        bundleConfiguration: options.bundleConfiguration,
+        workerVersion: options.workerVersion,
+        databaseVersion,
+      };
     },
 
     async onDeprovision(tenantId: string): Promise<void> {

--- a/packages/cloudflare/src/wfp-provisioner/provisioner.ts
+++ b/packages/cloudflare/src/wfp-provisioner/provisioner.ts
@@ -14,6 +14,11 @@ const DEFAULT_D1_NAME_TEMPLATE = "tenant-{tenant_id}";
 const DEFAULT_MAIN_MODULE = "index.js";
 const DEFAULT_COMPATIBILITY_DATE = "2026-05-01";
 
+// The recorded version token is persisted into `tenants.database_version`,
+// a 64-char column. Reject anything longer up front so we never run the
+// Cloudflare side effects and then fail the control-plane write afterwards.
+const MAX_DATABASE_VERSION_LENGTH = 64;
+
 function fillTemplate(template: string, tenantId: string): string {
   return template.replace(/\{tenant_id\}/g, tenantId);
 }
@@ -265,6 +270,20 @@ export function createCloudflareWfpD1Provisioner(
       const scriptName = fillTemplate(scriptNameTemplate, tenantId);
       const d1Name = fillTemplate(d1NameTemplate, tenantId);
 
+      // Validate the version token we'll persist BEFORE any Cloudflare side
+      // effects — otherwise an oversize migration name only surfaces after the
+      // tenant is provisioned, leaving the control-plane update broken.
+      const lastMigration = options.migrations[options.migrations.length - 1];
+      const databaseVersion = lastMigration?.name;
+      if (
+        databaseVersion !== undefined &&
+        databaseVersion.length > MAX_DATABASE_VERSION_LENGTH
+      ) {
+        throw new Error(
+          `Migration name "${databaseVersion}" exceeds the ${MAX_DATABASE_VERSION_LENGTH}-character database_version limit.`,
+        );
+      }
+
       // 1. D1: create-if-missing, capture id + whether we just created it.
       const { id: databaseId, created } = await findOrCreateD1(d1Name);
 
@@ -301,12 +320,8 @@ export function createCloudflareWfpD1Provisioner(
       //    — CF processes each set independently.
       await uploadSecrets(scriptName, tenantId);
 
-      // The schema version this bundle targets is the last migration in the
-      // configured list (they apply in array order). `undefined` when no
-      // migrations are configured.
-      const lastMigration = options.migrations[options.migrations.length - 1];
-      const databaseVersion = lastMigration?.name;
-
+      // `databaseVersion` is the last migration in the configured list (they
+      // apply in array order), validated for length at the top of this hook.
       return {
         d1DatabaseId: databaseId,
         scriptName,

--- a/packages/cloudflare/src/wfp-provisioner/tenant-hook.ts
+++ b/packages/cloudflare/src/wfp-provisioner/tenant-hook.ts
@@ -196,6 +196,13 @@ export function createWfpTenantProvisioningHook(
           );
         }
       }
+
+      await tenants.update(tenantId, {
+        ...resourceIds,
+        provisioning_state: "ready",
+        provisioning_error: undefined,
+        provisioning_state_changed_at: new Date().toISOString(),
+      });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       try {
@@ -213,13 +220,6 @@ export function createWfpTenantProvisioningHook(
       }
       throw err;
     }
-
-    await tenants.update(tenantId, {
-      ...resourceIds,
-      provisioning_state: "ready",
-      provisioning_error: undefined,
-      provisioning_state_changed_at: new Date().toISOString(),
-    });
   }
 
   return {
@@ -247,6 +247,10 @@ export function createWfpTenantProvisioningHook(
       try {
         await tenants.update(tenantId, {
           provisioning_state: "pending",
+          // Clear any error from a previous failed attempt so a retried
+          // upgrade starts clean — otherwise a stale error lingers alongside
+          // the in-flight `pending` state. Mirrors the success path.
+          provisioning_error: undefined,
           provisioning_state_changed_at: new Date().toISOString(),
         });
       } catch (writeErr) {

--- a/packages/cloudflare/src/wfp-provisioner/tenant-hook.ts
+++ b/packages/cloudflare/src/wfp-provisioner/tenant-hook.ts
@@ -83,6 +83,19 @@ export interface WfpTenantProvisioningHookOptions {
 export interface WfpTenantProvisioningHook {
   onProvision(tenantId: string): Promise<void>;
   onDeprovision(tenantId: string): Promise<void>;
+  /**
+   * Re-run provisioning for an already-existing WFP tenant to pull it onto the
+   * current bundle + migrations — i.e. an upgrade. Re-uploads the worker
+   * script (an upload overwrites), reconciles any migrations not yet applied to
+   * the tenant D1, re-runs `syncDefaults`, then rewrites `worker_version`,
+   * `bundle_configuration`, and `database_version` so the recorded versions
+   * reflect what now runs. Marks `provisioning_state = "pending"` while the
+   * upgrade is in flight and `ready` on success (`failed` on error).
+   *
+   * Throws if the tenant doesn't exist or isn't WFP-provisioned — callers
+   * (e.g. a management-API redeploy endpoint) surface that as a 4xx.
+   */
+  onUpgrade(tenantId: string): Promise<void>;
 }
 
 function defaultShouldProvision(tenant: {
@@ -141,67 +154,111 @@ export function createWfpTenantProvisioningHook(
     }
   }
 
+  /**
+   * Shared provision/upgrade body: run the provisioner (idempotent — creates or
+   * heals the D1, overwrites the worker, reconciles pending migrations), seed
+   * defaults, then write the resource ids + recorded versions and mark `ready`.
+   * Failure at any step marks the tenant `failed` (persisting resource ids when
+   * we have them) and re-throws.
+   */
+  async function provisionAndPersist(tenantId: string): Promise<void> {
+    let result;
+    try {
+      result = await provisioner.onProvision(tenantId);
+    } catch (err) {
+      // No resources (or only partial) — nothing to persist beyond the
+      // failure marker.
+      await markFailed(tenantId, err);
+      throw err;
+    }
+
+    // Resources exist. Persist their ids + recorded versions regardless of what
+    // happens next so a re-provision / deprovision / drift check can find them.
+    const resourceIds = {
+      d1_database_id: result.d1DatabaseId,
+      worker_script_name: result.scriptName,
+      bundle_configuration: result.bundleConfiguration,
+      worker_version: result.workerVersion,
+      database_version: result.databaseVersion,
+    };
+
+    try {
+      // Seed BEFORE marking ready so we never report "ready" over an empty
+      // D1 (no tenant row, no projected defaults). The seed runs with
+      // `continueOnError`, so a resolved result can still carry per-entity
+      // errors — treat those as a provisioning failure too.
+      if (syncDefaults) {
+        const seedResult = await syncDefaults(tenantId);
+        const seedErrors = collectSyncDefaultsErrors(seedResult);
+        if (seedErrors.length > 0) {
+          throw new Error(
+            `sync-defaults seed reported ${seedErrors.length} error(s): ${seedErrors.join("; ")}`,
+          );
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      try {
+        await tenants.update(tenantId, {
+          ...resourceIds,
+          provisioning_state: "failed",
+          provisioning_error: message.slice(0, 2048),
+          provisioning_state_changed_at: new Date().toISOString(),
+        });
+      } catch (writeErr) {
+        logger?.warn(
+          `Failed to write provisioning_state="failed" for tenant ${tenantId}:`,
+          writeErr,
+        );
+      }
+      throw err;
+    }
+
+    await tenants.update(tenantId, {
+      ...resourceIds,
+      provisioning_state: "ready",
+      provisioning_error: undefined,
+      provisioning_state_changed_at: new Date().toISOString(),
+    });
+  }
+
   return {
     async onProvision(tenantId: string): Promise<void> {
       const tenant = await tenants.get(tenantId);
       if (!tenant) return; // No tenant row — probably mid-rollback. Nothing to do.
       if (!shouldProvision(tenant)) return; // Shared deployment, skip.
 
-      let result;
-      try {
-        result = await provisioner.onProvision(tenantId);
-      } catch (err) {
-        // No resources (or only partial) — nothing to persist beyond the
-        // failure marker.
-        await markFailed(tenantId, err);
-        throw err;
+      await provisionAndPersist(tenantId);
+    },
+
+    async onUpgrade(tenantId: string): Promise<void> {
+      const tenant = await tenants.get(tenantId);
+      if (!tenant) {
+        throw new Error(`Cannot upgrade tenant "${tenantId}": not found.`);
+      }
+      if (!shouldProvision(tenant)) {
+        throw new Error(
+          `Cannot upgrade tenant "${tenantId}": not a WFP-provisioned tenant.`,
+        );
       }
 
-      // Resources exist. Persist their ids regardless of what happens next so a
-      // re-provision / deprovision can find them.
-      const resourceIds = {
-        d1_database_id: result.d1DatabaseId,
-        worker_script_name: result.scriptName,
-      };
-
+      // Flip to `pending` so the admin UI reflects an in-flight upgrade. A
+      // failure inside `provisionAndPersist` overwrites this with `failed`.
       try {
-        // Seed BEFORE marking ready so we never report "ready" over an empty
-        // D1 (no tenant row, no projected defaults). The seed runs with
-        // `continueOnError`, so a resolved result can still carry per-entity
-        // errors — treat those as a provisioning failure too.
-        if (syncDefaults) {
-          const result = await syncDefaults(tenantId);
-          const seedErrors = collectSyncDefaultsErrors(result);
-          if (seedErrors.length > 0) {
-            throw new Error(
-              `sync-defaults seed reported ${seedErrors.length} error(s): ${seedErrors.join("; ")}`,
-            );
-          }
-        }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        try {
-          await tenants.update(tenantId, {
-            ...resourceIds,
-            provisioning_state: "failed",
-            provisioning_error: message.slice(0, 2048),
-            provisioning_state_changed_at: new Date().toISOString(),
-          });
-        } catch (writeErr) {
-          logger?.warn(
-            `Failed to write provisioning_state="failed" for tenant ${tenantId}:`,
-            writeErr,
-          );
-        }
-        throw err;
+        await tenants.update(tenantId, {
+          provisioning_state: "pending",
+          provisioning_state_changed_at: new Date().toISOString(),
+        });
+      } catch (writeErr) {
+        // Non-fatal — the upgrade can still proceed; the state just won't show
+        // `pending` in the meantime.
+        logger?.warn(
+          `Failed to write provisioning_state="pending" for tenant ${tenantId}:`,
+          writeErr,
+        );
       }
 
-      await tenants.update(tenantId, {
-        ...resourceIds,
-        provisioning_state: "ready",
-        provisioning_error: undefined,
-        provisioning_state_changed_at: new Date().toISOString(),
-      });
+      await provisionAndPersist(tenantId);
     },
 
     async onDeprovision(tenantId: string): Promise<void> {

--- a/packages/cloudflare/src/wfp-provisioner/types.ts
+++ b/packages/cloudflare/src/wfp-provisioner/types.ts
@@ -89,8 +89,26 @@ export interface CloudflareWfpD1ProvisionerOptions {
   /**
    * SQL migrations applied in array order to every new tenant D1. Typically
    * loaded from `@authhero/drizzle`'s shipped migrations via your build tool.
+   *
+   * The name of the LAST entry is reported back as the tenant's
+   * `database_version` (the schema version this bundle targets), so keep the
+   * array ordered and the names stable.
    */
   migrations: ProvisionerMigration[];
+  /**
+   * Identifier of the worker image / variant being deployed (e.g.
+   * `"authhero-drizzle-d1"`). Recorded verbatim on the tenant row as
+   * `bundle_configuration` so the control plane can tell which build a tenant
+   * runs. Optional — omit if you don't track image variants.
+   */
+  bundleConfiguration?: string;
+  /**
+   * Release tag or git SHA of `tenantWorkerScript`, supplied by the operator
+   * at build time. Recorded verbatim on the tenant row as `worker_version` so
+   * the control plane can detect when a tenant lags the current build and
+   * needs an upgrade. Optional but strongly recommended.
+   */
+  workerVersion?: string;
   /**
    * Resolver that returns the secret values to set on the tenant worker.
    * Called once per `onProvision`. The provisioner uploads each entry via
@@ -152,6 +170,25 @@ export interface ProvisionResult {
   d1DatabaseId: string;
   scriptName: string;
   d1Name: string;
+  /**
+   * The worker image / variant that was deployed — echoes back
+   * `options.bundleConfiguration` (undefined if not configured). The hook
+   * persists it to `tenants.bundle_configuration`.
+   */
+  bundleConfiguration?: string;
+  /**
+   * The release tag / git SHA that was deployed — echoes back
+   * `options.workerVersion` (undefined if not configured). The hook persists
+   * it to `tenants.worker_version`.
+   */
+  workerVersion?: string;
+  /**
+   * Name of the latest migration applied to the tenant D1 (the last entry in
+   * `options.migrations`), i.e. the schema version the deployed bundle
+   * targets. `undefined` when no migrations are configured. The hook persists
+   * it to `tenants.database_version`.
+   */
+  databaseVersion?: string;
 }
 
 /**

--- a/packages/cloudflare/src/wfp-provisioner/wfp-forward.ts
+++ b/packages/cloudflare/src/wfp-provisioner/wfp-forward.ts
@@ -95,7 +95,53 @@ export function createWfpForwardMiddleware(
     }
 
     const scriptName = fillTemplate(scriptNameTemplate, tenantId);
-    const res = await dispatcher.get(scriptName).fetch(c.req.raw);
+
+    let res: Response;
+    try {
+      res = await dispatcher.get(scriptName).fetch(c.req.raw);
+    } catch (err) {
+      // `dispatcher.get(name).fetch()` throws when the tenant's worker isn't in
+      // the namespace ("worker not found") or fails to boot. Left unhandled this
+      // surfaces as an opaque control-plane 500 that names neither the tenant
+      // nor the script. Log the cause (visible in the control plane's own
+      // `wrangler tail`) and return a structured, tenant-scoped error so a
+      // routing/provisioning gap is distinguishable from a real upstream
+      // failure — and carries the same `X-Authhero-Error` code convention the
+      // tenant worker uses.
+      const detail = err instanceof Error ? err.message : String(err);
+      const missing = /not\s*found|no\s*such|does not exist/i.test(detail);
+      const code = missing ? "wfp_worker_not_found" : "wfp_dispatch_failed";
+      console.error(
+        `[wfp-forward] ${code} tenant=${tenantId} script=${scriptName}: ${detail}`,
+      );
+      c.header("X-Authhero-Error", code);
+      c.header("X-Wfp-Tenant", tenantId);
+      return c.json(
+        {
+          error: code,
+          detail: missing
+            ? `Tenant '${tenantId}' is marked ready but its worker '${scriptName}' is not deployed in the dispatch namespace.`
+            : `The worker for tenant '${tenantId}' could not be reached.`,
+          tenant_id: tenantId,
+        },
+        missing ? 503 : 502,
+      );
+    }
+
+    // A dispatched 5xx is the tenant worker failing. The control plane can't
+    // `wrangler tail` a dispatch-namespace worker, so record which tenant/script
+    // produced it — and any `X-Authhero-Error` code the worker tagged — here,
+    // where that context is known. The full cause still lives in the tenant
+    // worker's own logs, but this turns an opaque control-plane 500 into a
+    // traceable one.
+    if (res.status >= 500) {
+      const code = res.headers.get("X-Authhero-Error");
+      console.error(
+        `[wfp-forward] tenant worker ${res.status}${
+          code ? ` (${code})` : ""
+        } tenant=${tenantId} script=${scriptName}`,
+      );
+    }
 
     // A response returned straight from `fetch()` / WFP dispatch carries an
     // *immutable* header guard. authhero core mounts this middleware inside its
@@ -103,7 +149,7 @@ export function createWfpForwardMiddleware(
     // `Access-Control-*` on the response — mutating immutable headers throws
     // "Can't modify immutable headers." and every dispatched request 500s.
     // Re-wrap into a fresh Response, which has the mutable "response" guard, so
-    // downstream middleware can write headers.
+    // downstream middleware (and the tenant tag below) can write headers.
     //
     // Skip the re-wrap only for a 101 Switching Protocols upgrade: it carries a
     // `webSocket` handle that a reconstructed Response would drop, breaking the
@@ -115,6 +161,10 @@ export function createWfpForwardMiddleware(
       return res;
     }
 
-    return new Response(res.body, res);
+    // Tag every dispatched response so an operator can see, from the response
+    // alone, that the request was served by a tenant worker and which one.
+    const wrapped = new Response(res.body, res);
+    wrapped.headers.set("X-Wfp-Tenant", tenantId);
+    return wrapped;
   };
 }

--- a/packages/cloudflare/test/wfp-provisioner.spec.ts
+++ b/packages/cloudflare/test/wfp-provisioner.spec.ts
@@ -679,7 +679,46 @@ describe("createCloudflareWfpD1Provisioner", () => {
       d1DatabaseId: "db_kvartal",
       scriptName: "kvartal",
       d1Name: "tenant-kvartal",
+      // database_version is the last migration; no bundle/worker version set
+      databaseVersion: "0.sql",
     });
+  });
+
+  it("onProvision reports the deployed versions: bundle, worker, and the latest migration as database_version", async () => {
+    setupHappyPath();
+    const provisioner = createCloudflareWfpD1Provisioner({
+      accountId: ACCOUNT_ID,
+      apiToken: "token",
+      dispatchNamespace: NAMESPACE,
+      controlPlaneBaseUrl: "https://auth.example.com",
+      tenantWorkerScript: "",
+      bundleConfiguration: "authhero-drizzle-d1",
+      workerVersion: "v1.2.3",
+      migrations: [
+        { name: "0000_init.sql", sql: "SELECT 1;" },
+        { name: "0001_add_x.sql", sql: "SELECT 1;" },
+      ],
+      secrets: async () => ({ X: "y" }),
+    });
+    const result = await provisioner.onProvision("kvartal");
+    expect(result.bundleConfiguration).toBe("authhero-drizzle-d1");
+    expect(result.workerVersion).toBe("v1.2.3");
+    expect(result.databaseVersion).toBe("0001_add_x.sql");
+  });
+
+  it("onProvision leaves database_version undefined when no migrations are configured", async () => {
+    setupHappyPath();
+    const provisioner = createCloudflareWfpD1Provisioner({
+      accountId: ACCOUNT_ID,
+      apiToken: "token",
+      dispatchNamespace: NAMESPACE,
+      controlPlaneBaseUrl: "https://auth.example.com",
+      tenantWorkerScript: "",
+      migrations: [],
+      secrets: async () => ({ X: "y" }),
+    });
+    const result = await provisioner.onProvision("kvartal");
+    expect(result.databaseVersion).toBeUndefined();
   });
 });
 
@@ -937,5 +976,113 @@ describe("createWfpTenantProvisioningHook", () => {
     await expect(hook.onProvision("kvartal")).rejects.toThrow(/upstream failed/);
     expect(warn).toHaveBeenCalledOnce();
     expect(warn.mock.calls[0][0]).toMatch(/Failed to write provisioning_state/);
+  });
+
+  it("writes the deployed versions back onto the tenant row", async () => {
+    const provisioner = fakeProvisioner();
+    provisioner.nextProvisionResult = {
+      d1DatabaseId: "db_kvartal",
+      scriptName: "kvartal",
+      d1Name: "tenant-kvartal",
+      bundleConfiguration: "authhero-drizzle-d1",
+      workerVersion: "v1.2.3",
+      databaseVersion: "0001_add_x.sql",
+    };
+    const tenants = fakeTenantsAdapter({
+      id: "kvartal",
+      deployment_type: "wfp",
+      provisioning_state: "pending",
+    });
+    const hook = createWfpTenantProvisioningHook({ provisioner, tenants });
+    await hook.onProvision("kvartal");
+    expect(tenants.store.get("kvartal")).toMatchObject({
+      bundle_configuration: "authhero-drizzle-d1",
+      worker_version: "v1.2.3",
+      database_version: "0001_add_x.sql",
+      provisioning_state: "ready",
+    });
+  });
+
+  it("onUpgrade re-provisions a wfp tenant and rewrites its versions", async () => {
+    const provisioner = fakeProvisioner();
+    provisioner.nextProvisionResult = {
+      d1DatabaseId: "db_kvartal",
+      scriptName: "kvartal",
+      d1Name: "tenant-kvartal",
+      bundleConfiguration: "authhero-drizzle-d1",
+      workerVersion: "v2.0.0",
+      databaseVersion: "0002_add_y.sql",
+    };
+    const tenants = fakeTenantsAdapter({
+      id: "kvartal",
+      deployment_type: "wfp",
+      provisioning_state: "ready",
+      worker_version: "v1.0.0",
+      database_version: "0001_add_x.sql",
+    });
+    const hook = createWfpTenantProvisioningHook({ provisioner, tenants });
+    await hook.onUpgrade("kvartal");
+    expect(provisioner.onProvisionCalls).toEqual(["kvartal"]);
+    expect(tenants.store.get("kvartal")).toMatchObject({
+      worker_version: "v2.0.0",
+      database_version: "0002_add_y.sql",
+      provisioning_state: "ready",
+    });
+  });
+
+  it("onUpgrade marks the tenant 'pending' before re-provisioning", async () => {
+    const provisioner = fakeProvisioner();
+    const tenants = fakeTenantsAdapter({
+      id: "kvartal",
+      deployment_type: "wfp",
+      provisioning_state: "ready",
+    });
+    // Observe the state at the moment the provisioner runs.
+    let stateDuringProvision: string | undefined;
+    const baseOnProvision = provisioner.onProvision.bind(provisioner);
+    provisioner.onProvision = async (id: string) => {
+      stateDuringProvision = tenants.store.get(id)?.provisioning_state;
+      return baseOnProvision(id);
+    };
+    const hook = createWfpTenantProvisioningHook({ provisioner, tenants });
+    await hook.onUpgrade("kvartal");
+    expect(stateDuringProvision).toBe("pending");
+  });
+
+  it("onUpgrade marks failed and rethrows when the provisioner throws", async () => {
+    const provisioner = fakeProvisioner();
+    provisioner.nextProvisionError = new Error("upload failed");
+    const tenants = fakeTenantsAdapter({
+      id: "kvartal",
+      deployment_type: "wfp",
+      provisioning_state: "ready",
+    });
+    const hook = createWfpTenantProvisioningHook({ provisioner, tenants });
+    await expect(hook.onUpgrade("kvartal")).rejects.toThrow(/upload failed/);
+    expect(tenants.store.get("kvartal")).toMatchObject({
+      provisioning_state: "failed",
+      provisioning_error: "upload failed",
+    });
+  });
+
+  it("onUpgrade throws for a missing tenant", async () => {
+    const provisioner = fakeProvisioner();
+    const tenants = fakeTenantsAdapter({ id: "other", deployment_type: "wfp" });
+    const hook = createWfpTenantProvisioningHook({ provisioner, tenants });
+    await expect(hook.onUpgrade("missing")).rejects.toThrow(/not found/);
+    expect(provisioner.onProvisionCalls).toEqual([]);
+  });
+
+  it("onUpgrade throws for a non-wfp tenant", async () => {
+    const provisioner = fakeProvisioner();
+    const tenants = fakeTenantsAdapter({
+      id: "shared-tenant",
+      deployment_type: "shared",
+    });
+    const hook = createWfpTenantProvisioningHook({ provisioner, tenants });
+    await expect(hook.onUpgrade("shared-tenant")).rejects.toThrow(
+      /not a WFP-provisioned tenant/,
+    );
+    expect(provisioner.onProvisionCalls).toEqual([]);
   });
 });

--- a/packages/cloudflare/test/wfp-sync.spec.ts
+++ b/packages/cloudflare/test/wfp-sync.spec.ts
@@ -388,6 +388,113 @@ describe("createWfpForwardMiddleware", () => {
     }
     expect(dispatcher.calls).toHaveLength(0);
   });
+
+  it("returns a structured 503 when the tenant worker is not in the namespace", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const dispatcher = fakeDispatcher(() => {
+      throw new Error("Worker not found.");
+    });
+    const app = appWith(
+      createWfpForwardMiddleware({
+        tenants: fakeTenants({
+          acme: { deployment_type: "wfp", provisioning_state: "ready" },
+        }),
+        controlPlaneTenantId: CP,
+      }),
+    );
+
+    const res = await app.request(
+      "/users",
+      { headers: { "tenant-id": "acme" } },
+      { DISPATCHER: dispatcher },
+    );
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("X-Authhero-Error")).toBe("wfp_worker_not_found");
+    expect(res.headers.get("X-Wfp-Tenant")).toBe("acme");
+    expect(await res.json()).toMatchObject({
+      error: "wfp_worker_not_found",
+      tenant_id: "acme",
+    });
+  });
+
+  it("returns a structured 502 on an unexpected dispatch failure", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const dispatcher = fakeDispatcher(() => {
+      throw new Error("connection reset");
+    });
+    const app = appWith(
+      createWfpForwardMiddleware({
+        tenants: fakeTenants({
+          acme: { deployment_type: "wfp", provisioning_state: "ready" },
+        }),
+        controlPlaneTenantId: CP,
+      }),
+    );
+
+    const res = await app.request(
+      "/users",
+      { headers: { "tenant-id": "acme" } },
+      { DISPATCHER: dispatcher },
+    );
+
+    expect(res.status).toBe(502);
+    expect(res.headers.get("X-Authhero-Error")).toBe("wfp_dispatch_failed");
+  });
+
+  it("passes a tenant worker 5xx through and tags it for correlation", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const dispatcher = fakeDispatcher(
+      () =>
+        new Response(JSON.stringify({ error: "boom" }), {
+          status: 500,
+          headers: { "X-Authhero-Error": "tenant_app_error" },
+        }),
+    );
+    const app = appWith(
+      createWfpForwardMiddleware({
+        tenants: fakeTenants({
+          acme: { deployment_type: "wfp", provisioning_state: "ready" },
+        }),
+        controlPlaneTenantId: CP,
+      }),
+    );
+
+    const res = await app.request(
+      "/users",
+      { headers: { "tenant-id": "acme" } },
+      { DISPATCHER: dispatcher },
+    );
+
+    // The tenant worker's own response (status + body + its error code) is
+    // preserved; the dispatcher only adds the tenant tag.
+    expect(res.status).toBe(500);
+    expect(res.headers.get("X-Authhero-Error")).toBe("tenant_app_error");
+    expect(res.headers.get("X-Wfp-Tenant")).toBe("acme");
+  });
+
+  it("tags a successful dispatched response with X-Wfp-Tenant", async () => {
+    const dispatcher = fakeDispatcher(
+      () => new Response("from-tenant-worker", { status: 200 }),
+    );
+    const app = appWith(
+      createWfpForwardMiddleware({
+        tenants: fakeTenants({
+          acme: { deployment_type: "wfp", provisioning_state: "ready" },
+        }),
+        controlPlaneTenantId: CP,
+      }),
+    );
+
+    const res = await app.request(
+      "/users",
+      { headers: { "tenant-id": "acme" } },
+      { DISPATCHER: dispatcher },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Wfp-Tenant")).toBe("acme");
+  });
 });
 
 describe("createWfpTenantApp /internal/sync-defaults", () => {

--- a/packages/cloudflare/test/wfp-sync.spec.ts
+++ b/packages/cloudflare/test/wfp-sync.spec.ts
@@ -440,6 +440,11 @@ describe("createWfpForwardMiddleware", () => {
 
     expect(res.status).toBe(502);
     expect(res.headers.get("X-Authhero-Error")).toBe("wfp_dispatch_failed");
+    expect(res.headers.get("X-Wfp-Tenant")).toBe("acme");
+    expect(await res.json()).toMatchObject({
+      error: "wfp_dispatch_failed",
+      tenant_id: "acme",
+    });
   });
 
   it("passes a tenant worker 5xx through and tags it for correlation", async () => {
@@ -471,6 +476,7 @@ describe("createWfpForwardMiddleware", () => {
     expect(res.status).toBe(500);
     expect(res.headers.get("X-Authhero-Error")).toBe("tenant_app_error");
     expect(res.headers.get("X-Wfp-Tenant")).toBe("acme");
+    expect(await res.json()).toMatchObject({ error: "boom" });
   });
 
   it("tags a successful dispatched response with X-Wfp-Tenant", async () => {

--- a/packages/drizzle/drizzle/0000_init.sql
+++ b/packages/drizzle/drizzle/0000_init.sql
@@ -49,6 +49,7 @@ CREATE TABLE `tenants` (
 	`provisioning_state_changed_at` text(35),
 	`bundle_configuration` text(64),
 	`worker_version` text(64),
+	`database_version` text(64),
 	`worker_script_name` text(255),
 	`storage_kind` text(32),
 	`d1_database_id` text(64)

--- a/packages/drizzle/drizzle/meta/0000_snapshot.json
+++ b/packages/drizzle/drizzle/meta/0000_snapshot.json
@@ -359,6 +359,13 @@
           "notNull": false,
           "autoincrement": false
         },
+        "database_version": {
+          "name": "database_version",
+          "type": "text(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
         "worker_script_name": {
           "name": "worker_script_name",
           "type": "text(255)",

--- a/packages/drizzle/src/schema/sqlite/tenants.ts
+++ b/packages/drizzle/src/schema/sqlite/tenants.ts
@@ -65,6 +65,7 @@ export const tenants = sqliteTable("tenants", {
   }),
   bundle_configuration: text("bundle_configuration", { length: 64 }),
   worker_version: text("worker_version", { length: 64 }),
+  database_version: text("database_version", { length: 64 }),
   worker_script_name: text("worker_script_name", { length: 255 }),
   storage_kind: text("storage_kind", { length: 32 }),
   d1_database_id: text("d1_database_id", { length: 64 }),

--- a/packages/kysely/migrate/migrations/2026-06-27T12:00:00_tenant_database_version.ts
+++ b/packages/kysely/migrate/migrations/2026-06-27T12:00:00_tenant_database_version.ts
@@ -1,0 +1,23 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/db";
+
+/**
+ * Adds `database_version` to the tenant row so the control plane can record the
+ * schema version (the latest migration applied) the deployed WFP tenant worker
+ * targets. Together with `worker_version` and `bundle_configuration` this lets
+ * the control plane detect drift and drive upgrades. Nullable — shared tenants
+ * and pre-existing WFP tenants land as `null` until their next (re)provision.
+ */
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("tenants")
+    .addColumn("database_version", "varchar(64)")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("tenants")
+    .dropColumn("database_version")
+    .execute();
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -173,6 +173,7 @@ import * as o074_widen_user_permissions_resource_server_identifier from "./2026-
 import * as o075_create_grants from "./2026-06-04T11:00:00_create_grants";
 import * as o076_default_first_party_true from "./2026-06-04T11:01:00_default_first_party_true";
 import * as o077_tenant_deployment_fields from "./2026-06-06T12:00:00_tenant_deployment_fields";
+import * as o078_tenant_database_version from "./2026-06-27T12:00:00_tenant_database_version";
 
 // These need to be in alphabetic order
 export default {
@@ -351,4 +352,5 @@ export default {
   o075_create_grants,
   o076_default_first_party_true,
   o077_tenant_deployment_fields,
+  o078_tenant_database_version,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tenant **Members** page and a link from the tenants list for easier member management, including email invitation/revocation where available.
  * Improved organization invitations: trims invitee email, supports optional inviter details, and respects whether to send the invitation email.
  * Added a **redeploy** action to refresh WFP tenants from the latest configuration.

* **Bug Fixes**
  * Fixed intermittent 500s when header writes occurred on responses with immutable headers (CORS, server timing, preference).
  * Improved WFP dispatch failure reporting with clearer 502/503 responses and better response tagging.

* **Documentation**
  * Added **database version** tracking to tenant schema/support for upgrade behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->