### PR TITLE
fix: apply management-API CORS headers in the Cloudflare Workers runtime

### DIFF
--- a/.changeset/cors-websocket-runtime-check.md
+++ b/.changeset/cors-websocket-runtime-check.md
@@ -1,0 +1,16 @@
+---
+"authhero": patch
+"@authhero/cloudflare-adapter": patch
+---
+
+Fix management-API CORS headers missing on every actual request in the
+Cloudflare Workers runtime.
+
+The CORS middleware (and the WFP forward middleware) detected a WebSocket
+upgrade with `"webSocket" in res`. The Workers runtime defines a `webSocket`
+property — value `null` — on *every* `Response`, so that check was always true
+in production: the actual-request CORS block (`Vary: Origin` plus the
+`Access-Control-*` headers) was skipped for all non-preflight responses, while
+preflight kept working. The bug was invisible to tests because Node's `Response`
+has no `webSocket` property. Detection now requires a non-null `webSocket`
+handle (or status 101).

--- a/packages/authhero/src/helpers/mutable-response.ts
+++ b/packages/authhero/src/helpers/mutable-response.ts
@@ -15,17 +15,33 @@
  */
 
 /**
+ * True only for a live WebSocket upgrade — a `101 Switching Protocols` response
+ * that carries a non-null `webSocket` handle.
+ *
+ * The check must NOT be `"webSocket" in res`: the Cloudflare Workers runtime
+ * defines a `webSocket` property on *every* `Response` (it is `null` for an
+ * ordinary response), so the `in` operator is always true there and would
+ * misclassify every response as an upgrade. (In Node / the test runtime the
+ * property is absent, so the bug stays invisible to tests.) A real upgrade has
+ * a non-null handle, which is what we detect here.
+ */
+export function isWebSocketUpgrade(res: Response): boolean {
+  const webSocket: unknown = Reflect.get(res, "webSocket");
+  return res.status === 101 || webSocket != null;
+}
+
+/**
  * Return a response whose headers are mutable. A received response is re-wrapped
  * into a fresh `Response` (which has the mutable "response" header guard); an
  * already-mutable response is re-wrapped too, harmlessly, preserving every header
  * already set on it.
  *
- * A `101 Switching Protocols` upgrade is returned untouched: it carries a
- * `webSocket` handle that reconstruction would drop, breaking the upgrade. Its
- * headers stay immutable, so callers must not write to an upgrade response.
+ * A WebSocket upgrade is returned untouched: it carries a `webSocket` handle
+ * that reconstruction would drop, breaking the upgrade. Its headers stay
+ * immutable, so callers must not write to an upgrade response.
  */
 export function toMutableResponse(res: Response): Response {
-  if (res.status === 101 || "webSocket" in res) return res;
+  if (isWebSocketUpgrade(res)) return res;
   return new Response(res.body, res);
 }
 

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -37,7 +37,10 @@ import {
   serverTimingMiddleware,
 } from "../../helpers/server-timing";
 import { applyConfigMiddleware } from "../../middlewares/apply-config";
-import { ensureMutableResponse } from "../../helpers/mutable-response";
+import {
+  ensureMutableResponse,
+  isWebSocketUpgrade,
+} from "../../helpers/mutable-response";
 import { tenantMiddleware } from "../../middlewares/tenant";
 import { clientInfoMiddleware } from "../../middlewares/client-info";
 import { preferMiddleware } from "../../middlewares/prefer";
@@ -203,7 +206,7 @@ export default function create(config: AuthHeroConfig) {
     // can't survive reconstruction), so skip the header writes for it — it never
     // flows through this management API anyway.
     ensureMutableResponse(ctx);
-    const isUpgrade = ctx.res.status === 101 || "webSocket" in ctx.res;
+    const isUpgrade = isWebSocketUpgrade(ctx.res);
 
     if (!isUpgrade) {
       ctx.res.headers.append("Vary", "Origin");

--- a/packages/authhero/test/helpers/mutable-response.spec.ts
+++ b/packages/authhero/test/helpers/mutable-response.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   toMutableResponse,
   ensureMutableResponse,
+  isWebSocketUpgrade,
 } from "../../src/helpers/mutable-response";
 
 /**
@@ -56,6 +57,38 @@ describe("toMutableResponse", () => {
     const upgrade = new Response(null, { status: 200 });
     Object.defineProperty(upgrade, "webSocket", { value: {} });
     expect(toMutableResponse(upgrade)).toBe(upgrade);
+  });
+
+  it("re-wraps a Cloudflare-runtime response whose webSocket property is null", () => {
+    // Regression: the Workers runtime defines a `webSocket` property (value
+    // `null`) on every Response, so `"webSocket" in res` is true even for an
+    // ordinary response. Such a response must still be re-wrapped to mutable —
+    // otherwise downstream CORS/Vary writes are silently skipped in production
+    // while passing in Node (where the property is absent).
+    const res = immutableResponse("hello");
+    Object.defineProperty(res, "webSocket", { value: null });
+
+    const mutable = toMutableResponse(res);
+    expect(mutable).not.toBe(res);
+    expect(() => mutable.headers.set("X-Test", "1")).not.toThrow();
+  });
+});
+
+describe("isWebSocketUpgrade", () => {
+  it("is false for an ordinary response", () => {
+    expect(isWebSocketUpgrade(new Response("ok", { status: 200 }))).toBe(false);
+  });
+
+  it("is false when the runtime exposes a null webSocket property", () => {
+    const res = new Response("ok", { status: 200 });
+    Object.defineProperty(res, "webSocket", { value: null });
+    expect(isWebSocketUpgrade(res)).toBe(false);
+  });
+
+  it("is true for a live webSocket handle", () => {
+    const res = new Response(null, { status: 200 });
+    Object.defineProperty(res, "webSocket", { value: {} });
+    expect(isWebSocketUpgrade(res)).toBe(true);
   });
 });
 

--- a/packages/authhero/test/routes/management-api/cors.spec.ts
+++ b/packages/authhero/test/routes/management-api/cors.spec.ts
@@ -204,7 +204,7 @@ describe("management-api CORS", () => {
   it("sets CORS headers in a runtime where every Response exposes a null webSocket", async () => {
     const { managementApp, env } = await getTestServer();
 
-    const hadOwn = Object.prototype.hasOwnProperty.call(
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
       Response.prototype,
       "webSocket",
     );
@@ -238,7 +238,16 @@ describe("management-api CORS", () => {
       );
       expect(response.headers.get("Vary")).toContain("Origin");
     } finally {
-      if (!hadOwn) {
+      // Fully restore the original state so later tests don't inherit the
+      // patched getter: re-install the saved descriptor if there was one,
+      // otherwise remove the property we added.
+      if (originalDescriptor) {
+        Object.defineProperty(
+          Response.prototype,
+          "webSocket",
+          originalDescriptor,
+        );
+      } else {
         Reflect.deleteProperty(Response.prototype, "webSocket");
       }
     }

--- a/packages/authhero/test/routes/management-api/cors.spec.ts
+++ b/packages/authhero/test/routes/management-api/cors.spec.ts
@@ -191,6 +191,59 @@ describe("management-api CORS", () => {
     expect(response.headers.get("Vary")).toContain("Origin");
   });
 
+  // Regression (production CORS outage on the control plane): the Cloudflare
+  // Workers runtime defines a `webSocket` property — value `null` — on *every*
+  // Response. The actual-request CORS block used `"webSocket" in ctx.res` to
+  // detect an upgrade, which is therefore always true in production, so the
+  // whole block (Vary + Access-Control-*) was skipped on every real response.
+  // Node's Response has no such property (and a re-wrapped `new Response()`
+  // never gains one), so the bug was invisible to the suite. Faithfully
+  // simulate the runtime by defining a null `webSocket` getter on
+  // `Response.prototype` for the duration of the request — exactly what makes
+  // `"webSocket" in res` true for every response in production.
+  it("sets CORS headers in a runtime where every Response exposes a null webSocket", async () => {
+    const { managementApp, env } = await getTestServer();
+
+    const hadOwn = Object.prototype.hasOwnProperty.call(
+      Response.prototype,
+      "webSocket",
+    );
+    Object.defineProperty(Response.prototype, "webSocket", {
+      configurable: true,
+      get() {
+        return null;
+      },
+    });
+
+    try {
+      const response = await managementApp.request(
+        "/clients",
+        {
+          method: "GET",
+          headers: {
+            Origin: "https://example.com",
+            "tenant-id": "tenantId",
+          },
+        },
+        env,
+      );
+
+      // Without the fix, `isWebSocketUpgrade` would treat this ordinary response
+      // as an upgrade and skip the entire CORS block — no headers at all.
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://example.com",
+      );
+      expect(response.headers.get("Access-Control-Allow-Credentials")).toBe(
+        "true",
+      );
+      expect(response.headers.get("Vary")).toContain("Origin");
+    } finally {
+      if (!hadOwn) {
+        Reflect.deleteProperty(Response.prototype, "webSocket");
+      }
+    }
+  });
+
   // Regression: a `tenantDispatch` middleware that returns a `fetch()`-style
   // response carries an *immutable* header guard. The CORS middleware appends
   // `Vary: Origin` (and, for an allowed origin, `Access-Control-*`) to the

--- a/packages/cloudflare/src/wfp-provisioner/wfp-forward.ts
+++ b/packages/cloudflare/src/wfp-provisioner/wfp-forward.ts
@@ -157,7 +157,13 @@ export function createWfpForwardMiddleware(
     // guarantees their body is `null`, so `new Response(null, res)` is valid —
     // and re-wrapping them is what lets the CORS layer append `Vary` without
     // throwing.
-    if (res.status === 101 || "webSocket" in res) {
+    //
+    // The check is a non-null `webSocket` handle, NOT `"webSocket" in res`: the
+    // Cloudflare Workers runtime defines a (null) `webSocket` property on every
+    // Response, so the `in` operator is always true there and would early-return
+    // for ordinary responses — leaving them immutable for the CORS layer.
+    const webSocket: unknown = Reflect.get(res, "webSocket");
+    if (res.status === 101 || webSocket != null) {
       return res;
     }
 


### PR DESCRIPTION
## Problem

The management API works in Postman but is **blocked by CORS in the browser** — the actual (non-preflight) response carries no `Access-Control-Allow-Origin` and no `Vary: Origin`. The OPTIONS preflight works fine. This took down the control-plane admin UI (`id.sesamy.dev` → `auth2.sesamy.dev`).

## Root cause

Introduced in `780d5249`. The actual-request CORS block gates everything behind a WebSocket-upgrade check using the `in` operator:

```js
const isUpgrade = ctx.res.status === 101 || "webSocket" in ctx.res;
if (!isUpgrade) { /* Vary: Origin + Access-Control-* */ }
```

**In the Cloudflare Workers runtime, every `Response` has a `webSocket` property** (`null` for normal responses). So `"webSocket" in ctx.res` is **always true** in production → `isUpgrade` always true → the whole CORS block is skipped on every real response. The preflight uses a separate early-return branch, so it kept working.

The earlier refactor moved the `if (origin)` CORS block *inside* the websocket guard (it was previously outside), which is what exposed the runtime mismatch.

## Why no test caught it

Node's `Response` has no `webSocket` property, so `"webSocket" in res` is `false` in vitest — every existing test passed while production was broken. The same trap existed in `wfp-forward.ts`.

## Fix

Detect a live upgrade with a **non-null `webSocket` handle** (or status 101) via a new `isWebSocketUpgrade()` helper:
- `packages/authhero/src/helpers/mutable-response.ts`
- `packages/authhero/src/routes/management-api/index.ts`
- `packages/cloudflare/src/wfp-provisioner/wfp-forward.ts`

## Tests

Added regression tests that simulate the runtime by patching `Response.prototype` with a null `webSocket` getter — they **fail on the old check, pass on the fix**:
- Unit: `isWebSocketUpgrade` / `toMutableResponse` with a null `webSocket` property
- Integration: management-API actual GET returns `Access-Control-Allow-Origin` + `Vary` when every `Response` exposes `webSocket`

All related suites pass (authhero CORS/dispatch + cloudflare wfp). Changeset: patch to `authhero` and `@authhero/cloudflare-adapter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CORS headers being skipped on normal responses in Cloudflare Workers.
  * Improved WebSocket detection so only real upgrade responses bypass header rewriting.
  * Ensured response headers remain mutable for standard requests, including `Access-Control-*` and `Vary: Origin`.

* **Tests**
  * Added regression coverage for Worker runtime behavior and CORS header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->