### PR TITLE
fix(authhero): surface tenant export failures instead of a corrupt 200

### DIFF
--- a/.changeset/tenant-export-error-surfacing.md
+++ b/.changeset/tenant-export-error-surfacing.md
@@ -1,0 +1,10 @@
+---
+"authhero": patch
+---
+
+Fix tenant-data export silently returning a corrupt 10-byte gzip when the
+export fails before producing any row. The handler now prefetches the first
+line before committing the streamed response, so a pre-first-byte failure
+returns a proper 500 instead of a 200 with a truncated gzip header. All export
+failures (including mid-stream) are now logged as `FAILED_API_OPERATION` so the
+underlying cause is diagnosable.

--- a/packages/authhero/src/routes/management-api/tenant-export-import.ts
+++ b/packages/authhero/src/routes/management-api/tenant-export-import.ts
@@ -242,6 +242,17 @@ const exportRoute = defineRoute({
           "JSON-lines export of the tenant's durable data, one " +
           "`{ entity, data }` record per line (gzipped by default).",
       },
+      500: {
+        content: {
+          "application/json": {
+            schema: z.object({
+              message: z.string(),
+            }),
+          },
+        },
+        description:
+          "Export failed before the response body could be streamed.",
+      },
     },
   }),
   handler: async (ctx) => {

--- a/packages/authhero/src/routes/management-api/tenant-export-import.ts
+++ b/packages/authhero/src/routes/management-api/tenant-export-import.ts
@@ -262,10 +262,32 @@ const exportRoute = defineRoute({
     let rowCount = 0;
     let logged = false;
 
+    // Pull the first line *before* committing the response. The body streams,
+    // so returning the Response locks in status 200 + headers; if the very
+    // first adapter call throws after that, the only recourse is
+    // `controller.error`, which truncates the gzip to its 10-byte header and
+    // hands the client a 200 with a corrupt file. Surfacing that first failure
+    // here lets us return a real 5xx (and log it) instead.
+    let firstResult: IteratorResult<ExportLine>;
+    try {
+      firstResult = await iterator.next();
+    } catch (err) {
+      await logMessage(ctx, tenant_id, {
+        type: LogTypes.FAILED_API_OPERATION,
+        description: `Tenant export failed (password_hashes=${includePasswordHashes}) by ${ctx.var.user?.sub ?? "unknown"}: ${err instanceof Error ? err.message : String(err)}`,
+        targetType: "tenant",
+        targetId: tenant_id,
+      });
+      throw new HTTPException(500, { message: "Tenant export failed" });
+    }
+    // The first chunk is already fetched; emit it before resuming the iterator.
+    let pending: IteratorResult<ExportLine> | undefined = firstResult;
+
     const ndjson = new ReadableStream<Uint8Array<ArrayBuffer>>({
       async pull(controller) {
         try {
-          const { value, done } = await iterator.next();
+          const { value, done } = pending ?? (await iterator.next());
+          pending = undefined;
           if (done) {
             if (!logged) {
               logged = true;
@@ -282,6 +304,17 @@ const exportRoute = defineRoute({
           rowCount += 1;
           controller.enqueue(encoder.encode(JSON.stringify(value) + "\n"));
         } catch (err) {
+          // Mid-stream failure: status 200 is already on the wire, so the
+          // client still gets a truncated body — but at least record why.
+          if (!logged) {
+            logged = true;
+            await logMessage(ctx, tenant_id, {
+              type: LogTypes.FAILED_API_OPERATION,
+              description: `Tenant export failed after ${rowCount} rows (password_hashes=${includePasswordHashes}) by ${ctx.var.user?.sub ?? "unknown"}: ${err instanceof Error ? err.message : String(err)}`,
+              targetType: "tenant",
+              targetId: tenant_id,
+            });
+          }
           controller.error(err);
         }
       },

--- a/packages/authhero/test/management-api/tenant-export-import.test.ts
+++ b/packages/authhero/test/management-api/tenant-export-import.test.ts
@@ -67,6 +67,30 @@ describe("GET /tenant-data/export", () => {
     expect(entities).toContain("clients");
   });
 
+  it("returns 500 (not a corrupt 200) when the export fails before the first row", async () => {
+    // Hit the full app so the root onError converts the thrown HTTPException
+    // into a 500 response (the management app deliberately rethrows >=500s).
+    const { app, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    // The export streams, so status is committed before any row is produced.
+    // A throw on the very first adapter call must surface as a real error
+    // rather than a 200 with a truncated 10-byte gzip header.
+    env.data.tenants.get = async () => {
+      throw new Error("boom");
+    };
+
+    const res = await app.request(
+      "/api/v2/tenant-data/export",
+      {
+        headers: { authorization: `Bearer ${token}`, "tenant-id": "tenantId" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(500);
+  });
+
   it("rejects include_password_hashes without the elevated scope", async () => {
     const { managementApp, env } = await getTestServer();
     const token = await getAdminToken();


### PR DESCRIPTION
## Problem

`GET /api/v2/tenant-data/export` could return **HTTP 200** with a **corrupt 10-byte `.gz`** body (observed for tenant `canopy` on `auth2.sesamy.dev`).

The handler streams the export, so `new Response(body, { status: 200 })` commits the status + headers **before the first row is generated**. On the first `pull()`, `exportTenantLines` runs `data.tenants.get()` → `clients.list()`; if that throws, the only recourse was `controller.error()`, which aborts the gzip stream after just its **10-byte member header** has been flushed — no deflate body, no CRC/size trailer. That is exactly the corrupt 10-byte file.

Worse, the real exception was **swallowed**: `logMessage` only fired on the success path, so there was no record of *why* the export failed.

> A 10-byte file is the tell: a gzip header is exactly 10 bytes. A *clean empty* export (`controller.close()`) produces a valid ~20-byte gzip. 10 broken bytes means the generator threw before yielding its first row, after streaming had already locked in the 200.

## Fix

- **Prefetch the first export line before committing the response.** A pre-first-byte failure now logs `FAILED_API_OPERATION` and throws `HTTPException(500)` — a real error instead of a 200 with garbage.
- **Log mid-stream failures too** before `controller.error`. Those still can't change the already-sent 200 (inherent to streaming), but they're now diagnosable.

## Out of scope

This makes the underlying `canopy` failure **observable** but doesn't fix it — the next step is to read the new `FAILED_API_OPERATION` log, which will name the failing adapter call.

## Tests

- New: mock `tenants.get` rejects → export returns **500** (not a corrupt 200).
- Existing export/import suites still pass (healthy + empty tenants produce valid gzip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)