### PR TITLE
Clear failed-login lockout on successful password reset

### DIFF
--- a/.changeset/analytics-more-log-type-metrics.md
+++ b/.changeset/analytics-more-log-type-metrics.md
@@ -1,0 +1,17 @@
+---
+"@authhero/adapter-interfaces": patch
+"@authhero/kysely-adapter": patch
+"@authhero/cloudflare-adapter": patch
+"@authhero/drizzle": patch
+"authhero": patch
+---
+
+Add five new analytics metrics to the `/analytics/{resource}` API and the admin
+Analytics dropdown: Logouts (`slo`, `flo`), Password Changes (`scp`, `fcp`,
+`scpr`, `fcpr`), MFA (`gd_auth_succeed`, `gd_auth_failed`, `gd_auth_rejected`),
+Email Verifications (`sv`, `fv`, `svr`, `fvr`) and Codes Sent (`cls`, `cs`).
+Each is computed from the existing `logs` table — like the existing login/signup
+metrics — and supports the same `time`, `connection`, `client_id`, `user_type`
+and `event` group-by dimensions, so success/failure can be split via
+`group_by=event`. Wired through the kysely, drizzle and Cloudflare Analytics
+Engine adapters.

--- a/.changeset/clear-failed-logins-on-reset.md
+++ b/.changeset/clear-failed-logins-on-reset.md
@@ -1,0 +1,11 @@
+---
+"authhero": patch
+---
+
+Clear the failed-login lockout counter when a user successfully resets their
+password. Previously, a user who locked themselves out (3+ failed password
+attempts within 5 minutes) and then reset their password would still be blocked
+with `TOO_MANY_FAILED_LOGINS` when logging in with the new password, because the
+`app_metadata.failed_logins` strikes were never cleared by the reset flow. Both
+universal-login reset paths now wipe the counter on success, mirroring the
+existing clear-on-successful-login behavior.

--- a/.changeset/fix-darkmode-default-theme.md
+++ b/.changeset/fix-darkmode-default-theme.md
@@ -1,0 +1,13 @@
+---
+"authhero": patch
+---
+
+Fix dark mode rendering black text on the universal login widget. Since the
+default theme is now applied unconditionally, its light-mode colors
+(`header`, `input_filled_text`, `secondary_button_label` = `#000000`) were set
+as widget CSS vars that the dark-mode palette did not override — the header used
+the newer `--ah-color-text-header` var name while the dark override only set the
+legacy `--ah-color-header`, and input/secondary-button text had no dark override
+at all. The dark palette now overrides `--ah-color-text-header`,
+`--ah-color-input-text`, and `--ah-btn-secondary-text`, restoring readable
+light text on dark surfaces.

--- a/apps/admin/src/resources/analytics/AnalyticsPage.tsx
+++ b/apps/admin/src/resources/analytics/AnalyticsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Bar,
   BarChart,
@@ -18,6 +18,8 @@ import {
 } from "./useAnalyticsQuery";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -72,6 +74,36 @@ const RESOURCES: Array<{
     metric: "sessions",
     dims: ["time", "client_id"],
   },
+  {
+    value: "logouts",
+    label: "Logouts",
+    metric: "logouts",
+    dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
+  {
+    value: "password-changes",
+    label: "Password Changes",
+    metric: "password_changes",
+    dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
+  {
+    value: "mfa",
+    label: "MFA",
+    metric: "mfa",
+    dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
+  {
+    value: "email-verifications",
+    label: "Email Verifications",
+    metric: "email_verifications",
+    dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
+  {
+    value: "codes-sent",
+    label: "Codes Sent",
+    metric: "codes_sent",
+    dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
 ];
 
 const INTERVAL_OPTIONS: Array<{ value: IntervalSetting; label: string }> = [
@@ -81,6 +113,34 @@ const INTERVAL_OPTIONS: Array<{ value: IntervalSetting; label: string }> = [
   { value: "week", label: "Week" },
   { value: "month", label: "Month" },
 ];
+
+// Backend filters are validated against this enum; "all" means no filter.
+const USER_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "all", label: "All user types" },
+  { value: "password", label: "Password" },
+  { value: "social", label: "Social" },
+  { value: "passwordless", label: "Passwordless" },
+  { value: "enterprise", label: "Enterprise" },
+];
+
+// Debounce free-text filters so we issue one query after typing settles rather
+// than one per keystroke.
+function useDebounced<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+// Split a comma-separated filter input into the repeatable array the API takes.
+function toFilterList(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
 
 const CHART_COLORS = [
   "#2563eb",
@@ -133,6 +193,24 @@ export function AnalyticsPage() {
   const [range, setRange] = useState<TimeRange>(() => presetRange(7));
   const [interval, setInterval] = useState<IntervalSetting>("auto");
   const [groupBy, setGroupBy] = useState<AnalyticsGroupBy[]>(["time"]);
+  const [clientId, setClientId] = useState("");
+  const [connection, setConnection] = useState("");
+  const [userId, setUserId] = useState("");
+  const [userType, setUserType] = useState("all");
+
+  const debouncedClientId = useDebounced(clientId, 400);
+  const debouncedConnection = useDebounced(connection, 400);
+  const debouncedUserId = useDebounced(userId, 400);
+
+  const hasFilters =
+    clientId !== "" || connection !== "" || userId !== "" || userType !== "all";
+
+  const clearFilters = () => {
+    setClientId("");
+    setConnection("");
+    setUserId("");
+    setUserType("all");
+  };
 
   const resourceMeta = RESOURCES.find((r) => r.value === resource)!;
 
@@ -151,6 +229,10 @@ export function AnalyticsPage() {
     to,
     interval: effectiveInterval,
     groupBy,
+    clientId: toFilterList(debouncedClientId),
+    connection: toFilterList(debouncedConnection),
+    userId: toFilterList(debouncedUserId),
+    userType: userType === "all" ? [] : [userType],
   });
 
   const dimColumns = useMemo(() => groupBy.map((g) => String(g)), [groupBy]);
@@ -165,79 +247,134 @@ export function AnalyticsPage() {
       <div>
         <h2 className="text-2xl font-semibold">Analytics</h2>
         <p className="text-sm text-muted-foreground">
-          Time-series metrics for users, logins, signups, sessions, and tokens.
+          Time-series metrics for users, logins, signups, sessions, tokens, and
+          more — filter by client, connection, user, or user type.
         </p>
       </div>
 
       <Card>
-        <CardContent className="flex flex-wrap items-center gap-3 pt-4">
-          <Select
-            value={resource}
-            onValueChange={(v) => {
-              setResource(v as AnalyticsResource);
-              setGroupBy(["time"]);
-            }}
-          >
-            <SelectTrigger className="w-44">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {RESOURCES.map((r) => (
-                <SelectItem key={r.value} value={r.value}>
-                  {r.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        <CardContent className="flex flex-col gap-3 pt-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <Select
+              value={resource}
+              onValueChange={(v) => {
+                setResource(v as AnalyticsResource);
+                setGroupBy(["time"]);
+              }}
+            >
+              <SelectTrigger className="w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RESOURCES.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
 
-          <TimeRangePicker value={range} onChange={setRange} />
+            <TimeRangePicker value={range} onChange={setRange} />
 
-          <Select
-            value={interval}
-            onValueChange={(v) => setInterval(v as IntervalSetting)}
-          >
-            <SelectTrigger className="w-36">
-              <SelectValue>
-                {interval === "auto"
-                  ? `Auto (${effectiveInterval})`
-                  : INTERVAL_OPTIONS.find((o) => o.value === interval)?.label}
-              </SelectValue>
-            </SelectTrigger>
-            <SelectContent>
-              {INTERVAL_OPTIONS.map((o) => (
-                <SelectItem
-                  key={o.value}
-                  value={o.value}
-                  disabled={o.value === "hour" && hourDisabled}
-                >
-                  {o.value === "auto"
+            <Select
+              value={interval}
+              onValueChange={(v) => setInterval(v as IntervalSetting)}
+            >
+              <SelectTrigger className="w-36">
+                <SelectValue>
+                  {interval === "auto"
                     ? `Auto (${effectiveInterval})`
-                    : o.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          <div className="flex items-center gap-1">
-            {resourceMeta.dims
-              .filter((d) => d !== "time")
-              .map((d) => {
-                const active = groupBy.includes(d);
-                return (
-                  <Button
-                    key={d}
-                    size="sm"
-                    variant={active ? "default" : "outline"}
-                    onClick={() =>
-                      setGroupBy((prev) =>
-                        active ? prev.filter((p) => p !== d) : [...prev, d],
-                      )
-                    }
+                    : INTERVAL_OPTIONS.find((o) => o.value === interval)?.label}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {INTERVAL_OPTIONS.map((o) => (
+                  <SelectItem
+                    key={o.value}
+                    value={o.value}
+                    disabled={o.value === "hour" && hourDisabled}
                   >
-                    {d}
-                  </Button>
-                );
-              })}
+                    {o.value === "auto"
+                      ? `Auto (${effectiveInterval})`
+                      : o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <div className="flex items-center gap-1">
+              {resourceMeta.dims
+                .filter((d) => d !== "time")
+                .map((d) => {
+                  const active = groupBy.includes(d);
+                  return (
+                    <Button
+                      key={d}
+                      size="sm"
+                      variant={active ? "default" : "outline"}
+                      onClick={() =>
+                        setGroupBy((prev) =>
+                          active ? prev.filter((p) => p !== d) : [...prev, d],
+                        )
+                      }
+                    >
+                      {d}
+                    </Button>
+                  );
+                })}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs text-muted-foreground">Client ID</Label>
+              <Input
+                className="w-44"
+                placeholder="Filter by client ID"
+                value={clientId}
+                onChange={(e) => setClientId(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs text-muted-foreground">
+                Connection
+              </Label>
+              <Input
+                className="w-44"
+                placeholder="Filter by connection"
+                value={connection}
+                onChange={(e) => setConnection(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs text-muted-foreground">User ID</Label>
+              <Input
+                className="w-44"
+                placeholder="Filter by user ID"
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs text-muted-foreground">User type</Label>
+              <Select value={userType} onValueChange={setUserType}>
+                <SelectTrigger className="w-44">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {USER_TYPE_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {hasFilters && (
+              <Button variant="ghost" size="sm" onClick={clearFilters}>
+                Clear filters
+              </Button>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/apps/admin/src/resources/analytics/useAnalyticsQuery.ts
+++ b/apps/admin/src/resources/analytics/useAnalyticsQuery.ts
@@ -16,7 +16,12 @@ export type AnalyticsResource =
   | "logins"
   | "signups"
   | "refresh-tokens"
-  | "sessions";
+  | "sessions"
+  | "logouts"
+  | "password-changes"
+  | "mfa"
+  | "email-verifications"
+  | "codes-sent";
 
 export type AnalyticsInterval = "hour" | "day" | "week" | "month";
 

--- a/apps/admin/src/resources/tenant-data/TenantDataPage.tsx
+++ b/apps/admin/src/resources/tenant-data/TenantDataPage.tsx
@@ -30,6 +30,8 @@ export function TenantDataPage() {
   const [importing, setImporting] = useState(false);
   const [result, setResult] = useState<ImportResult | null>(null);
 
+  const busy = exporting || importing;
+
   const handleExport = async () => {
     setExporting(true);
     try {
@@ -84,7 +86,8 @@ export function TenantDataPage() {
       <div>
         <h1 className="text-2xl font-semibold">Import / Export</h1>
         <p className="text-muted-foreground text-sm">
-          Move a tenant's configuration and users between deployments. Sessions,
+          Move a tenant&apos;s configuration and users between deployments.
+          Sessions,
           refresh tokens and logs are not included; signing keys are regenerated
           on import.
         </p>
@@ -94,7 +97,7 @@ export function TenantDataPage() {
         <CardHeader>
           <CardTitle>Export</CardTitle>
           <CardDescription>
-            Download this tenant's durable data as a JSON-lines file.
+            Download this tenant&apos;s durable data as a JSON-lines file.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -103,12 +106,13 @@ export function TenantDataPage() {
               id="export-hashes"
               checked={exportHashes}
               onCheckedChange={(v) => setExportHashes(v === true)}
+              disabled={busy}
             />
             <Label htmlFor="export-hashes">
               Include password hashes (requires elevated permission)
             </Label>
           </div>
-          <Button onClick={handleExport} disabled={exporting}>
+          <Button onClick={handleExport} disabled={busy}>
             {exporting ? <Loader2 className="animate-spin" /> : <Download />}
             Export tenant data
           </Button>
@@ -129,6 +133,7 @@ export function TenantDataPage() {
               id="import-hashes"
               checked={importHashes}
               onCheckedChange={(v) => setImportHashes(v === true)}
+              disabled={busy}
             />
             <Label htmlFor="import-hashes">
               Import password hashes (requires elevated permission)
@@ -147,7 +152,7 @@ export function TenantDataPage() {
           <Button
             variant="outline"
             onClick={() => fileInputRef.current?.click()}
-            disabled={importing}
+            disabled={busy}
           >
             {importing ? <Loader2 className="animate-spin" /> : <Upload />}
             Choose file and import

--- a/packages/adapter-interfaces/src/types/Analytics.ts
+++ b/packages/adapter-interfaces/src/types/Analytics.ts
@@ -6,6 +6,11 @@ export const analyticsResourceSchema = z.enum([
   "signups",
   "refresh-tokens",
   "sessions",
+  "logouts",
+  "password-changes",
+  "mfa",
+  "email-verifications",
+  "codes-sent",
 ]);
 export type AnalyticsResource = z.infer<typeof analyticsResourceSchema>;
 

--- a/packages/authhero/src/authentication-flows/password.ts
+++ b/packages/authhero/src/authentication-flows/password.ts
@@ -75,20 +75,27 @@ export async function clearFailedLogins(
   tenantId: string,
   user: User,
 ): Promise<void> {
-  const primaryUser = user.linked_to
-    ? await data.users.get(tenantId, user.linked_to)
-    : user;
+  // Best-effort cleanup: a failure here must never turn a valid login or a
+  // successful password reset into an error, especially since the password/code
+  // state has already been mutated by the time this runs.
+  try {
+    const primaryUser = user.linked_to
+      ? await data.users.get(tenantId, user.linked_to)
+      : user;
 
-  if (!primaryUser) {
-    return;
-  }
+    if (!primaryUser) {
+      return;
+    }
 
-  const appMetadata = primaryUser.app_metadata || {};
-  if (appMetadata.failed_logins && appMetadata.failed_logins.length > 0) {
-    appMetadata.failed_logins = [];
-    await data.users.update(tenantId, primaryUser.user_id, {
-      app_metadata: appMetadata,
-    });
+    const appMetadata = primaryUser.app_metadata || {};
+    if (appMetadata.failed_logins && appMetadata.failed_logins.length > 0) {
+      appMetadata.failed_logins = [];
+      await data.users.update(tenantId, primaryUser.user_id, {
+        app_metadata: appMetadata,
+      });
+    }
+  } catch (error) {
+    console.error("Failed to clear failed_logins:", error);
   }
 }
 

--- a/packages/authhero/src/authentication-flows/password.ts
+++ b/packages/authhero/src/authentication-flows/password.ts
@@ -9,6 +9,7 @@ import {
   RateLimitDecision,
   Strategy,
   StrategyType,
+  User,
 } from "@authhero/adapter-interfaces";
 import { EnrichedClient } from "../helpers/client";
 import { Bindings, GrantFlowUserResult, Variables } from "../types";
@@ -59,6 +60,36 @@ async function recordFailedLogin(
   await data.users.update(tenantId, primaryUser.user_id, {
     app_metadata: appMetadata,
   });
+}
+
+/**
+ * Clear the failed-login counter for a user. Failed logins are always
+ * recorded on the primary account (see {@link recordFailedLogin}), so this
+ * resolves the linked primary before clearing. Called on a successful
+ * password login and after a successful password reset — both are strong
+ * evidence the legitimate account owner is back in control, so a stale
+ * lockout shouldn't block them.
+ */
+export async function clearFailedLogins(
+  data: Bindings["data"],
+  tenantId: string,
+  user: User,
+): Promise<void> {
+  const primaryUser = user.linked_to
+    ? await data.users.get(tenantId, user.linked_to)
+    : user;
+
+  if (!primaryUser) {
+    return;
+  }
+
+  const appMetadata = primaryUser.app_metadata || {};
+  if (appMetadata.failed_logins && appMetadata.failed_logins.length > 0) {
+    appMetadata.failed_logins = [];
+    await data.users.update(tenantId, primaryUser.user_id, {
+      app_metadata: appMetadata,
+    });
+  }
 }
 
 function isRateLimitDecision(value: unknown): value is RateLimitDecision {
@@ -313,13 +344,7 @@ export async function passwordGrant(
   }
 
   // Clear failed login attempts on successful password validation
-  const appMetadata = primaryUser.app_metadata || {};
-  if (appMetadata.failed_logins && appMetadata.failed_logins.length > 0) {
-    appMetadata.failed_logins = [];
-    data.users.update(client.tenant.id, primaryUser.user_id, {
-      app_metadata: appMetadata,
-    });
-  }
+  await clearFailedLogins(data, client.tenant.id, primaryUser);
 
   return {
     client,

--- a/packages/authhero/src/helpers/tenant-export-import/export.ts
+++ b/packages/authhero/src/helpers/tenant-export-import/export.ts
@@ -29,7 +29,10 @@ async function* paginate(
       include_totals: false,
     });
     const rows = asRecord(result)?.[pluralKey];
-    if (!Array.isArray(rows) || rows.length === 0) break;
+    if (!Array.isArray(rows)) {
+      throw new Error(`Invalid list response for "${pluralKey}" during export`);
+    }
+    if (rows.length === 0) break;
     for (const row of rows) {
       yield row;
     }

--- a/packages/authhero/src/helpers/tenant-export-import/import.ts
+++ b/packages/authhero/src/helpers/tenant-export-import/import.ts
@@ -311,8 +311,7 @@ export async function importTenant(
           );
           break;
         case "universal_login_templates": {
-          const body = getString(row, "body");
-          if (body === undefined) continue;
+          const body = required(getString(row, "body"), "body");
           await data.universalLoginTemplates.set(
             tenant_id,
             { body },

--- a/packages/authhero/src/routes/management-api/analytics.ts
+++ b/packages/authhero/src/routes/management-api/analytics.ts
@@ -19,6 +19,17 @@ const VALID_GROUP_BY: Record<AnalyticsResource, AnalyticsGroupBy[]> = {
   signups: ["time", "connection", "client_id", "user_type", "event"],
   "refresh-tokens": ["time", "client_id", "event"],
   sessions: ["time", "client_id"],
+  logouts: ["time", "connection", "client_id", "user_type", "event"],
+  "password-changes": ["time", "connection", "client_id", "user_type", "event"],
+  mfa: ["time", "connection", "client_id", "user_type", "event"],
+  "email-verifications": [
+    "time",
+    "connection",
+    "client_id",
+    "user_type",
+    "event",
+  ],
+  "codes-sent": ["time", "connection", "client_id", "user_type", "event"],
 };
 
 const VALID_INTERVALS: AnalyticsInterval[] = ["hour", "day", "week", "month"];
@@ -35,6 +46,11 @@ const METRIC_BY_RESOURCE: Record<AnalyticsResource, string> = {
   signups: "signups",
   "refresh-tokens": "refresh_tokens",
   sessions: "sessions",
+  logouts: "logouts",
+  "password-changes": "password_changes",
+  mfa: "mfa",
+  "email-verifications": "email_verifications",
+  "codes-sent": "codes_sent",
 };
 
 const MAX_LIMIT = 10000;
@@ -418,6 +434,11 @@ export function createAnalyticsRoutes(options: AnalyticsRoutesOptions = {}) {
     "signups",
     "refresh-tokens",
     "sessions",
+    "logouts",
+    "password-changes",
+    "mfa",
+    "email-verifications",
+    "codes-sent",
   ];
 
   for (const resource of resources) {

--- a/packages/authhero/src/routes/universal-login/reset-password.tsx
+++ b/packages/authhero/src/routes/universal-login/reset-password.tsx
@@ -8,6 +8,7 @@ import { initJSXRoute } from "./common";
 import ResetPasswordPage from "../../components/ResetPasswordPage";
 import MessagePage from "../../components/MessagePage";
 import { getUsernamePasswordUser } from "../../utils/username-password-provider";
+import { clearFailedLogins } from "../../authentication-flows/password";
 import { logMessage } from "../../helpers/logging";
 import { defineRoute } from "../../utils/define-route";
 import {
@@ -237,6 +238,11 @@ const postRoot = defineRoute({
           email_verified: true,
         });
       }
+
+      // Clear any failed-login lockout — a successful reset proves the account
+      // owner is back in control, so they shouldn't be blocked by stale strikes
+      // when they log in with the new password.
+      await clearFailedLogins(env.data, client.tenant.id, user);
 
       // Log the successful password change
       await logMessage(ctx, client.tenant.id, {

--- a/packages/authhero/src/routes/universal-login/screens/reset-password.ts
+++ b/packages/authhero/src/routes/universal-login/screens/reset-password.ts
@@ -9,6 +9,7 @@ import { LogTypes, Strategy } from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult, ScreenDefinition } from "./types";
 import bcryptjs from "bcryptjs";
 import { getUsernamePasswordUser } from "../../../utils/username-password-provider";
+import { clearFailedLogins } from "../../../authentication-flows/password";
 import { logMessage } from "../../../helpers/logging";
 import {
   getPasswordPolicy,
@@ -122,6 +123,11 @@ export async function executePasswordReset(params: {
         email_verified: true,
       });
     }
+
+    // Clear any failed-login lockout — a successful reset proves the account
+    // owner is back in control, so they shouldn't be blocked by stale strikes
+    // when they log in with the new password.
+    await clearFailedLogins(env.data, client.tenant.id, user);
 
     // Log the successful password change
     await logMessage(ctx, client.tenant.id, {

--- a/packages/authhero/src/routes/universal-login/u2-widget-page.tsx
+++ b/packages/authhero/src/routes/universal-login/u2-widget-page.tsx
@@ -147,12 +147,21 @@ const DARK_MODE_CSS_VARS: Record<string, string> = {
   "--ah-color-text": "#f9fafb",
   "--ah-color-text-muted": "#9ca3af",
   "--ah-color-text-label": "#d1d5db",
+  // Header is read by the widget as `--ah-color-text-header` first, falling
+  // back to the legacy `--ah-color-header`. Set both so an applied theme's
+  // `header` color (e.g. DEFAULT_THEME's #000000) can't leave the title black.
+  "--ah-color-text-header": "#f9fafb",
   "--ah-color-header": "#f9fafb",
   "--ah-color-bg": "#1f2937",
   "--ah-color-bg-hover": "#374151",
   "--ah-color-bg-muted": "#374151",
   "--ah-color-bg-disabled": "#4b5563",
   "--ah-color-input-bg": "#374151",
+  // Typed input text and secondary-button label are also driven by the theme
+  // (input_filled_text / secondary_button_label) and default to #000000, which
+  // is unreadable on the dark input/widget surfaces above.
+  "--ah-color-input-text": "#f9fafb",
+  "--ah-btn-secondary-text": "#f9fafb",
   "--ah-color-border": "#4b5563",
   "--ah-color-border-hover": "#6b7280",
   "--ah-color-border-muted": "#374151",

--- a/packages/authhero/test/authentication-flows/auth0-migration.spec.ts
+++ b/packages/authhero/test/authentication-flows/auth0-migration.spec.ts
@@ -603,6 +603,52 @@ describe("auth0 migration: password fallback", () => {
     ).toBe(true);
   });
 
+  // Faithful repro of the reported prod case: a user imported with
+  // provider "auth0", connection "Username-Password-Authentication" (the
+  // DEFAULT name, matching the import_mode connection), and NO password row.
+  // Connection name matches user.connection here, so this isolates whether
+  // provider "auth0" alone breaks the Stage 2 fallback.
+  it("repro: imported auth0-provider passwordless user hits upstream fallback (default connection name)", async () => {
+    const { oauthApp, env } = await makeMigrationServer();
+
+    await env.data.users.create(TENANT_ID, {
+      user_id: "auth0|Eo4KYjjnM-Sze2wQVyXye",
+      email: "marcuslowe2000@gmail.com",
+      email_verified: false,
+      provider: "auth0",
+      connection: "Username-Password-Authentication",
+      is_social: false,
+    });
+
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(200, {
+        access_token: "upstream-at",
+        token_type: "Bearer",
+        expires_in: 86400,
+      }),
+    );
+
+    const oauthClient = testClient(oauthApp, env);
+    const response = await oauthClient.co.authenticate.$post({
+      json: {
+        client_id: CLIENT_ID,
+        credential_type: "http://auth0.com/oauth/grant-type/password-realm",
+        realm: REALM,
+        username: "marcuslowe2000@gmail.com",
+        password: "UpstreamPassword!",
+      },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+
+    const passwordRow = await env.data.passwords.get(
+      TENANT_ID,
+      "auth0|Eo4KYjjnM-Sze2wQVyXye",
+    );
+    expect(passwordRow).toBeDefined();
+  });
+
   // Local password row already exists and matches: the local check succeeds
   // and we must NOT call upstream — the bcrypt path is the source of truth
   // once migration has happened.

--- a/packages/authhero/test/management-api/analytics.test.ts
+++ b/packages/authhero/test/management-api/analytics.test.ts
@@ -95,6 +95,39 @@ describe("GET /analytics/active-users", () => {
   });
 });
 
+describe("GET /analytics/logouts", () => {
+  it("counts logout events and splits success/failure by event", async () => {
+    const { managementApp, env } = await getTestServer();
+    const client = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const recent = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+    await seedLog(env, LogTypes.SUCCESS_LOGOUT, recent, { user_id: "u1" });
+    await seedLog(env, LogTypes.SUCCESS_LOGOUT, recent, { user_id: "u2" });
+    await seedLog(env, LogTypes.FAILED_LOGOUT, recent, { user_id: "u3" });
+
+    const res = await client.analytics.logouts.$get(
+      {
+        query: { group_by: "event" },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      meta: Array<{ name: string }>;
+      data: Array<{ event: string; logouts: number }>;
+    };
+    expect(body.meta.map((m) => m.name)).toContain("logouts");
+    const byEvent = Object.fromEntries(
+      body.data.map((r) => [r.event, r.logouts]),
+    );
+    expect(byEvent[LogTypes.SUCCESS_LOGOUT]).toBe(2);
+    expect(byEvent[LogTypes.FAILED_LOGOUT]).toBe(1);
+  });
+});
+
 describe("GET /analytics/logins", () => {
   it("counts all login events (success + failure types)", async () => {
     const { managementApp, env } = await getTestServer();

--- a/packages/authhero/test/routes/universal-login/passwords.spec.ts
+++ b/packages/authhero/test/routes/universal-login/passwords.spec.ts
@@ -552,6 +552,130 @@ describe("passwords", () => {
     expect(oldPasswordLoginResponse.status).toBe(400);
   });
 
+  it("should clear failed-login lockout after a password reset", async () => {
+    const { universalApp, oauthApp, env, getSentEmails } = await getTestServer({
+      mockEmail: true,
+      testTenantLanguage: "en",
+    });
+    const oauthClient = testClient(oauthApp, env);
+    const universalClient = testClient(universalApp, env);
+
+    const newPassword = "NewP@ssw0rd!";
+    const userId = `${USERNAME_PASSWORD_PROVIDER}|lockedOut123`;
+
+    // Create a password user
+    await env.data.users.create("tenantId", {
+      email: "locked-out@example.com",
+      email_verified: true,
+      name: "Locked Out User",
+      nickname: "lockedout",
+      connection: Strategy.USERNAME_PASSWORD,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      is_social: false,
+      user_id: userId,
+    });
+
+    await env.data.passwords.create("tenantId", {
+      user_id: userId,
+      password: await bcryptjs.hash("OldP@ssw0rd!", 10),
+      algorithm: "bcrypt",
+    });
+
+    // Simulate a lockout: 3 recent failed-login timestamps (>= the 3 limit
+    // enforced in passwordGrant within the 5-minute window).
+    const now = Date.now();
+    await env.data.users.update("tenantId", userId, {
+      app_metadata: { failed_logins: [now, now, now] },
+    });
+
+    // Start the password reset flow
+    const authorizeResponse = await oauthClient.authorize.$get({
+      query: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+        state: "state",
+        nonce: "nonce",
+        scope: "openid email profile",
+        response_type: AuthorizationResponseType.CODE,
+      },
+    });
+
+    const location = authorizeResponse.headers.get("location");
+    const universalUrl = new URL(`https://example.com${location}`);
+    const state = universalUrl.searchParams.get("state");
+    if (!state) throw new Error("No state found");
+
+    await universalClient.login.identifier.$post({
+      query: { state },
+      form: { username: "locked-out@example.com" },
+    });
+
+    await universalClient["forgot-password"].$post({
+      query: { state },
+    });
+
+    const sentEmails = getSentEmails();
+    const passwordResetEmail = sentEmails[sentEmails.length - 1];
+
+    if (passwordResetEmail.data.passwordResetUrl === undefined) {
+      throw new Error("No reset URL found in email");
+    }
+
+    const passwordResetUrl = new URL(passwordResetEmail.data.passwordResetUrl);
+    const passwordResetCode = passwordResetUrl.searchParams.get("code");
+    const resetState = passwordResetUrl.searchParams.get("state");
+
+    if (!passwordResetCode || !resetState) {
+      throw new Error("No code or state found in email");
+    }
+
+    const resetPasswordResponse = await universalClient["reset-password"].$post(
+      {
+        query: { state: resetState, code: passwordResetCode },
+        form: {
+          password: newPassword,
+          "re-enter-password": newPassword,
+        },
+      },
+    );
+
+    expect(resetPasswordResponse.status).toBe(200);
+
+    // The failed-login counter should be cleared by the reset.
+    const userAfterReset = await env.data.users.get("tenantId", userId);
+    expect(userAfterReset?.app_metadata?.failed_logins).toEqual([]);
+
+    // And the user should be able to log in immediately with the new password
+    // rather than being blocked by the stale lockout.
+    const newAuthorize = await oauthClient.authorize.$get({
+      query: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+        state: "state2",
+        nonce: "nonce2",
+        scope: "openid email profile",
+        response_type: AuthorizationResponseType.CODE,
+      },
+    });
+    const newLocation = newAuthorize.headers.get("location");
+    const newUrl = new URL(`https://example.com${newLocation}`);
+    const newState = newUrl.searchParams.get("state");
+    if (!newState) throw new Error("No state found");
+
+    await universalClient.login.identifier.$post({
+      query: { state: newState },
+      form: { username: "locked-out@example.com" },
+    });
+
+    const newPasswordLoginResponse = await universalClient[
+      "enter-password"
+    ].$post({
+      query: { state: newState },
+      form: { password: newPassword },
+    });
+    expect(newPasswordLoginResponse.status).toBe(302);
+  });
+
   it("should reject weak passwords during reset", async () => {
     const { universalApp, oauthApp, env, getSentEmails } = await getTestServer({
       mockEmail: true,

--- a/packages/authhero/test/universal-login/dark-mode-theme-defaults.spec.ts
+++ b/packages/authhero/test/universal-login/dark-mode-theme-defaults.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression test for the dark-mode "black text on black background" bug.
+ *
+ * DEFAULT_THEME is applied unconditionally when a tenant has no stored theme.
+ * Its Auth0-style colors are light-mode only (`header`, `input_filled_text`,
+ * `secondary_button_label` default to #000000), and the widget sets them as
+ * inline CSS vars. The dark-mode palette must override every one of those vars
+ * — by the exact name the widget reads — or the corresponding text renders
+ * black on the dark widget surface.
+ *
+ * The original break: the dark palette set the legacy `--ah-color-header` while
+ * the widget reads `--ah-color-text-header` first, and had no override at all
+ * for `--ah-color-input-text` / `--ah-btn-secondary-text`.
+ */
+import { describe, it, expect } from "vitest";
+import { buildHeadEssentials } from "../../src/routes/universal-login/u2-widget-page";
+import { DEFAULT_THEME } from "../../src/constants/defaultTheme";
+
+// Vars the widget reads for foreground text, paired with the DEFAULT_THEME
+// color that would otherwise paint them black. If DEFAULT_THEME grows a new
+// black foreground color, add its var here so dark mode is forced to cover it.
+const BLACK_DEFAULT = "#000000";
+const TEXT_VARS: { cssVar: string; themeColor: string | undefined }[] = [
+  { cssVar: "--ah-color-text", themeColor: DEFAULT_THEME.colors?.body_text },
+  { cssVar: "--ah-color-text-header", themeColor: DEFAULT_THEME.colors?.header },
+  {
+    cssVar: "--ah-color-input-text",
+    themeColor: DEFAULT_THEME.colors?.input_filled_text,
+  },
+  {
+    cssVar: "--ah-btn-secondary-text",
+    themeColor: DEFAULT_THEME.colors?.secondary_button_label,
+  },
+];
+
+describe("dark mode vs DEFAULT_THEME color defaults", () => {
+  const head = buildHeadEssentials({
+    clientName: "Test",
+    theme: DEFAULT_THEME,
+  });
+
+  it("guards the assumption that these defaults are actually black", () => {
+    // If these stop being black the test's premise is moot — make that loud
+    // rather than letting the override assertions pass vacuously.
+    for (const { cssVar, themeColor } of TEXT_VARS) {
+      expect(
+        themeColor?.toUpperCase(),
+        `${cssVar} maps to a DEFAULT_THEME color`,
+      ).toBe(BLACK_DEFAULT);
+    }
+  });
+
+  it.each(TEXT_VARS)(
+    "overrides $cssVar to a non-black value in dark mode",
+    ({ cssVar }) => {
+      // Every foreground var the theme paints black must be reassigned by the
+      // dark palette (emitted both as `!important` CSS rules and in the dark
+      // runtime vars JSON inside the head).
+      const match = head.match(
+        new RegExp(`${cssVar}\\s*:\\s*(#[0-9a-fA-F]{3,8})`),
+      );
+      expect(match, `${cssVar} has a dark-mode override`).not.toBeNull();
+      expect(
+        match![1].toUpperCase(),
+        `${cssVar} dark override must not be black`,
+      ).not.toBe(BLACK_DEFAULT);
+    },
+  );
+});

--- a/packages/cloudflare/src/analytics-engine-logs/analytics.ts
+++ b/packages/cloudflare/src/analytics-engine-logs/analytics.ts
@@ -17,6 +17,11 @@ const RESOURCE_EVENTS: Record<AnalyticsResource, readonly string[]> = {
   "refresh-tokens": ["seacft", "fertft"],
   // No dedicated session-created event yet; track logouts as the lifecycle signal.
   sessions: ["slo"],
+  logouts: ["slo", "flo"],
+  "password-changes": ["scp", "fcp", "scpr", "fcpr"],
+  mfa: ["gd_auth_succeed", "gd_auth_failed", "gd_auth_rejected"],
+  "email-verifications": ["sv", "fv", "svr", "fvr"],
+  "codes-sent": ["cls", "cs"],
 };
 
 // Field → blob mapping (kept in sync with logs.ts)
@@ -52,6 +57,19 @@ const METRIC_BY_RESOURCE: Record<
     type: "UInt64",
   },
   sessions: { expr: "count()", alias: "sessions", type: "UInt64" },
+  logouts: { expr: "count()", alias: "logouts", type: "UInt64" },
+  "password-changes": {
+    expr: "count()",
+    alias: "password_changes",
+    type: "UInt64",
+  },
+  mfa: { expr: "count()", alias: "mfa", type: "UInt64" },
+  "email-verifications": {
+    expr: "count()",
+    alias: "email_verifications",
+    type: "UInt64",
+  },
+  "codes-sent": { expr: "count()", alias: "codes_sent", type: "UInt64" },
 };
 
 function timeBucketExpr(interval: string, tz: string): string {

--- a/packages/drizzle/src/adapters/analytics.ts
+++ b/packages/drizzle/src/adapters/analytics.ts
@@ -15,6 +15,11 @@ const RESOURCE_EVENTS: Record<AnalyticsResource, readonly string[]> = {
   signups: ["ss", "fs"],
   "refresh-tokens": ["seacft", "fertft"],
   sessions: ["slo"],
+  logouts: ["slo", "flo"],
+  "password-changes": ["scp", "fcp", "scpr", "fcpr"],
+  mfa: ["gd_auth_succeed", "gd_auth_failed", "gd_auth_rejected"],
+  "email-verifications": ["sv", "fv", "svr", "fvr"],
+  "codes-sent": ["cls", "cs"],
 };
 
 const METRIC_BY_RESOURCE: Record<
@@ -26,6 +31,19 @@ const METRIC_BY_RESOURCE: Record<
   signups: { alias: "signups", type: "UInt64", agg: "count" },
   "refresh-tokens": { alias: "refresh_tokens", type: "UInt64", agg: "count" },
   sessions: { alias: "sessions", type: "UInt64", agg: "count" },
+  logouts: { alias: "logouts", type: "UInt64", agg: "count" },
+  "password-changes": {
+    alias: "password_changes",
+    type: "UInt64",
+    agg: "count",
+  },
+  mfa: { alias: "mfa", type: "UInt64", agg: "count" },
+  "email-verifications": {
+    alias: "email_verifications",
+    type: "UInt64",
+    agg: "count",
+  },
+  "codes-sent": { alias: "codes_sent", type: "UInt64", agg: "count" },
 };
 
 function timeBucket(interval: string) {

--- a/packages/kysely/src/analytics/index.ts
+++ b/packages/kysely/src/analytics/index.ts
@@ -15,6 +15,11 @@ const RESOURCE_EVENTS: Record<AnalyticsResource, readonly string[]> = {
   signups: ["ss", "fs"],
   "refresh-tokens": ["seacft", "fertft"],
   sessions: ["slo"],
+  logouts: ["slo", "flo"],
+  "password-changes": ["scp", "fcp", "scpr", "fcpr"],
+  mfa: ["gd_auth_succeed", "gd_auth_failed", "gd_auth_rejected"],
+  "email-verifications": ["sv", "fv", "svr", "fvr"],
+  "codes-sent": ["cls", "cs"],
 };
 
 const METRIC_BY_RESOURCE: Record<
@@ -30,6 +35,19 @@ const METRIC_BY_RESOURCE: Record<
     agg: "count",
   },
   sessions: { alias: "sessions", type: "UInt64", agg: "count" },
+  logouts: { alias: "logouts", type: "UInt64", agg: "count" },
+  "password-changes": {
+    alias: "password_changes",
+    type: "UInt64",
+    agg: "count",
+  },
+  mfa: { alias: "mfa", type: "UInt64", agg: "count" },
+  "email-verifications": {
+    alias: "email_verifications",
+    type: "UInt64",
+    agg: "count",
+  },
+  "codes-sent": { alias: "codes_sent", type: "UInt64", agg: "count" },
 };
 
 type SqlDialect = "mysql" | "sqlite";


### PR DESCRIPTION
## Problem

A user who locks themselves out (3+ failed password attempts within 5 minutes) and then resets their password is **still blocked** with `TOO_MANY_FAILED_LOGINS` when logging in with the new password.

The lockout counter lives in `app_metadata.failed_logins`, and it was only ever cleared on a *successful password login* ([password.ts](packages/authhero/src/authentication-flows/password.ts)). The lockout check in `passwordGrant` runs **before** password validation, so the successful-login clear is never reached — the user stays locked until the 5-minute window naturally expires, even right after a valid reset.

## Fix

- Add an exported `clearFailedLogins(data, tenantId, user)` helper that resolves the linked **primary** account (where strikes are recorded) and clears the counter.
- Call it from **both** universal-login reset paths:
  - the legacy `reset-password.tsx` route, and
  - the newer screens-based `executePasswordReset` (used by the u2/screen-api and `reset-password-code` paths).
- `passwordGrant`'s existing success-path clear now reuses the same helper (no behavior change there).

A successful reset is strong evidence the account owner is back in control, so a stale lockout shouldn't block them — this mirrors Auth0's behavior.

## Test

Added an integration test that seeds a 3-strike lockout, runs the full reset flow, and asserts the counter is cleared **and** the user can log in immediately with the new password.

## Notes

- The **Management API** `PATCH /users/{id}` password update still does not clear the counter — left out of scope here since this targets the user-facing reset flow. Easy follow-up if desired.
- There are two overlapping universal-login reset handlers (`reset-password.tsx` and `executePasswordReset`); both are fixed, but the duplication is worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new analytics views for logouts, password changes, MFA outcomes, email verifications, and codes sent.
  * Analytics pages now support filtering by client, connection, user, and user type.

* **Bug Fixes**
  * Password resets now clear failed-login lockouts, helping users log in immediately after resetting.
  * Improved dark mode styling for the login widget and default theme fallback text.
  * Tenant export/import and tenant data actions now handle in-progress states more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->