### PR TITLE
fix(userinfo): don't fabricate default picture without profile scope

### DIFF
--- a/.changeset/userinfo-picture-scope.md
+++ b/.changeset/userinfo-picture-scope.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Fix `/userinfo` leaking a generated default-avatar `picture` for users who have none when `picture` is requested via the OIDC `claims` parameter without the `profile` scope. The default-avatar fallback is now only attached on the `profile`-scoped claims path; individually requested `picture` claims reflect the user's real value.

--- a/packages/authhero/src/routes/auth-api/userinfo.ts
+++ b/packages/authhero/src/routes/auth-api/userinfo.ts
@@ -71,14 +71,25 @@ function buildUserInfoResponse(
   user: User,
   scopes: string[],
   requestedClaims: string[] = [],
+  issuer?: string,
 ) {
   // sub is the only claim always included (OIDC Core 5.3.2). Scope-driven
   // claims are shared with the ID Token via buildScopeClaims. Individually
   // requested claims (OIDC Core 5.5 `claims.userinfo`) are merged on top,
   // regardless of scope.
+  //
+  // The generated-avatar fallback is a convenience for the `profile` scope,
+  // where consumers expect `picture` to always be present. It must NOT leak
+  // into responses that didn't grant `profile` — in particular an
+  // individually requested `picture` claim must reflect the user's real
+  // value, so buildRequestedClaims always sees the un-enriched user.
+  const scopedUser =
+    issuer && scopes.includes("profile")
+      ? withDefaultPicture(user, issuer)
+      : user;
   return {
     sub: user.user_id,
-    ...buildScopeClaims(user, scopes),
+    ...buildScopeClaims(scopedUser, scopes),
     ...buildRequestedClaims(user, requestedClaims),
   };
 }
@@ -142,12 +153,11 @@ const getRoot = defineRoute({
       throw new HTTPException(404, { message: "User not found" });
     }
 
-    // Guarantee `picture` is always present, falling back to a generated
-    // avatar so consumers never have to render their own placeholder.
-    const user = withDefaultPicture(
-      storedUser,
-      getIssuer(ctx.env, ctx.var.custom_domain),
-    );
+    const issuer = getIssuer(ctx.env, ctx.var.custom_domain);
+    // The hook context has historically always seen a `picture`; keep a
+    // default-picture-enriched copy for it. The response itself only attaches
+    // the fallback on the `profile`-scoped path (see buildUserInfoResponse).
+    const user = withDefaultPicture(storedUser, issuer);
 
     // Get scope from token payload (ctx.var.user contains full JWT payload)
     const tokenPayload = ctx.var.user;
@@ -155,7 +165,12 @@ const getRoot = defineRoute({
     const requestedClaims = extractRequestedUserinfoClaims(tokenPayload);
 
     // Build initial userinfo response based on scopes + requested claims
-    const baseUserInfo = buildUserInfoResponse(user, scopes, requestedClaims);
+    const baseUserInfo = buildUserInfoResponse(
+      storedUser,
+      scopes,
+      requestedClaims,
+      issuer,
+    );
 
     // Call onFetchUserInfo hook if configured
     const onFetchUserInfo = ctx.env.hooks?.onFetchUserInfo;
@@ -307,19 +322,23 @@ const postRoot = defineRoute({
       throw new HTTPException(404, { message: "User not found" });
     }
 
-    // Guarantee `picture` is always present, falling back to a generated
-    // avatar so consumers never have to render their own placeholder.
-    const user = withDefaultPicture(
-      storedUser,
-      getIssuer(ctx.env, ctx.var.custom_domain),
-    );
+    const issuer = getIssuer(ctx.env, ctx.var.custom_domain);
+    // The hook context has historically always seen a `picture`; keep a
+    // default-picture-enriched copy for it. The response itself only attaches
+    // the fallback on the `profile`-scoped path (see buildUserInfoResponse).
+    const user = withDefaultPicture(storedUser, issuer);
 
     // Get scopes from the token
     const scopes = tokenPayload?.scope?.split(" ") || [];
     const requestedClaims = extractRequestedUserinfoClaims(tokenPayload);
 
     // Build initial userinfo response based on scopes + requested claims
-    const baseUserInfo = buildUserInfoResponse(user, scopes, requestedClaims);
+    const baseUserInfo = buildUserInfoResponse(
+      storedUser,
+      scopes,
+      requestedClaims,
+      issuer,
+    );
 
     // Call onFetchUserInfo hook if configured
     const onFetchUserInfo = ctx.env.hooks?.onFetchUserInfo;

--- a/packages/authhero/test/routes/auth-api/userinfo.spec.ts
+++ b/packages/authhero/test/routes/auth-api/userinfo.spec.ts
@@ -131,6 +131,83 @@ describe("userinfo", () => {
       });
     });
 
+    // Regression: the generated-avatar fallback must not leak into responses
+    // that didn't grant `profile`. A user with no picture of their own who
+    // requests `picture` via the OIDC `claims` parameter (no `profile` scope)
+    // must NOT receive a fabricated default avatar.
+    it("should not fabricate a default picture for a requested claim without profile scope", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const client = testClient(oauthApp, env);
+
+      await env.data.users.create("tenantId", {
+        email: "nopicture@example.com",
+        email_verified: true,
+        name: "No Picture User",
+        connection: "email",
+        provider: "email",
+        is_social: false,
+        user_id: "email|noPictureUserId",
+      });
+
+      const accessToken = await createToken({
+        user_id: "email|noPictureUserId",
+        tenant_id: "tenantId",
+        scope: "openid", // no `profile` scope
+        requested_userinfo_claims: ["picture"],
+      });
+
+      const response = await client.userinfo.$get(
+        {},
+        {
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual({ sub: "email|noPictureUserId" });
+      expect(body.picture).toBeUndefined();
+    });
+
+    // Counterpart: the default avatar fallback IS attached when `profile` is
+    // granted, so consumers can always rely on `picture` being present.
+    it("should attach a default picture under profile scope when the user has none", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const client = testClient(oauthApp, env);
+
+      await env.data.users.create("tenantId", {
+        email: "nopicture2@example.com",
+        email_verified: true,
+        name: "No Picture User Two",
+        connection: "email",
+        provider: "email",
+        is_social: false,
+        user_id: "email|noPictureUserId2",
+      });
+
+      const accessToken = await createToken({
+        user_id: "email|noPictureUserId2",
+        tenant_id: "tenantId",
+        scope: "openid profile",
+      });
+
+      const response = await client.userinfo.$get(
+        {},
+        {
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(typeof body.picture).toBe("string");
+      expect(body.picture).toContain("/avatars/");
+    });
+
     it("should ignore unknown requested claim names", async () => {
       const { oauthApp, env } = await getTestServer();
       const client = testClient(oauthApp, env);


### PR DESCRIPTION
## Summary

`/userinfo` was leaking a generated default-avatar `picture` for users who have none when `picture` is requested via the OIDC `claims` parameter **without** the `profile` scope.

The default-avatar fallback is now only attached on the `profile`-scoped claims path:
- `buildScopeClaims` receives a default-picture-enriched user only when `profile` is granted.
- `buildRequestedClaims` always sees the un-enriched user, so an individually requested `picture` claim reflects the user's real value.
- The `onFetchUserInfo` hook context still receives a `picture`-enriched user (unchanged behavior).

Applies to both `GET` and `POST /userinfo`.

## Tests

Added two regression tests:
- No `profile` scope + requested `picture` claim on a user with no picture → response is `{ sub }`, no fabricated avatar.
- `profile` scope on a user with no picture → default avatar (`/avatars/`) attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)