### PR TITLE
fix(drizzle): make multi-statement writes atomic on D1 via db.batch()

### DIFF
--- a/.changeset/bump-template-pins.md
+++ b/.changeset/bump-template-pins.md
@@ -1,0 +1,5 @@
+---
+"create-authhero": patch
+---
+
+Bump stale third-party version pins in generated project templates: `@hono/zod-openapi` `^0.19.0` → `^1.4.0` (aligns with `authhero` core, which requires v1 — previously a major-version mismatch), `@hono/swagger-ui` `^0.5.0` → `^0.6.0`, `hono` `^4.6.0` → `^4.12.0`, `wrangler` `^3.0.0` → `^4.0.0`, `typescript` `^5.5.0` → `^5.9.0`, and `@types/node` `^20.0.0` → `^22.0.0`.

--- a/.changeset/drizzle-atomic-batch.md
+++ b/.changeset/drizzle-atomic-batch.md
@@ -1,0 +1,5 @@
+---
+"@authhero/drizzle": patch
+---
+
+Make the Drizzle adapter's multi-statement writes atomic on D1. `sessions.create`, `refreshTokens.create`, `users.create` (with password) and `users.remove` previously wrapped their dependent writes in manual `BEGIN`/`COMMIT`/`ROLLBACK`, which is not atomic on D1's async driver and could leave partial writes on failure. These now go through a `runAtomic` helper that uses `db.batch()` (atomic on D1) when the driver supports it, and falls back to `BEGIN`/`COMMIT`/`ROLLBACK` on better-sqlite3 (used in tests).

--- a/packages/create-authhero/src/index.ts
+++ b/packages/create-authhero/src/index.ts
@@ -86,21 +86,21 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
           "@authhero/kysely-adapter": v,
           ...(adminUi && { "@authhero/admin": v }),
           "@authhero/widget": v,
-          "@hono/swagger-ui": "^0.5.0",
-          "@hono/zod-openapi": "^0.19.0",
+          "@hono/swagger-ui": "^0.6.0",
+          "@hono/zod-openapi": "^1.4.0",
           "@hono/node-server": "latest",
           authhero: v,
           "better-sqlite3": "latest",
-          hono: "^4.6.0",
+          hono: "^4.12.0",
           kysely: "latest",
           ...(multiTenant && { "@authhero/multi-tenancy": v }),
           ...(conformance && { bcryptjs: "latest" }),
         },
         devDependencies: {
           "@types/better-sqlite3": "^7.6.0",
-          "@types/node": "^20.0.0",
+          "@types/node": "^22.0.0",
           tsx: "^4.0.0",
-          typescript: "^5.5.0",
+          typescript: "^5.9.0",
         },
       };
     },
@@ -146,19 +146,19 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
           "@authhero/drizzle": v,
           ...(adminUi && { "@authhero/admin": v }),
           "@authhero/widget": v,
-          "@hono/swagger-ui": "^0.5.0",
-          "@hono/zod-openapi": "^0.19.0",
+          "@hono/swagger-ui": "^0.6.0",
+          "@hono/zod-openapi": "^1.4.0",
           authhero: v,
           "drizzle-orm": "^0.44.0",
-          hono: "^4.6.0",
+          hono: "^4.12.0",
           ...(multiTenant && { "@authhero/multi-tenancy": v }),
           ...(conformance && { bcryptjs: "latest" }),
         },
         devDependencies: {
           "@cloudflare/workers-types": "^4.0.0",
           "drizzle-kit": "^0.31.0",
-          typescript: "^5.5.0",
-          wrangler: "^3.0.0",
+          typescript: "^5.9.0",
+          wrangler: "^4.0.0",
         },
       };
     },
@@ -191,13 +191,13 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
           "@authhero/drizzle": v,
           "@authhero/proxy": v,
           "drizzle-orm": "^0.44.0",
-          hono: "^4.6.0",
+          hono: "^4.12.0",
         },
         devDependencies: {
           "@cloudflare/workers-types": "^4.0.0",
           "drizzle-kit": "^0.31.0",
-          typescript: "^5.5.0",
-          wrangler: "^3.0.0",
+          typescript: "^5.9.0",
+          wrangler: "^4.0.0",
         },
       };
     },
@@ -234,17 +234,17 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
           "@authhero/drizzle": v,
           "@authhero/multi-tenancy": v,
           "@authhero/widget": v,
-          "@hono/swagger-ui": "^0.5.0",
-          "@hono/zod-openapi": "^0.19.0",
+          "@hono/swagger-ui": "^0.6.0",
+          "@hono/zod-openapi": "^1.4.0",
           authhero: v,
           "drizzle-orm": "^0.44.0",
-          hono: "^4.6.0",
+          hono: "^4.12.0",
         },
         devDependencies: {
           "@cloudflare/workers-types": "^4.0.0",
           "drizzle-kit": "^0.31.0",
-          typescript: "^5.5.0",
-          wrangler: "^3.0.0",
+          typescript: "^5.9.0",
+          wrangler: "^4.0.0",
         },
       };
     },
@@ -284,17 +284,17 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
           "@authhero/drizzle": v,
           "@authhero/multi-tenancy": v,
           "@authhero/widget": v,
-          "@hono/swagger-ui": "^0.5.0",
-          "@hono/zod-openapi": "^0.19.0",
+          "@hono/swagger-ui": "^0.6.0",
+          "@hono/zod-openapi": "^1.4.0",
           authhero: v,
           "drizzle-orm": "^0.44.0",
-          hono: "^4.6.0",
+          hono: "^4.12.0",
         },
         devDependencies: {
           "@cloudflare/workers-types": "^4.0.0",
           "drizzle-kit": "^0.31.0",
-          typescript: "^5.5.0",
-          wrangler: "^3.0.0",
+          typescript: "^5.9.0",
+          wrangler: "^4.0.0",
         },
       };
     },
@@ -317,13 +317,13 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
         },
         dependencies: {
           "@authhero/proxy": v,
-          hono: "^4.6.0",
+          hono: "^4.12.0",
         },
         devDependencies: {
           "@cloudflare/workers-types": "^4.0.0",
-          "@types/node": "^20.0.0",
-          typescript: "^5.5.0",
-          wrangler: "^3.0.0",
+          "@types/node": "^22.0.0",
+          typescript: "^5.9.0",
+          wrangler: "^4.0.0",
         },
       };
     },
@@ -359,19 +359,19 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
           "@authhero/widget": v,
           "@aws-sdk/client-dynamodb": "^3.0.0",
           "@aws-sdk/lib-dynamodb": "^3.0.0",
-          "@hono/swagger-ui": "^0.5.0",
-          "@hono/zod-openapi": "^0.19.0",
+          "@hono/swagger-ui": "^0.6.0",
+          "@hono/zod-openapi": "^1.4.0",
           authhero: v,
-          hono: "^4.6.0",
+          hono: "^4.12.0",
           ...(multiTenant && { "@authhero/multi-tenancy": v }),
           ...(conformance && { bcryptjs: "latest" }),
         },
         devDependencies: {
           "@types/aws-lambda": "^8.10.0",
-          "@types/node": "^20.0.0",
+          "@types/node": "^22.0.0",
           sst: "^3.0.0",
           tsx: "^4.0.0",
-          typescript: "^5.5.0",
+          typescript: "^5.9.0",
         },
       };
     },
@@ -2071,7 +2071,9 @@ ENCRYPTION_KEY=${generateEncryptionKey()}
         );
       } else if (setupType === "cloudflare-control-plane") {
         console.log("  npm install");
-        console.log("  npm run setup  # creates wrangler.local.toml + .dev.vars");
+        console.log(
+          "  npm run setup  # creates wrangler.local.toml + .dev.vars",
+        );
         console.log(
           "  # set CONTROL_PLANE_ENCRYPTION_KEY in .dev.vars (share it with every tenant worker)",
         );
@@ -2084,7 +2086,9 @@ ENCRYPTION_KEY=${generateEncryptionKey()}
         console.log("  POST /internal/tenants/:id/sync-defaults");
       } else if (setupType === "cloudflare-wfp-tenant") {
         console.log("  npm install");
-        console.log("  npm run setup  # creates wrangler.local.toml + .dev.vars");
+        console.log(
+          "  npm run setup  # creates wrangler.local.toml + .dev.vars",
+        );
         console.log(
           "  # set CONTROL_PLANE_ENCRYPTION_KEY in .dev.vars (must match the control plane)",
         );

--- a/packages/drizzle/src/adapters/atomic.ts
+++ b/packages/drizzle/src/adapters/atomic.ts
@@ -59,7 +59,13 @@ export async function runAtomic(
     await db.run(sql`COMMIT`);
     return results;
   } catch (error) {
-    await db.run(sql`ROLLBACK`);
+    // Roll back best-effort: a failing ROLLBACK must not mask the original
+    // write/commit error that actually explains what went wrong.
+    try {
+      await db.run(sql`ROLLBACK`);
+    } catch (rollbackError) {
+      console.error("runAtomic rollback failed", rollbackError);
+    }
     throw error;
   }
 }

--- a/packages/drizzle/src/adapters/atomic.ts
+++ b/packages/drizzle/src/adapters/atomic.ts
@@ -1,0 +1,65 @@
+import { sql } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
+import type { DrizzleDb } from "./types";
+
+export type SqliteBatchItem = BatchItem<"sqlite">;
+
+/** A non-empty list of write statements to apply as a single atomic unit. */
+type AtomicStatements = readonly [SqliteBatchItem, ...SqliteBatchItem[]];
+
+/** Mutable variant call sites build up before passing to {@link runAtomic}. */
+export type AtomicStatementList = [SqliteBatchItem, ...SqliteBatchItem[]];
+
+/**
+ * The async (D1) driver exposes `batch()`, which executes its statements as a
+ * single atomic unit. The sync better-sqlite3 driver used in tests does not, so
+ * `DrizzleDb` (shared across both) can't declare it. We feature-detect instead.
+ */
+interface BatchCapableDb {
+  batch(statements: AtomicStatements): Promise<unknown[]>;
+}
+
+function hasBatch(db: DrizzleDb): db is DrizzleDb & BatchCapableDb {
+  const candidate: unknown = db;
+  return (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    "batch" in candidate &&
+    typeof candidate.batch === "function"
+  );
+}
+
+/**
+ * Apply a set of dependent write statements atomically across drivers.
+ *
+ * On D1 (async) this uses `db.batch()`, which D1 runs as one atomic unit, so a
+ * failure of any statement (or the commit) leaves nothing persisted. On
+ * better-sqlite3 (sync, tests) it falls back to manual `BEGIN/COMMIT/ROLLBACK`,
+ * because that driver has no `batch()` and Drizzle's `db.transaction()` can't
+ * await an async callback there. Interactive `BEGIN/COMMIT` is *not* atomic on
+ * D1, which is why the batch path exists.
+ *
+ * Returns the per-statement results in order (the batch response on D1; each
+ * awaited builder's result on better-sqlite3).
+ */
+export async function runAtomic(
+  db: DrizzleDb,
+  statements: AtomicStatements,
+): Promise<unknown[]> {
+  if (hasBatch(db)) {
+    return db.batch(statements);
+  }
+
+  await db.run(sql`BEGIN`);
+  try {
+    const results: unknown[] = [];
+    for (const statement of statements) {
+      results.push(await statement);
+    }
+    await db.run(sql`COMMIT`);
+    return results;
+  } catch (error) {
+    await db.run(sql`ROLLBACK`);
+    throw error;
+  }
+}

--- a/packages/drizzle/src/adapters/refreshTokens.ts
+++ b/packages/drizzle/src/adapters/refreshTokens.ts
@@ -1,13 +1,4 @@
-import {
-  eq,
-  and,
-  lt,
-  isNull,
-  count as countFn,
-  asc,
-  desc,
-  sql,
-} from "drizzle-orm";
+import { eq, and, lt, isNull, count as countFn, asc, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type {
   RefreshToken,
@@ -19,6 +10,8 @@ import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import { convertDatesToAdapter, isoToDbDate } from "../helpers/dates";
 import { buildLuceneFilter } from "../helpers/filter";
 import type { DrizzleDb } from "./types";
+import { runAtomic } from "./atomic";
+import type { AtomicStatementList } from "./atomic";
 
 function sqlToRefreshToken(row: any): RefreshToken {
   const {
@@ -95,20 +88,20 @@ export function createRefreshTokensAdapter(db: DrizzleDb) {
         last_exchanged_at_ts: isoToDbDate(token.last_exchanged_at),
       };
 
-      // Use manual BEGIN/COMMIT/ROLLBACK because Drizzle's built-in
-      // db.transaction() doesn't support async callbacks with better-sqlite3.
-      // TODO: switch to db.batch() in a follow-up PR — interactive
-      // BEGIN/COMMIT does not provide atomicity on D1 (async driver).
-      await db.run(sql`BEGIN`);
-      try {
-        await db.insert(refreshTokens).values(values);
+      // Insert the refresh token and keep the parent login_session alive
+      // atomically. runAtomic uses db.batch() on D1 and BEGIN/COMMIT on
+      // better-sqlite3.
+      const statements: AtomicStatementList = [
+        db.insert(refreshTokens).values(values),
+      ];
 
-        const newLoginSessionExpiry = maxExpiry(
-          values.expires_at_ts,
-          values.idle_expires_at_ts,
-        );
-        if (newLoginSessionExpiry > 0 && values.login_id) {
-          await db
+      const newLoginSessionExpiry = maxExpiry(
+        values.expires_at_ts,
+        values.idle_expires_at_ts,
+      );
+      if (newLoginSessionExpiry > 0 && values.login_id) {
+        statements.push(
+          db
             .update(loginSessions)
             .set({
               expires_at_ts: newLoginSessionExpiry,
@@ -120,14 +113,11 @@ export function createRefreshTokensAdapter(db: DrizzleDb) {
                 eq(loginSessions.id, values.login_id),
                 lt(loginSessions.expires_at_ts, newLoginSessionExpiry),
               ),
-            );
-        }
-
-        await db.run(sql`COMMIT`);
-      } catch (err) {
-        await db.run(sql`ROLLBACK`);
-        throw err;
+            ),
+        );
       }
+
+      await runAtomic(db, statements);
 
       return sqlToRefreshToken({ ...values, tenant_id });
     },

--- a/packages/drizzle/src/adapters/sessions.ts
+++ b/packages/drizzle/src/adapters/sessions.ts
@@ -1,4 +1,4 @@
-import { eq, and, lt, count as countFn, asc, desc, sql } from "drizzle-orm";
+import { eq, and, lt, count as countFn, asc, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { Session, ListParams } from "@authhero/adapter-interfaces";
 import { sessions, loginSessions } from "../schema/sqlite";
@@ -6,6 +6,8 @@ import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import { convertDatesToAdapter, isoToDbDate } from "../helpers/dates";
 import { buildLuceneFilter } from "../helpers/filter";
 import type { DrizzleDb } from "./types";
+import { runAtomic } from "./atomic";
+import type { AtomicStatementList } from "./atomic";
 
 const REQUIRED_DATE_COLS = ["created_at_ts", "updated_at_ts"] as const;
 const OPTIONAL_DATE_COLS = [
@@ -89,23 +91,22 @@ export function createSessionsAdapter(db: DrizzleDb) {
         revoked_at_ts: isoToDbDate(session.revoked_at),
       };
 
-      // Use manual BEGIN/COMMIT/ROLLBACK because Drizzle's built-in
-      // db.transaction() doesn't support async callbacks with better-sqlite3.
-      // TODO: switch to db.batch() in a follow-up PR — interactive
-      // BEGIN/COMMIT does not provide atomicity on D1 (async driver).
-      await db.run(sql`BEGIN`);
-      try {
-        await db.insert(sessions).values(values);
+      // Insert the session and keep the parent login_session alive atomically.
+      // runAtomic uses db.batch() on D1 and BEGIN/COMMIT on better-sqlite3.
+      const statements: AtomicStatementList = [
+        db.insert(sessions).values(values),
+      ];
 
-        const newLoginSessionExpiry = maxExpiry(
-          values.expires_at_ts,
-          values.idle_expires_at_ts,
-        );
-        if (newLoginSessionExpiry > 0 && values.login_session_id) {
-          // Keep the parent login_session alive at least as long as this
-          // session. The `expires_at_ts < ?` predicate makes this "never
-          // shorten" atomic, mirroring refreshTokens.create.
-          await db
+      const newLoginSessionExpiry = maxExpiry(
+        values.expires_at_ts,
+        values.idle_expires_at_ts,
+      );
+      if (newLoginSessionExpiry > 0 && values.login_session_id) {
+        // Keep the parent login_session alive at least as long as this
+        // session. The `expires_at_ts < ?` predicate makes this "never
+        // shorten" atomic, mirroring refreshTokens.create.
+        statements.push(
+          db
             .update(loginSessions)
             .set({
               expires_at_ts: newLoginSessionExpiry,
@@ -117,14 +118,11 @@ export function createSessionsAdapter(db: DrizzleDb) {
                 eq(loginSessions.id, values.login_session_id),
                 lt(loginSessions.expires_at_ts, newLoginSessionExpiry),
               ),
-            );
-        }
-
-        await db.run(sql`COMMIT`);
-      } catch (err) {
-        await db.run(sql`ROLLBACK`);
-        throw err;
+            ),
+        );
       }
+
+      await runAtomic(db, statements);
 
       return sqlToSession({ ...values, tenant_id });
     },

--- a/packages/drizzle/src/adapters/users.ts
+++ b/packages/drizzle/src/adapters/users.ts
@@ -6,7 +6,6 @@ import {
   desc,
   inArray,
   isNull,
-  sql,
 } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { HTTPException } from "hono/http-exception";
@@ -15,6 +14,7 @@ import { users, passwords, authenticationMethods } from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import { buildLuceneFilter, sanitizeLuceneQuery } from "../helpers/filter";
 import type { DrizzleDb } from "./types";
+import { runAtomic } from "./atomic";
 
 // Fields users.list() accepts in `q`. Excludes `tenant_id` so a clause like
 // `q=tenant_id:other` cannot reach arbitrary columns. Mirrors the kysely
@@ -146,14 +146,12 @@ export function createUsersAdapter(db: DrizzleDb) {
 
     try {
       if (params.password && passwordId) {
-        // Wrap user + password inserts in a transaction so both
-        // succeed or both rollback.
-        // TODO: switch to db.batch() in a follow-up PR — interactive
-        // BEGIN/COMMIT does not provide atomicity on D1 (async driver).
-        await db.run(sql`BEGIN`);
-        try {
-          await db.insert(users).values(sqlData);
-          await db.insert(passwords).values({
+        // Insert the user and its password atomically so both succeed or both
+        // roll back. runAtomic uses db.batch() on D1 and BEGIN/COMMIT on
+        // better-sqlite3.
+        await runAtomic(db, [
+          db.insert(users).values(sqlData),
+          db.insert(passwords).values({
             id: passwordId,
             tenant_id,
             user_id: params.user_id,
@@ -162,12 +160,8 @@ export function createUsersAdapter(db: DrizzleDb) {
             is_current: 1,
             created_at: now,
             updated_at: now,
-          });
-          await db.run(sql`COMMIT`);
-        } catch (e) {
-          await db.run(sql`ROLLBACK`);
-          throw e;
-        }
+          }),
+        ]);
       } else {
         await db.insert(users).values(sqlData);
       }
@@ -300,7 +294,11 @@ export function createUsersAdapter(db: DrizzleDb) {
         // arbitrary columns.
         const sanitized = sanitizeLuceneQuery(q, ALLOWED_Q_FIELDS);
         if (sanitized) {
-          const filter = buildLuceneFilter(users, sanitized, SEARCHABLE_COLUMNS);
+          const filter = buildLuceneFilter(
+            users,
+            sanitized,
+            SEARCHABLE_COLUMNS,
+          );
           if (filter) conditions.push(filter);
         }
       }
@@ -359,62 +357,60 @@ export function createUsersAdapter(db: DrizzleDb) {
     },
 
     async remove(tenant_id: string, user_id: string): Promise<boolean> {
-      // Use manual BEGIN/COMMIT/ROLLBACK because Drizzle's built-in
-      // db.transaction() doesn't support async callbacks with better-sqlite3.
-      // TODO: switch to db.batch() in a follow-up PR — interactive
-      // BEGIN/COMMIT does not provide atomicity on D1 (async driver).
-      await db.run(sql`BEGIN`);
-      try {
-        // Collect all user IDs to delete: primary + linked
-        const linkedUsers = await db
-          .select({ user_id: users.user_id })
-          .from(users)
-          .where(
-            and(eq(users.tenant_id, tenant_id), eq(users.linked_to, user_id)),
-          );
-        const allUserIds = [user_id, ...linkedUsers.map((u) => u.user_id)];
+      // Collect all user IDs to delete: primary + linked. This read can sit
+      // outside the atomic unit — it mutates nothing, and the deletes it feeds
+      // are applied together below.
+      const linkedUsers = await db
+        .select({ user_id: users.user_id })
+        .from(users)
+        .where(
+          and(eq(users.tenant_id, tenant_id), eq(users.linked_to, user_id)),
+        );
+      const allUserIds = [user_id, ...linkedUsers.map((u) => u.user_id)];
 
+      // Apply the cascade deletes atomically so we never leave a user behind
+      // with its auth methods / passwords removed (or vice versa). runAtomic
+      // uses db.batch() on D1 and BEGIN/COMMIT on better-sqlite3.
+      const results = await runAtomic(db, [
         // Delete authentication methods for all users
-        await db
+        db
           .delete(authenticationMethods)
           .where(
             and(
               eq(authenticationMethods.tenant_id, tenant_id),
               inArray(authenticationMethods.user_id, allUserIds),
             ),
-          );
-
+          ),
         // Delete passwords for all users
-        await db
+        db
           .delete(passwords)
           .where(
             and(
               eq(passwords.tenant_id, tenant_id),
               inArray(passwords.user_id, allUserIds),
             ),
-          );
-
+          ),
         // Delete linked users
-        await db
+        db
           .delete(users)
           .where(
             and(eq(users.tenant_id, tenant_id), eq(users.linked_to, user_id)),
-          );
-
+          ),
         // Delete primary user
-        const results = await db
+        db
           .delete(users)
           .where(
             and(eq(users.tenant_id, tenant_id), eq(users.user_id, user_id)),
           )
-          .returning();
+          .returning(),
+      ]);
 
-        await db.run(sql`COMMIT`);
-        return results.length > 0;
-      } catch (e) {
-        await db.run(sql`ROLLBACK`);
-        throw e;
-      }
+      // The primary-user delete is the last statement; its `.returning()` rows
+      // tell us whether a row actually existed.
+      const primaryDeleteResult = results[results.length - 1];
+      return (
+        Array.isArray(primaryDeleteResult) && primaryDeleteResult.length > 0
+      );
     },
 
     async unlink(

--- a/packages/drizzle/src/adapters/users.ts
+++ b/packages/drizzle/src/adapters/users.ts
@@ -366,7 +366,8 @@ export function createUsersAdapter(db: DrizzleDb) {
         .where(
           and(eq(users.tenant_id, tenant_id), eq(users.linked_to, user_id)),
         );
-      const allUserIds = [user_id, ...linkedUsers.map((u) => u.user_id)];
+      const linkedIds = linkedUsers.map((u) => u.user_id);
+      const allUserIds = [user_id, ...linkedIds];
 
       // Apply the cascade deletes atomically so we never leave a user behind
       // with its auth methods / passwords removed (or vice versa). runAtomic
@@ -390,11 +391,16 @@ export function createUsersAdapter(db: DrizzleDb) {
               inArray(passwords.user_id, allUserIds),
             ),
           ),
-        // Delete linked users
+        // Delete linked users — by the same captured IDs the credential
+        // deletes above use, so the cascade never diverges from a live
+        // `linked_to` predicate if linkage changes between read and batch.
         db
           .delete(users)
           .where(
-            and(eq(users.tenant_id, tenant_id), eq(users.linked_to, user_id)),
+            and(
+              eq(users.tenant_id, tenant_id),
+              inArray(users.user_id, linkedIds),
+            ),
           ),
         // Delete primary user
         db

--- a/packages/drizzle/test/adapters/atomic.test.ts
+++ b/packages/drizzle/test/adapters/atomic.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { runAtomic } from "../../src/adapters/atomic";
+import type { DrizzleDb } from "../../src/adapters/types";
+
+// A statement stand-in: a thenable that records when it is awaited, so we can
+// assert ordering relative to BEGIN/COMMIT on the fallback path. Casting to the
+// BatchItem tuple keeps runAtomic's public signature intact for the test.
+function fakeStatement(
+  label: string,
+  log: string[],
+  options: { fail?: boolean } = {},
+) {
+  return {
+    then(resolve: (value: string) => void, reject: (reason: unknown) => void) {
+      log.push(label);
+      if (options.fail) {
+        reject(new Error(`boom:${label}`));
+      } else {
+        resolve(label);
+      }
+    },
+  } as unknown as Parameters<typeof runAtomic>[1][number];
+}
+
+describe("runAtomic", () => {
+  it("uses db.batch() when the driver exposes it (D1 path), without BEGIN/COMMIT", async () => {
+    const run = vi.fn();
+    const batch = vi.fn(async (stmts: unknown[]) =>
+      stmts.map((_, i) => `result-${i}`),
+    );
+    const db = { run, batch } as unknown as DrizzleDb;
+
+    const log: string[] = [];
+    const statements = [
+      fakeStatement("a", log),
+      fakeStatement("b", log),
+    ] as unknown as Parameters<typeof runAtomic>[1];
+
+    const results = await runAtomic(db, statements);
+
+    expect(batch).toHaveBeenCalledTimes(1);
+    expect(batch).toHaveBeenCalledWith(statements);
+    // The batch driver runs the statements itself — runAtomic must not await
+    // them (they'd execute twice) nor emit any interactive transaction.
+    expect(log).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+    expect(results).toEqual(["result-0", "result-1"]);
+  });
+
+  it("falls back to BEGIN/COMMIT and awaits each statement when batch is absent", async () => {
+    const log: string[] = [];
+    const run = vi.fn(async () => {
+      log.push("run");
+    });
+    const db = { run } as unknown as DrizzleDb;
+
+    const statements = [
+      fakeStatement("a", log),
+      fakeStatement("b", log),
+    ] as unknown as Parameters<typeof runAtomic>[1];
+
+    const results = await runAtomic(db, statements);
+
+    // BEGIN first, both statements, COMMIT last.
+    expect(log).toEqual(["run", "a", "b", "run"]);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(results).toEqual(["a", "b"]);
+  });
+
+  it("rolls back and rethrows when a statement fails on the fallback path", async () => {
+    const log: string[] = [];
+    const run = vi.fn(async () => {
+      log.push("run");
+    });
+    const db = { run } as unknown as DrizzleDb;
+
+    const statements = [
+      fakeStatement("a", log),
+      fakeStatement("b", log, { fail: true }),
+    ] as unknown as Parameters<typeof runAtomic>[1];
+
+    await expect(runAtomic(db, statements)).rejects.toThrow("boom:b");
+
+    // BEGIN, a, b (fails) → ROLLBACK. No COMMIT.
+    expect(log).toEqual(["run", "a", "b", "run"]);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #981.

Several Drizzle adapter writes wrapped a primary write plus a dependent write in manual `BEGIN`/`COMMIT`/`ROLLBACK` via `db.run(sql\`...\`)`. This works under the synchronous better-sqlite3 driver used in tests, but **interactive `BEGIN/COMMIT` is not atomic on D1** (async driver) — if a later statement or the commit fails, a row can already be persisted, leaving a partial write.

### Approach

The issue proposed "switch to `db.batch()`", but `batch()` exists only on Drizzle's D1 driver — **not** on `BaseSQLiteDatabase` (the shared `DrizzleDb` type) nor on better-sqlite3 (the test driver). A blanket swap would fail to typecheck and break the tests.

So this adds a small cross-driver helper, `runAtomic(db, statements)`:
- **D1 (prod):** feature-detects `db.batch()` and runs the statements as one atomic unit.
- **better-sqlite3 (tests):** falls back to `BEGIN`/`COMMIT`/`ROLLBACK`.

### Converted sites (the 4 from the issue)
- `sessions.create` — login_session expiry bump
- `refreshTokens.create` — login_session expiry bump
- `users.create` (with password) — user + password insert
- `users.remove` — cascade deletes (the id-gathering `SELECT` stays outside the batch, since it only feeds the deletes)

### Left as manual transactions (out of scope, can't be a fixed batch)
- `index.ts` generic `transaction()` wrapper — takes an arbitrary async callback
- `actionVersions.create` — read-compute-write (SELECT latest `number` → compute → insert)

## Testing
- `pnpm --filter @authhero/drizzle build` — clean (helper is `as`-free)
- 45/45 drizzle tests pass: existing `sessionLoginSessionBump` tests now exercise the fallback path, plus a new `atomic.test.ts` covering the batch path, the BEGIN/COMMIT fallback, and rollback-on-failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of multi-step account, session, refresh token, and user operations by ensuring writes execute atomically and roll back cleanly on failure (especially on D1).
  * Reduced the risk of partial updates during user deletion and related record cleanup.
* **New Features**
  * Added safer atomic write handling across supported database environments to improve consistency.
* **Tests**
  * Added coverage for atomic execution behavior in both batch-capable and fallback scenarios.
* **Chores**
  * Updated scaffolded template dependency versions and adjusted console “next steps” output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->