### PR TITLE
Fix log filtering on values with Lucene special characters

### DIFF
--- a/.changeset/ae-logs-filter-fixes.md
+++ b/.changeset/ae-logs-filter-fixes.md
@@ -1,0 +1,8 @@
+---
+"@authhero/cloudflare-adapter": patch
+---
+
+Improve Analytics Engine log filtering to match the kysely adapter:
+
+- Unescape Lucene escape sequences in `field:value` clauses. Clients escape filter values per Lucene rules (a dash becomes `\-`), but the backslash leaked into the generated SQL comparison, so filtering by any value containing a `-` returned no rows.
+- Support bare free-text search terms in `q`. A term without a `field:` prefix now matches `user_id` (exact) and `ip`/`description` (substring), instead of being ignored (which returned every log). Searching `description` lets a user's email match failed-login events recorded before any user record existed.

--- a/.changeset/unescape-lucene-filter-values.md
+++ b/.changeset/unescape-lucene-filter-values.md
@@ -1,0 +1,9 @@
+---
+"@authhero/kysely-adapter": patch
+---
+
+Fix log filtering crashes and missing matches on `q` queries:
+
+- Values containing Lucene-reserved characters (e.g. a `-`) returned no rows. Clients escape filter values per Lucene rules (a dash becomes `\-`) and quote them, but `luceneFilter` stripped the quotes without reversing the escaping, so exact-match comparisons ran against a backslash-prefixed literal. Lucene escape sequences are now unescaped before the value is used.
+- A free-text term containing a `:` (e.g. a timestamp like `2024-01-01T10:00:00`) or a clause referencing a non-column (e.g. `success`) was misparsed as a column reference and crashed the request with a SQL error. `logs.list` now sanitizes `q` against an allowlist of real columns (as `users`/`organizations` already do) before filtering.
+- Free-text log search now also matches `description` (substring), so searching for a user's email finds failed-login events that happened before any user record existed.

--- a/apps/admin/src/components/admin/list.tsx
+++ b/apps/admin/src/components/admin/list.tsx
@@ -193,6 +193,7 @@ const ListToolbar = ({
 
   return (
     <div className="flex items-center gap-2 my-2">
+      {/* Query controls (search + filters) on the left */}
       {!disableSearch && (
         <div className="flex w-full max-w-sm">
           <FilterLiveForm formComponent={SearchFormComponent}>
@@ -204,10 +205,13 @@ const ListToolbar = ({
           </FilterLiveForm>
         </div>
       )}
-      <div className="flex items-center gap-2 ml-auto">
-        {hasToggleableFilters ? <FilterButton /> : <AddFilterPlaceholder />}
-        {!disableColumns ? <ColumnsButton /> : null}
-      </div>
+      {hasToggleableFilters ? <FilterButton /> : <AddFilterPlaceholder />}
+      {/* Display controls (columns) on the right */}
+      {!disableColumns ? (
+        <div className="ml-auto">
+          <ColumnsButton />
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/apps/admin/src/resources/analytics/AnalyticsPage.tsx
+++ b/apps/admin/src/resources/analytics/AnalyticsPage.tsx
@@ -327,8 +327,14 @@ export function AnalyticsPage() {
 
           <div className="flex flex-wrap items-end gap-3">
             <div className="flex flex-col gap-1">
-              <Label className="text-xs text-muted-foreground">Client ID</Label>
+              <Label
+                htmlFor="analytics-filter-client-id"
+                className="text-xs text-muted-foreground"
+              >
+                Client ID
+              </Label>
               <Input
+                id="analytics-filter-client-id"
                 className="w-44"
                 placeholder="Filter by client ID"
                 value={clientId}
@@ -336,10 +342,14 @@ export function AnalyticsPage() {
               />
             </div>
             <div className="flex flex-col gap-1">
-              <Label className="text-xs text-muted-foreground">
+              <Label
+                htmlFor="analytics-filter-connection"
+                className="text-xs text-muted-foreground"
+              >
                 Connection
               </Label>
               <Input
+                id="analytics-filter-connection"
                 className="w-44"
                 placeholder="Filter by connection"
                 value={connection}
@@ -347,8 +357,14 @@ export function AnalyticsPage() {
               />
             </div>
             <div className="flex flex-col gap-1">
-              <Label className="text-xs text-muted-foreground">User ID</Label>
+              <Label
+                htmlFor="analytics-filter-user-id"
+                className="text-xs text-muted-foreground"
+              >
+                User ID
+              </Label>
               <Input
+                id="analytics-filter-user-id"
                 className="w-44"
                 placeholder="Filter by user ID"
                 value={userId}
@@ -356,9 +372,14 @@ export function AnalyticsPage() {
               />
             </div>
             <div className="flex flex-col gap-1">
-              <Label className="text-xs text-muted-foreground">User type</Label>
+              <Label
+                htmlFor="analytics-filter-user-type"
+                className="text-xs text-muted-foreground"
+              >
+                User type
+              </Label>
               <Select value={userType} onValueChange={setUserType}>
-                <SelectTrigger className="w-44">
+                <SelectTrigger id="analytics-filter-user-type" className="w-44">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/apps/admin/src/resources/users/tabs/logs-tab.tsx
+++ b/apps/admin/src/resources/users/tabs/logs-tab.tsx
@@ -19,9 +19,13 @@ export function LogsTab() {
       }
     >
       <div className="flex flex-row items-end gap-2 mb-2 flex-wrap">
+        {/* Query controls (filters) on the left */}
         <FilterForm filters={logFiltersWithSearch} />
         <FilterButton filters={logFiltersWithSearch} resource="logs" />
-        <ColumnsButton />
+        {/* Display controls (columns) on the right */}
+        <div className="ml-auto">
+          <ColumnsButton />
+        </div>
       </div>
       <LogsTable bulkActionButtons={false} />
     </ReferenceManyField>

--- a/packages/authhero/test/routes/universal-login/passwords.spec.ts
+++ b/packages/authhero/test/routes/universal-login/passwords.spec.ts
@@ -676,6 +676,127 @@ describe("passwords", () => {
     expect(newPasswordLoginResponse.status).toBe(302);
   });
 
+  it("should clear failed-login lockout after a screens-path password reset", async () => {
+    const { u2App, oauthApp, env, getSentEmails } = await getTestServer({
+      mockEmail: true,
+      testTenantLanguage: "en",
+    });
+    const oauthClient = testClient(oauthApp, env);
+
+    const newPassword = "NewP@ssw0rd!";
+    const userId = `${USERNAME_PASSWORD_PROVIDER}|screensLockedOut123`;
+
+    // Create a password user
+    await env.data.users.create("tenantId", {
+      email: "screens-locked-out@example.com",
+      email_verified: true,
+      name: "Screens Locked Out User",
+      nickname: "screenslockedout",
+      connection: Strategy.USERNAME_PASSWORD,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      is_social: false,
+      user_id: userId,
+    });
+
+    await env.data.passwords.create("tenantId", {
+      user_id: userId,
+      password: await bcryptjs.hash("OldP@ssw0rd!", 10),
+      algorithm: "bcrypt",
+    });
+
+    // Simulate a lockout: 3 recent failed-login timestamps (>= the 3 limit
+    // enforced in passwordGrant within the 5-minute window).
+    const now = Date.now();
+    await env.data.users.update("tenantId", userId, {
+      app_metadata: { failed_logins: [now, now, now] },
+    });
+
+    // Start the password reset flow
+    const authorizeResponse = await oauthClient.authorize.$get({
+      query: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+        state: "state",
+        nonce: "nonce",
+        scope: "openid email profile",
+        response_type: AuthorizationResponseType.CODE,
+      },
+    });
+
+    const location = authorizeResponse.headers.get("location");
+    const universalUrl = new URL(`https://example.com${location}`);
+    const state = universalUrl.searchParams.get("state");
+    if (!state) throw new Error("No state found");
+
+    // Request a reset code through the screens (u2) forgot-password route. The
+    // screens flow defaults to the "code" verification method, so the user gets
+    // a 6-digit code by email rather than a link.
+    await u2Screen(u2App, env, "reset-password/request").$post({
+      query: { state },
+      form: { email: "screens-locked-out@example.com" },
+    });
+
+    const sentEmails = getSentEmails();
+    const passwordResetEmail = sentEmails[sentEmails.length - 1];
+    const resetCode = passwordResetEmail.data.code;
+    if (!resetCode) {
+      throw new Error("No reset code found in email");
+    }
+
+    // Complete the reset through the screens reset-password-code route, which
+    // calls resetPassword's clearFailedLogins path via executePasswordReset.
+    const resetPasswordResponse = await u2Screen(
+      u2App,
+      env,
+      "reset-password/code",
+    ).$post({
+      query: { state },
+      form: {
+        code: resetCode,
+        password: newPassword,
+        confirm_password: newPassword,
+      },
+    });
+
+    expect(resetPasswordResponse.status).toBe(302);
+
+    // The failed-login counter should be cleared by the reset.
+    const userAfterReset = await env.data.users.get("tenantId", userId);
+    expect(userAfterReset?.app_metadata?.failed_logins).toEqual([]);
+
+    // And the user should be able to log in immediately with the new password
+    // rather than being blocked by the stale lockout.
+    const newAuthorize = await oauthClient.authorize.$get({
+      query: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+        state: "state2",
+        nonce: "nonce2",
+        scope: "openid email profile",
+        response_type: AuthorizationResponseType.CODE,
+      },
+    });
+    const newLocation = newAuthorize.headers.get("location");
+    const newUrl = new URL(`https://example.com${newLocation}`);
+    const newState = newUrl.searchParams.get("state");
+    if (!newState) throw new Error("No state found");
+
+    await u2Screen(u2App, env, "login/identifier").$post({
+      query: { state: newState },
+      form: { username: "screens-locked-out@example.com" },
+    });
+
+    const newPasswordLoginResponse = await u2Screen(
+      u2App,
+      env,
+      "enter-password",
+    ).$post({
+      query: { state: newState },
+      form: { password: newPassword },
+    });
+    expect(newPasswordLoginResponse.status).toBe(302);
+  });
+
   it("should reject weak passwords during reset", async () => {
     const { universalApp, oauthApp, env, getSentEmails } = await getTestServer({
       mockEmail: true,

--- a/packages/cloudflare/src/analytics-engine-logs/list.ts
+++ b/packages/cloudflare/src/analytics-engine-logs/list.ts
@@ -14,25 +14,81 @@ interface ListLogsResponse {
   length: number;
 }
 
+interface ParsedQuery {
+  /** `field:value` clauses, grouped by field (repeated keys collected). */
+  fields: Record<string, string[]>;
+  /** Bare free-text terms (no `field:` prefix). */
+  terms: string[];
+}
+
+/**
+ * Reverse Lucene escaping on a value operand: a backslash followed by a Lucene
+ * reserved character is a literal of that character (e.g. `auth0|abc\-123` ->
+ * `auth0|abc-123`). Clients (such as the admin UI) escape filter values per
+ * Lucene rules before interpolating them, so without this the backslash leaks
+ * into the SQL comparison and exact matches never hit.
+ */
+function unescapeLuceneValue(value: string): string {
+  return value.replace(/\\([\\"+\-!(){}[\]^~*?:/&|])/g, "$1");
+}
+
+/** Split a query into tokens, treating double-quoted spans as atomic. */
+function tokenizeQuery(q: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < q.length; i++) {
+    const char = q[i];
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      current += char;
+    } else if (char === " " && !inQuotes) {
+      if (current.trim()) tokens.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) tokens.push(current.trim());
+  return tokens;
+}
+
+/** Strip one layer of surrounding double quotes, then unescape Lucene escapes. */
+function cleanValue(raw: string): string {
+  let value = raw;
+  if (value.startsWith('"') && value.endsWith('"') && value.length > 1) {
+    value = value.slice(1, -1);
+  }
+  return unescapeLuceneValue(value);
+}
+
 /**
  * Parse lucene-style filter query (simple implementation).
  * Supports key:value, key:"quoted value", and repeated keys joined with OR
- * (e.g. `user_id:"a" OR user_id:"b"`) which are collected into a list.
+ * (e.g. `user_id:"a" OR user_id:"b"`) which are collected into a list. Tokens
+ * without a `field:` prefix are treated as bare free-text search terms.
  */
-function parseLuceneFilter(q: string): Record<string, string[]> {
-  const filters: Record<string, string[]> = {};
+function parseLuceneFilter(q: string): ParsedQuery {
+  const fields: Record<string, string[]> = {};
+  const terms: string[] = [];
 
-  const regex = /(\w+):(?:"([^"]*)"|(\S+))/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(q)) !== null) {
-    const key = match[1];
-    const value = match[2] !== undefined ? match[2] : match[3];
-    if (!key || value === undefined) continue;
-    if (!filters[key]) filters[key] = [];
-    filters[key].push(value);
+  for (const token of tokenizeQuery(q)) {
+    // `OR`/`AND` are conjunction markers, not values.
+    if (token === "OR" || token === "AND") continue;
+
+    const match = token.match(/^(\w+):([\s\S]*)$/);
+    if (match) {
+      const key = match[1]!;
+      const value = cleanValue(match[2]!);
+      if (!fields[key]) fields[key] = [];
+      fields[key].push(value);
+    } else {
+      const term = cleanValue(token);
+      if (term) terms.push(term);
+    }
   }
 
-  return filters;
+  return { fields, terms };
 }
 
 /**
@@ -106,6 +162,22 @@ function buildWhereConditions(filters: Record<string, string[]>): string[] {
 }
 
 /**
+ * Build WHERE conditions for bare free-text terms. Each term matches user_id
+ * (blob7, exact), or ip (blob5) / description (blob4) as a substring. Searching
+ * description matters because a user's email can appear there before login
+ * completes — i.e. before any user_id exists to match against.
+ */
+function buildTermConditions(terms: string[]): string[] {
+  return terms
+    .filter((term) => term !== "")
+    .map((term) => {
+      const exact = escapeSQLString(term);
+      const like = escapeSQLString(`%${term}%`);
+      return `(blob7 = ${exact} OR blob5 LIKE ${like} OR blob4 LIKE ${like})`;
+    });
+}
+
+/**
  * Map sort field to Analytics Engine field name
  */
 function mapSortFieldToColumn(field: string): string {
@@ -145,8 +217,9 @@ export function listLogs(config: AnalyticsEngineLogsAdapterConfig) {
     const whereConditions: string[] = [`index1 = ${escapeSQLString(tenantId)}`];
 
     if (q) {
-      const filters = parseLuceneFilter(q);
-      whereConditions.push(...buildWhereConditions(filters));
+      const { fields, terms } = parseLuceneFilter(q);
+      whereConditions.push(...buildWhereConditions(fields));
+      whereConditions.push(...buildTermConditions(terms));
     }
 
     // Date range filter (Unix seconds → epoch ms stored in double2)

--- a/packages/cloudflare/test/analytics-engine-logs.spec.ts
+++ b/packages/cloudflare/test/analytics-engine-logs.spec.ts
@@ -442,6 +442,95 @@ describe("Analytics Engine Logs Adapter", () => {
       expect(sql).toContain("double2 <= 1705399200000");
     });
 
+    it("should unescape Lucene-escaped characters in field values (e.g. a dash)", async () => {
+      const capturedQueries: string[] = [];
+      server.use(
+        http.post(
+          "https://api.cloudflare.com/client/v4/accounts/test-account/analytics_engine/sql",
+          async ({ request }) => {
+            capturedQueries.push(await request.text());
+            return HttpResponse.json({ success: true, data: mockLogs });
+          },
+        ),
+      );
+
+      const adapter = createAnalyticsEngineLogsAdapter({
+        accountId: "test-account",
+        apiToken: "test-token",
+        dataset: "authhero_logs",
+      });
+
+      // Exactly what apps/admin escapeLuceneValue produces: dash -> \-
+      await adapter.list("tenant-1", {
+        page: 0,
+        per_page: 50,
+        q: `user_id:"auth0|abc\\-123"`,
+      });
+
+      const sql = capturedQueries[0]!;
+      expect(sql).toContain("blob7 = 'auth0|abc-123'");
+      expect(sql).not.toContain("abc\\-123");
+    });
+
+    it("should match a bare free-text term against user_id, ip, and description", async () => {
+      const capturedQueries: string[] = [];
+      server.use(
+        http.post(
+          "https://api.cloudflare.com/client/v4/accounts/test-account/analytics_engine/sql",
+          async ({ request }) => {
+            capturedQueries.push(await request.text());
+            return HttpResponse.json({ success: true, data: mockLogs });
+          },
+        ),
+      );
+
+      const adapter = createAnalyticsEngineLogsAdapter({
+        accountId: "test-account",
+        apiToken: "test-token",
+        dataset: "authhero_logs",
+      });
+
+      await adapter.list("tenant-1", {
+        page: 0,
+        per_page: 50,
+        q: "foo@example.com",
+      });
+
+      const sql = capturedQueries[0]!;
+      expect(sql).toContain(
+        "(blob7 = 'foo@example.com' OR blob5 LIKE '%foo@example.com%' OR blob4 LIKE '%foo@example.com%')",
+      );
+    });
+
+    it("should combine a bare term with field filters", async () => {
+      const capturedQueries: string[] = [];
+      server.use(
+        http.post(
+          "https://api.cloudflare.com/client/v4/accounts/test-account/analytics_engine/sql",
+          async ({ request }) => {
+            capturedQueries.push(await request.text());
+            return HttpResponse.json({ success: true, data: mockLogs });
+          },
+        ),
+      );
+
+      const adapter = createAnalyticsEngineLogsAdapter({
+        accountId: "test-account",
+        apiToken: "test-token",
+        dataset: "authhero_logs",
+      });
+
+      await adapter.list("tenant-1", {
+        page: 0,
+        per_page: 50,
+        q: "type:f foo@example.com",
+      });
+
+      const sql = capturedQueries[0]!;
+      expect(sql).toContain("blob3 = 'f'");
+      expect(sql).toContain("blob4 LIKE '%foo@example.com%'");
+    });
+
     it("should translate success:false to a failure type prefix match", async () => {
       const capturedQueries: string[] = [];
       server.use(

--- a/packages/kysely/src/helpers/filter.ts
+++ b/packages/kysely/src/helpers/filter.ts
@@ -1,6 +1,15 @@
 import { Kysely, SelectQueryBuilder } from "kysely";
 import { Database } from "../db";
 
+// Reverse Lucene escaping on a value operand: a backslash followed by a Lucene
+// reserved character is a literal of that character (e.g. `auth0|abc\-123` ->
+// `auth0|abc-123`). Clients (such as the admin UI) escape filter values per
+// Lucene rules before interpolating them into the query string, so without this
+// the backslash leaks into the SQL comparison and exact matches never hit.
+function unescapeLuceneValue(value: string): string {
+  return value.replace(/\\([\\"+\-!(){}[\]^~*?:/&|])/g, "$1");
+}
+
 // Strip field-scoped clauses (`field:value`, `-field:value`, `_exists_:field`,
 // `field=value`) whose field is not in `allowedFields`. Bare-string tokens are
 // preserved (luceneFilter routes them through its own searchable-columns
@@ -81,7 +90,9 @@ export function luceneFilter<TB extends keyof Database>(
             const [, field, value] = match;
             if (!field || !value) return null;
             const fieldName = field.trim();
-            const cleanValue = value.replace(/^"(.*)"$/, "$1").trim();
+            const cleanValue = unescapeLuceneValue(
+              value.replace(/^"(.*)"$/, "$1").trim(),
+            );
             if (likeSet.has(fieldName)) {
               return eb(fieldName as any, "like", `%${cleanValue}%`);
             }
@@ -174,9 +185,13 @@ export function luceneFilter<TB extends keyof Database>(
         if (value.startsWith('"') && value.endsWith('"') && value.length > 1) {
           value = value.slice(1, -1);
         }
+
+        // Reverse client-side Lucene escaping (e.g. `\-` -> `-`) so the operand
+        // matches the stored value rather than a backslash-prefixed literal.
+        value = unescapeLuceneValue(value);
       } else {
         key = null;
-        value = filter;
+        value = unescapeLuceneValue(filter);
         isExistsQuery = false;
       }
 

--- a/packages/kysely/src/logs/list.ts
+++ b/packages/kysely/src/logs/list.ts
@@ -1,9 +1,44 @@
 import { Kysely } from "kysely";
 import { ListParams } from "@authhero/adapter-interfaces";
-import { luceneFilter } from "../helpers/filter";
+import { luceneFilter, sanitizeLuceneQuery } from "../helpers/filter";
 import { getLogResponse } from "./logs";
 import { Database } from "../db";
 import getCountAsInt from "../utils/getCountAsInt";
+
+// Fields logs.list() accepts as `field:value` clauses in `q`. Every entry maps
+// to a real column on the logs table. Excludes `tenant_id` so a clause like
+// `q=tenant_id:other` cannot cross tenant boundaries, and excludes derived
+// concepts such as `success` (no column) and JSON blobs. A clause referencing
+// anything outside this list is stripped by sanitizeLuceneQuery before it
+// reaches luceneFilter — otherwise it would emit SQL against a non-existent
+// column and crash the request (e.g. a free-text term like `2024-01-01T10:00`
+// gets misread as `2024-01-01T10:00` -> column reference).
+const ALLOWED_Q_FIELDS = [
+  "user_id",
+  "ip",
+  "type",
+  "date",
+  "client_id",
+  "client_name",
+  "user_agent",
+  "description",
+  "user_name",
+  "connection",
+  "connection_id",
+  "audience",
+  "scope",
+  "strategy",
+  "strategy_type",
+  "hostname",
+  "log_id",
+  "session_connection",
+  "country_code",
+  "city_name",
+  "latitude",
+  "longitude",
+  "time_zone",
+  "continent_code",
+];
 
 export function listLogs(db: Kysely<Database>) {
   return async (tenant_id: string, params: ListParams = {}) => {
@@ -20,7 +55,24 @@ export function listLogs(db: Kysely<Database>) {
     let query = db.selectFrom("logs").where("logs.tenant_id", "=", tenant_id);
 
     if (q) {
-      query = luceneFilter(db, query, q, ["user_id", "ip"], ["description"]);
+      // Sanitize first so only whitelisted fields reach luceneFilter;
+      // otherwise a free-text term containing a `:` (e.g. a timestamp) is
+      // misparsed as `field:value` and emits SQL against a bogus column,
+      // crashing the request.
+      const sanitized = sanitizeLuceneQuery(q, ALLOWED_Q_FIELDS);
+      if (sanitized) {
+        // Bare free-text terms match user_id (exact), and ip + description
+        // (substring). Searching description matters because a user's email
+        // can appear there before login completes — i.e. before any user_id
+        // exists to match against.
+        query = luceneFilter(
+          db,
+          query,
+          sanitized,
+          ["user_id", "ip", "description"],
+          ["description"],
+        );
+      }
     }
 
     if (typeof from_date === "number" && Number.isFinite(from_date)) {

--- a/packages/kysely/test/helpers/filter.spec.ts
+++ b/packages/kysely/test/helpers/filter.spec.ts
@@ -36,6 +36,24 @@ describe("luceneFilter", () => {
     expect(mockQb.where).toHaveBeenCalledWith("field", "!=", "value");
   });
 
+  it("unescapes Lucene-escaped characters in quoted values", () => {
+    // Clients (e.g. the admin UI) escape reserved chars before quoting, so a
+    // value such as `auth0|abc-123` arrives as `auth0|abc\-123`. The dash must
+    // be unescaped or the exact match never hits.
+    luceneFilter(
+      mockDb,
+      mockQb as any,
+      'user_id:"auth0|abc\\-123"',
+      searchableColumns,
+    );
+    expect(mockQb.where).toHaveBeenCalledWith("user_id", "=", "auth0|abc-123");
+  });
+
+  it("unescapes Lucene-escaped characters in unquoted values", () => {
+    luceneFilter(mockDb, mockQb as any, "field:a\\-b", searchableColumns);
+    expect(mockQb.where).toHaveBeenCalledWith("field", "=", "a-b");
+  });
+
   it("handles greater than query", () => {
     luceneFilter(mockDb, mockQb as any, "field:>value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", ">", "value");

--- a/packages/kysely/test/helpers/filter.spec.ts
+++ b/packages/kysely/test/helpers/filter.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Kysely } from "kysely";
+import { Database } from "../../src/db";
 import { luceneFilter, sanitizeLuceneQuery } from "../../src/helpers/filter";
 
 describe("luceneFilter", () => {
@@ -8,12 +9,20 @@ describe("luceneFilter", () => {
     dynamic: {
       ref: vi.fn((col) => col),
     },
-  } as unknown as Kysely<any>;
+  } as unknown as Kysely<Database>;
 
-  // Mock query builder
+  // Mock query builder. `qb` is the same object presented as the typed
+  // SelectQueryBuilder that luceneFilter expects, so calls type-check without
+  // `any`; assertions read `mockQb.where` to reach the underlying vi mock.
   const mockQb = {
     where: vi.fn().mockReturnThis(),
   };
+  const qb = mockQb as unknown as Parameters<typeof luceneFilter>[1];
+
+  // A minimal stand-in for Kysely's expression builder: callable (records the
+  // `(field, op, value)` triples the OR branch emits) plus an `or` method.
+  const makeExpressionBuilderStub = () =>
+    Object.assign(vi.fn(), { or: vi.fn() });
 
   const searchableColumns = ["title", "description"];
 
@@ -22,17 +31,17 @@ describe("luceneFilter", () => {
   });
 
   it("handles single word search", () => {
-    luceneFilter(mockDb, mockQb as any, "test", searchableColumns);
+    luceneFilter(mockDb, qb, "test", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it("handles exact match query", () => {
-    luceneFilter(mockDb, mockQb as any, "field:value", searchableColumns);
+    luceneFilter(mockDb, qb, "field:value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "=", "value");
   });
 
   it("handles negation query", () => {
-    luceneFilter(mockDb, mockQb as any, "-field:value", searchableColumns);
+    luceneFilter(mockDb, qb, "-field:value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "!=", "value");
   });
 
@@ -42,7 +51,7 @@ describe("luceneFilter", () => {
     // be unescaped or the exact match never hits.
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'user_id:"auth0|abc\\-123"',
       searchableColumns,
     );
@@ -50,64 +59,64 @@ describe("luceneFilter", () => {
   });
 
   it("unescapes Lucene-escaped characters in unquoted values", () => {
-    luceneFilter(mockDb, mockQb as any, "field:a\\-b", searchableColumns);
+    luceneFilter(mockDb, qb, "field:a\\-b", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "=", "a-b");
   });
 
   it("handles greater than query", () => {
-    luceneFilter(mockDb, mockQb as any, "field:>value", searchableColumns);
+    luceneFilter(mockDb, qb, "field:>value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", ">", "value");
   });
 
   it("handles greater than or equal to query", () => {
-    luceneFilter(mockDb, mockQb as any, "field:>=value", searchableColumns);
+    luceneFilter(mockDb, qb, "field:>=value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", ">=", "value");
   });
 
   it("handles less than query", () => {
-    luceneFilter(mockDb, mockQb as any, "field:<value", searchableColumns);
+    luceneFilter(mockDb, qb, "field:<value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "<", "value");
   });
 
   it("handles less than or equal to query", () => {
-    luceneFilter(mockDb, mockQb as any, "field:<=value", searchableColumns);
+    luceneFilter(mockDb, qb, "field:<=value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "<=", "value");
   });
 
   it("handles negated greater than query", () => {
-    luceneFilter(mockDb, mockQb as any, "-field:>value", searchableColumns);
+    luceneFilter(mockDb, qb, "-field:>value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "<=", "value");
   });
 
   it("handles negated greater than or equal to query", () => {
-    luceneFilter(mockDb, mockQb as any, "-field:>=value", searchableColumns);
+    luceneFilter(mockDb, qb, "-field:>=value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "<", "value");
   });
 
   it("handles negated less than query", () => {
-    luceneFilter(mockDb, mockQb as any, "-field:<value", searchableColumns);
+    luceneFilter(mockDb, qb, "-field:<value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", ">=", "value");
   });
 
   it("handles negated less than or equal to query", () => {
-    luceneFilter(mockDb, mockQb as any, "-field:<=value", searchableColumns);
+    luceneFilter(mockDb, qb, "-field:<=value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", ">", "value");
   });
 
   it("handles exists query", () => {
-    luceneFilter(mockDb, mockQb as any, "_exists_:field", searchableColumns);
+    luceneFilter(mockDb, qb, "_exists_:field", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "is not", null);
   });
 
   it("handles not exists query", () => {
-    luceneFilter(mockDb, mockQb as any, "-_exists_:field", searchableColumns);
+    luceneFilter(mockDb, qb, "-_exists_:field", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "is", null);
   });
 
   it("handles multiple conditions", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       "field1:value1 field2:>value2 field3:<value3",
       searchableColumns,
     );
@@ -120,7 +129,7 @@ describe("luceneFilter", () => {
   it("handles mixed conditions", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       "searchword field:>=value _exists_:field2",
       searchableColumns,
     );
@@ -138,7 +147,7 @@ describe("luceneFilter", () => {
     // signing key resolver.
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       "type:jwt_signing AND -_exists_:tenant_id",
       searchableColumns,
     );
@@ -148,7 +157,7 @@ describe("luceneFilter", () => {
   });
 
   it('handles query with "=" instead of ":"', () => {
-    luceneFilter(mockDb, mockQb as any, "field=value", searchableColumns);
+    luceneFilter(mockDb, qb, "field=value", searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "=", "value");
   });
 
@@ -156,7 +165,7 @@ describe("luceneFilter", () => {
   it("handles quoted values", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'email:"test@example.com"',
       searchableColumns,
     );
@@ -164,14 +173,14 @@ describe("luceneFilter", () => {
   });
 
   it("handles quoted values with spaces", () => {
-    luceneFilter(mockDb, mockQb as any, 'name:"John Doe"', searchableColumns);
+    luceneFilter(mockDb, qb, 'name:"John Doe"', searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("name", "=", "John Doe");
   });
 
   it("handles quoted values with special characters", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'description:"Value with @#$% special chars"',
       searchableColumns,
     );
@@ -183,19 +192,19 @@ describe("luceneFilter", () => {
   });
 
   it("handles empty quoted values", () => {
-    luceneFilter(mockDb, mockQb as any, 'field:""', searchableColumns);
+    luceneFilter(mockDb, qb, 'field:""', searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "=", "");
   });
 
   it("handles single character quoted values", () => {
-    luceneFilter(mockDb, mockQb as any, 'field:"a"', searchableColumns);
+    luceneFilter(mockDb, qb, 'field:"a"', searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "=", "a");
   });
 
   it("handles quoted values with operators", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'date:>"2023-01-01"',
       searchableColumns,
     );
@@ -205,7 +214,7 @@ describe("luceneFilter", () => {
   it("handles negated quoted values", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       '-email:"blocked@example.com"',
       searchableColumns,
     );
@@ -219,7 +228,7 @@ describe("luceneFilter", () => {
   it("handles mixed quoted and unquoted values", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'email:"test@example.com" status:active',
       searchableColumns,
     );
@@ -230,17 +239,17 @@ describe("luceneFilter", () => {
 
   // Edge cases
   it("handles values with only opening quote", () => {
-    luceneFilter(mockDb, mockQb as any, 'field:"value', searchableColumns);
+    luceneFilter(mockDb, qb, 'field:"value', searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "=", '"value');
   });
 
   it("handles values with only closing quote", () => {
-    luceneFilter(mockDb, mockQb as any, 'field:value"', searchableColumns);
+    luceneFilter(mockDb, qb, 'field:value"', searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "=", 'value"');
   });
 
   it("handles values with quotes in the middle", () => {
-    luceneFilter(mockDb, mockQb as any, 'field:val"ue', searchableColumns);
+    luceneFilter(mockDb, qb, 'field:val"ue', searchableColumns);
     expect(mockQb.where).toHaveBeenCalledWith("field", "=", 'val"ue');
   });
 
@@ -248,7 +257,7 @@ describe("luceneFilter", () => {
   it("handles email searches properly", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'email:"user@domain.com"',
       searchableColumns,
     );
@@ -258,7 +267,7 @@ describe("luceneFilter", () => {
   it("handles phone number searches", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'phone_number:"+1-555-123-4567"',
       searchableColumns,
     );
@@ -272,7 +281,7 @@ describe("luceneFilter", () => {
   it("handles user ID searches with pipes", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'user_id:"auth0|123456789"',
       searchableColumns,
     );
@@ -286,7 +295,7 @@ describe("luceneFilter", () => {
   it("handles complex queries with quotes and operators", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'email:"test@example.com" created_at:>"2023-01-01" -status:"banned"',
       searchableColumns,
     );
@@ -297,20 +306,31 @@ describe("luceneFilter", () => {
   });
 
   // OR logic tests
-  it("handles simple OR query", () => {
+  it("handles simple OR query and unescapes values in the OR branch", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
-      "field1:value1 OR field2:value2",
+      qb,
+      "field1:a\\-b OR field2:value2",
       searchableColumns,
     );
     expect(mockQb.where).toHaveBeenCalledWith(expect.any(Function));
+
+    // The OR branch builds its conditions inside the callback handed to
+    // `where`, so exercising the callback is the only way to confirm operands
+    // are Lucene-unescaped there too (the AND path is covered separately).
+    const orCallback = mockQb.where.mock.calls[0]![0] as (
+      eb: ReturnType<typeof makeExpressionBuilderStub>,
+    ) => unknown;
+    const eb = makeExpressionBuilderStub();
+    orCallback(eb);
+    expect(eb).toHaveBeenCalledWith("field1", "=", "a-b");
+    expect(eb).toHaveBeenCalledWith("field2", "=", "value2");
   });
 
   it("handles OR query with multiple fields", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       "id:tenant1 OR id:tenant2 OR id:tenant3",
       searchableColumns,
     );
@@ -320,7 +340,7 @@ describe("luceneFilter", () => {
   it("handles OR query with quoted values", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       'name:"John Doe" OR name:"Jane Smith"',
       searchableColumns,
     );
@@ -330,7 +350,7 @@ describe("luceneFilter", () => {
   it("handles OR query case-insensitively", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       "field1:value1 or field2:value2",
       searchableColumns,
     );
@@ -340,7 +360,7 @@ describe("luceneFilter", () => {
   it("handles OR query with mixed case", () => {
     luceneFilter(
       mockDb,
-      mockQb as any,
+      qb,
       "field1:value1 Or field2:value2",
       searchableColumns,
     );

--- a/packages/kysely/test/logs-query.spec.ts
+++ b/packages/kysely/test/logs-query.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { getTestServer } from "./helpers/test-server";
 
 describe("logs list query robustness", () => {
-  let data: any;
+  let data: Awaited<ReturnType<typeof getTestServer>>["data"];
   const tenantId = "test-tenant";
 
   beforeEach(async () => {

--- a/packages/kysely/test/logs-query.spec.ts
+++ b/packages/kysely/test/logs-query.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestServer } from "./helpers/test-server";
+
+describe("logs list query robustness", () => {
+  let data: any;
+  const tenantId = "test-tenant";
+
+  beforeEach(async () => {
+    const res = await getTestServer();
+    data = res.data;
+    await data.logs.create(tenantId, {
+      type: "s",
+      description: "email-code login",
+      user_id: "auth0|abc-123",
+      ip: "1.2.3.4",
+      date: new Date().toISOString(),
+    });
+    // A failed login before any user record exists: email only in description.
+    await data.logs.create(tenantId, {
+      type: "f",
+      description: "Login failed for foo@example.com",
+      ip: "5.6.7.8",
+      date: new Date().toISOString(),
+    });
+  });
+
+  async function run(q: string) {
+    const r = await data.logs.list(tenantId, { q, include_totals: true });
+    return r.logs.length;
+  }
+
+  it("does not crash on a free-text term containing a colon", async () => {
+    await expect(run("2024-01-01T10:00:00")).resolves.toBeTypeOf("number");
+  });
+
+  it("does not crash on a clause referencing a non-column (success)", async () => {
+    await expect(run('success:"true"')).resolves.toBeTypeOf("number");
+  });
+
+  it("matches a dash-containing field value (admin-escaped)", async () => {
+    // exactly what apps/admin escapeLuceneValue produces: dash -> \-
+    expect(await run('user_id:"auth0|abc\\-123"')).toBe(1);
+    expect(await run('description:"email\\-code"')).toBe(1);
+  });
+
+  it("still applies a legitimate allowed field filter", async () => {
+    expect(await run('user_id:"auth0|abc-123"')).toBe(1);
+    expect(await run('user_id:"nobody"')).toBe(0);
+  });
+
+  it("free-text search matches an email in the description (no user_id yet)", async () => {
+    expect(await run("foo@example.com")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Filtering logs by a value containing a `-` (e.g. a `user_id` like `auth0|abc-123`, or a description fragment) returned **no rows**. The admin UI escapes filter values per Lucene rules (`-` → `\-`) and quotes them, but the backends stripped the quotes without reversing the escaping — so the comparison ran against the literal backslash and never matched.

While investigating, two adjacent issues surfaced:
- A free-text term containing a `:` (e.g. a timestamp `2024-01-01T10:00:00`) or a non-column clause (e.g. `success`) was misparsed as a column reference and **crashed the request with a 500**.
- Free-text search ignored `description`, so a user's email couldn't find failed-login events recorded before any user record existed.

## Changes

**kysely adapter** (`@authhero/kysely-adapter`)
- Unescape Lucene escape sequences in filter values before they reach SQL.
- Sanitize `q` against an allowlist of real log columns (the pattern `users`/`organizations` already use) so bogus-column clauses can no longer 500.
- Add `description` to free-text searchable columns (substring match).

**cloudflare Analytics Engine adapter** (`@authhero/cloudflare-adapter`)
- Apply the same Lucene unescaping in `field:value` clauses.
- Support bare free-text terms (match `user_id` exact, `ip`/`description` substring) instead of ignoring them and returning every log.

## Tests

- kysely: unit tests for unescaping + integration tests in `logs-query.spec.ts` (crash cases, dash matching, email-in-description). 51 passing.
- cloudflare: 3 new tests (dash unescape, bare-term search, bare term + field filter); 17 passing, no regressions to existing quote-stripping / `IN` / `success` tests.

## Notes (not addressed here)

- The admin `success` filter still doesn't actually filter in the kysely adapter (no column to map it to) — now harmlessly ignored rather than erroring. The AE adapter already handles it.
- The AE `description:"x"` field filter is still exact-match (vs. kysely's substring `LIKE`), despite the admin placeholder saying "Contains…". Small remaining inconsistency between the two adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log search so values with escaped special characters now match correctly.
  * Free-text log queries now return relevant results instead of being ignored or causing errors.
  * Search now matches more log details, including user IDs, IPs, and descriptions, for better log discovery.
  * Queries with mixed filters and free-text terms now work more reliably without crashing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->