### PR TITLE
feat: add user_activity entity + capture full upstream IdP claims (#1003)

### DIFF
--- a/.changeset/capture-full-upstream-claims.md
+++ b/.changeset/capture-full-upstream-claims.md
@@ -1,0 +1,12 @@
+---
+"authhero": minor
+---
+
+Persist the full upstream claim set to `profileData` for enterprise connections (issue #1003).
+
+The connection callback now prefers each strategy's `validateAuthorizationCodeAndGetUserWithRaw` variant and stores the entire decoded upstream claim set (id_token / userinfo claims — no tokens or secrets) in `profileData`, instead of only the five normalized fields. This makes claims like `upn`, `preferred_username`, `unique_name`, and `oid` durably available (Auth0 `identities[].profileData` parity) — e.g. for diagnosing Entra/`waad` cases where the `email` claim (from `mail`) differs from the sign-in identifier.
+
+- Added a `WithRaw` variant to the `waad` / Microsoft Entra strategy.
+- Strategies that don't implement `WithRaw` (most social ones) are unchanged: they fall back to the normalized userinfo with `raw: null`.
+
+Also double-writes the login counters (`last_login`, `last_ip`, `login_count`) to the new `user_activity` adapter when present, alongside the existing `users` columns (expand phase of issue #1003). No-op when the adapter isn't configured.

--- a/.changeset/user-activity-adapter.md
+++ b/.changeset/user-activity-adapter.md
@@ -1,0 +1,7 @@
+---
+"@authhero/adapter-interfaces": minor
+---
+
+Add an optional `userActivity` adapter (issue #1003).
+
+New `UserActivity` type and `UserActivityAdapter` interface (`get` + merge-`upsert`) for the write-often per-user counters (`last_login`, `last_ip`, `login_count`, `failed_logins`, `last_password_reset`) split out of the `users` row. It's optional on `DataAdapters` — adapters that don't implement it (e.g. drizzle) are unaffected, and the login flow only double-writes when it's present.

--- a/.changeset/user-activity-and-column-cleanup.md
+++ b/.changeset/user-activity-and-column-cleanup.md
@@ -1,0 +1,14 @@
+---
+"@authhero/kysely-adapter": minor
+---
+
+Add a `user_activity` table and clean up `users` column types (issue #1003).
+
+Schema-only, forward-only migration — no data is moved or backfilled yet:
+
+- Converts the large, non-indexed `users` columns `profileData`, `picture`, and `app_metadata` from `varchar` to `TEXT` (so enriched profile data is no longer capped/truncated and InnoDB row-size pressure is relieved). `app_metadata` keeps its `'{}'` default via a MySQL 8 expression default.
+- Right-sizes oversized `users` varchars: `created_at`/`updated_at` → `varchar(35)`, `locale` → `varchar(64)`.
+- Adds an empty `user_activity` entity (keyed `(tenant_id, user_id)`, FK to `users` with `ON DELETE CASCADE`) to hold the write-often counters (`last_login`, `last_ip`, `login_count`, `failed_logins`, `last_password_reset`).
+- Implements the `userActivity` adapter (`get` + merge-`upsert`) and wires it into `createAdapters`.
+
+The login flow now double-writes the login counters to `user_activity` (expand phase). Reads still come from the legacy `users` columns; the read cutover, backfill, and column drops ship in a follow-up PR.

--- a/packages/adapter-interfaces/src/adapters/UserActivity.ts
+++ b/packages/adapter-interfaces/src/adapters/UserActivity.ts
@@ -1,0 +1,14 @@
+import { UserActivity, UserActivityUpdate } from "../types/UserActivity";
+
+export interface UserActivityAdapter {
+  get(tenantId: string, userId: string): Promise<UserActivity | null>;
+  /**
+   * Insert or merge-update the activity row for a user. Only the provided
+   * fields are written; previously-stored fields are preserved.
+   */
+  upsert(
+    tenantId: string,
+    userId: string,
+    activity: UserActivityUpdate,
+  ): Promise<void>;
+}

--- a/packages/adapter-interfaces/src/adapters/index.ts
+++ b/packages/adapter-interfaces/src/adapters/index.ts
@@ -32,6 +32,7 @@ import { FormsAdapter } from "./Forms";
 import { ResourceServersAdapter } from "./ResourceServers";
 import { RolePermissionsAdapter } from "./RolePermissions";
 import { GrantsAdapter } from "./Grants";
+import { UserActivityAdapter } from "./UserActivity";
 import { UserPermissionsAdapter } from "./UserPermissions";
 import { RolesAdapter } from "./Roles";
 import { UserRolesAdapter } from "./UserRoles";
@@ -116,6 +117,14 @@ export interface DataAdapters {
    * `/api/v2/client-grants`, which is `clientGrants` above).
    */
   grants?: GrantsAdapter;
+  /**
+   * Optional write-often per-user activity counters (last_login, last_ip,
+   * login_count, …) split out of the `users` row (issue #1003). When set, the
+   * login flow double-writes these alongside the legacy `users` columns during
+   * the expand/contract migration. When undefined, only the legacy columns are
+   * written.
+   */
+  userActivity?: UserActivityAdapter;
   userPermissions: UserPermissionsAdapter;
   roles: RolesAdapter;
   sessions: SessionsAdapter;
@@ -238,4 +247,5 @@ export * from "./TenantSettings";
 export * from "./Tenants";
 export * from "./Themes";
 export * from "./Grants";
+export * from "./UserActivity";
 export * from "./Users";

--- a/packages/adapter-interfaces/src/types/UserActivity.ts
+++ b/packages/adapter-interfaces/src/types/UserActivity.ts
@@ -1,0 +1,22 @@
+import { z } from "@hono/zod-openapi";
+
+/**
+ * Write-often per-user counters split out of the `users` row (issue #1003) so
+ * the profile row isn't rewritten on every login / failed password attempt.
+ * 1:1 with a user, keyed by `(tenant_id, user_id)`.
+ */
+export const userActivitySchema = z.object({
+  user_id: z.string(),
+  last_login: z.string().optional(),
+  last_ip: z.string().optional(),
+  login_count: z.number().default(0),
+  // Lockout timestamps (ISO 8601). Lifted out of `app_metadata` in a later
+  // phase — included here so the schema is complete.
+  failed_logins: z.array(z.string()).optional(),
+  last_password_reset: z.string().optional(),
+});
+
+export type UserActivity = z.infer<typeof userActivitySchema>;
+
+/** Partial payload for an upsert — only the provided fields are written. */
+export type UserActivityUpdate = Partial<Omit<UserActivity, "user_id">>;

--- a/packages/adapter-interfaces/src/types/index.ts
+++ b/packages/adapter-interfaces/src/types/index.ts
@@ -87,6 +87,7 @@ export * from "./SmsProvider";
 export * from "./ResourceServer";
 export * from "./RolePermission";
 export * from "./Grant";
+export * from "./UserActivity";
 export * from "./UserPermission";
 export * from "./UserRole";
 export * from "./Role";

--- a/packages/authhero/src/authentication-flows/connection.ts
+++ b/packages/authhero/src/authentication-flows/connection.ts
@@ -244,15 +244,41 @@ export async function connectionCallback(
     }
   }
 
-  const userinfo = await strategy.validateAuthorizationCodeAndGetUser(
-    ctx,
-    connection,
-    code,
-    auth0state.code_verifier,
-  );
+  // Prefer the raw-capturing variant so the entire upstream claim set is
+  // persisted to profileData (Auth0 parity — e.g. waad's upn /
+  // preferred_username / unique_name / oid). Strategies that don't implement it
+  // (most social ones) fall back to the normalized userinfo with raw: null, so
+  // their behavior is unchanged.
+  const { userinfo, raw } = strategy.validateAuthorizationCodeAndGetUserWithRaw
+    ? await strategy.validateAuthorizationCodeAndGetUserWithRaw(
+        ctx,
+        connection,
+        code,
+        auth0state.code_verifier,
+      )
+    : {
+        userinfo: await strategy.validateAuthorizationCodeAndGetUser(
+          ctx,
+          connection,
+          code,
+          auth0state.code_verifier,
+        ),
+        raw: null,
+      };
 
-  const { sub, ...profileData } = userinfo;
+  const { sub, ...normalizedProfile } = userinfo;
   ctx.set("user_id", sub);
+
+  // Persist the full decoded upstream claims when the strategy exposes them
+  // (id_token / userinfo claims only — no tokens or secrets), with the
+  // normalized fields taking precedence. `sub` is dropped since it maps to
+  // user_id, matching the prior profileData shape.
+  let profileData: Record<string, unknown> = { ...normalizedProfile };
+  if (raw) {
+    const rawClaims = { ...raw };
+    delete rawClaims.sub;
+    profileData = { ...rawClaims, ...normalizedProfile };
+  }
 
   const email =
     userinfo.email?.toLocaleLowerCase() ||

--- a/packages/authhero/src/hooks/post-user-login.ts
+++ b/packages/authhero/src/hooks/post-user-login.ts
@@ -265,14 +265,31 @@ export async function postUserLoginHook(
     // the pre-login values either way), and the row write plus its
     // user-update decorator chain is one of the slowest calls in the login
     // flow.
+    const lastLogin = new Date().toISOString();
+    const lastIp = ctx.var.ip || "";
+    const loginCount = user.login_count + 1;
     waitUntil(
       ctx,
       data.users.update(tenant_id, user.user_id, {
-        last_login: new Date().toISOString(),
-        last_ip: ctx.var.ip || "",
-        login_count: user.login_count + 1,
+        last_login: lastLogin,
+        last_ip: lastIp,
+        login_count: loginCount,
       }),
     );
+    // Expand/contract migration (issue #1003): double-write the same counters
+    // to the user_activity entity. Reads still come from the legacy `users`
+    // columns this phase; a later PR cuts reads over and drops the columns.
+    // Guarded because the adapter is optional (e.g. drizzle doesn't ship it).
+    if (data.userActivity) {
+      waitUntil(
+        ctx,
+        data.userActivity.upsert(tenant_id, user.user_id, {
+          last_login: lastLogin,
+          last_ip: lastIp,
+          login_count: loginCount,
+        }),
+      );
+    }
 
     // Build the Auth0-compatible event once. Reused by both the env-hook
     // (ctx.env.hooks.onExecutePostLogin) and the code-hook loop below so user

--- a/packages/authhero/src/strategies/microsoft-entra.ts
+++ b/packages/authhero/src/strategies/microsoft-entra.ts
@@ -69,7 +69,7 @@ export async function microsoftEntraRedirect(
   };
 }
 
-export async function microsoftEntraValidate(
+async function microsoftEntraValidateInternal(
   ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
   connection: Connection,
   code: string,
@@ -88,17 +88,56 @@ export async function microsoftEntraValidate(
     throw new Error("Invalid ID token");
   }
 
+  // idTokenSchema is `.passthrough()`, so the parsed payload retains every
+  // upstream claim (upn, preferred_username, unique_name, oid, …) — we expose
+  // it as `raw` so the full claim set can be persisted to profileData.
   const payload = idTokenSchema.parse(idToken.payload);
   ctx.set("log", `Microsoft user: ${JSON.stringify(payload)}`);
 
   return {
-    sub: payload.sub,
-    email: payload.email,
-    given_name: payload.given_name,
-    family_name: payload.family_name,
-    name: payload.name,
-    picture: payload.picture,
+    userinfo: {
+      sub: payload.sub,
+      email: payload.email,
+      given_name: payload.given_name,
+      family_name: payload.family_name,
+      name: payload.name,
+      picture: payload.picture,
+    },
+    raw: { ...idToken.payload } as Record<string, unknown>,
   };
+}
+
+export async function microsoftEntraValidate(
+  ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
+  connection: Connection,
+  code: string,
+  code_verifier: string | undefined,
+  defaultTenant: string,
+) {
+  const { userinfo } = await microsoftEntraValidateInternal(
+    ctx,
+    connection,
+    code,
+    code_verifier,
+    defaultTenant,
+  );
+  return userinfo;
+}
+
+export async function microsoftEntraValidateWithRaw(
+  ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
+  connection: Connection,
+  code: string,
+  code_verifier: string | undefined,
+  defaultTenant: string,
+) {
+  return microsoftEntraValidateInternal(
+    ctx,
+    connection,
+    code,
+    code_verifier,
+    defaultTenant,
+  );
 }
 
 export const microsoftLogoDataUri =

--- a/packages/authhero/src/strategies/waad.ts
+++ b/packages/authhero/src/strategies/waad.ts
@@ -4,6 +4,7 @@ import { Bindings, Variables } from "../types";
 import {
   microsoftEntraRedirect,
   microsoftEntraValidate,
+  microsoftEntraValidateWithRaw,
   microsoftLogoDataUri,
 } from "./microsoft-entra";
 
@@ -32,6 +33,24 @@ export function validateAuthorizationCodeAndGetUser(
   code_verifier?: string,
 ) {
   return microsoftEntraValidate(
+    ctx,
+    connection,
+    code,
+    code_verifier,
+    DEFAULT_TENANT,
+  );
+}
+
+// Exposes the full decoded ID token payload alongside the normalized user so
+// the connection callback can persist the entire upstream claim set (upn,
+// preferred_username, unique_name, oid, …) to profileData.
+export function validateAuthorizationCodeAndGetUserWithRaw(
+  ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
+  connection: Connection,
+  code: string,
+  code_verifier?: string,
+) {
+  return microsoftEntraValidateWithRaw(
     ctx,
     connection,
     code,

--- a/packages/authhero/test/authentication-flows/connection.spec.ts
+++ b/packages/authhero/test/authentication-flows/connection.spec.ts
@@ -66,4 +66,58 @@ describe("connection", () => {
       },
     });
   });
+
+  it("persists the full upstream claim set to profileData on callback", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    // mock-strategy exposes validateAuthorizationCodeAndGetUserWithRaw, so the
+    // callback should persist the entire decoded claim set (incl. upn /
+    // preferred_username) to profileData — not just the normalized email.
+    await oauthClient.authorize.$get(
+      {
+        query: {
+          client_id: "clientId",
+          redirect_uri: "https://example.com/callback",
+          state: "state",
+          connection: "mock-strategy",
+          response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
+        },
+      },
+      { headers: { origin: "https://example.com" } },
+    );
+
+    // mock-strategy.getRedirect uses the fixed oauth2_state "code".
+    const oauth2Code = await env.data.codes.get(
+      "tenantId",
+      "code",
+      "oauth2_state",
+    );
+    if (!oauth2Code) throw new Error("No oauth2_state code found");
+
+    const callbackResponse = await oauthClient.login.callback.$get({
+      query: { state: "code", code: "entra-mismatch" },
+    });
+    expect(callbackResponse.status).toEqual(302);
+
+    const user = await env.data.users.get(
+      "tenantId",
+      "mock-strategy|entra-oid-123",
+    );
+    if (!user?.profileData) throw new Error("User or profileData missing");
+    const profileData = JSON.parse(user.profileData);
+
+    // The full upstream claim set is captured...
+    expect(profileData).toMatchObject({
+      preferred_username: "alice@contoso.com",
+      upn: "alice@contoso.com",
+      unique_name: "alice@contoso.com",
+      oid: "00000000-aaaa-bbbb-cccc-111111111111",
+      tid: "contoso-tenant-guid",
+      email: "mail-attr@contoso.com",
+    });
+    // ...but the upstream `sub` is not duplicated into profileData (it maps to
+    // user_id).
+    expect(profileData.sub).toBeUndefined();
+  });
 });

--- a/packages/authhero/test/helpers/mock-strategy.ts
+++ b/packages/authhero/test/helpers/mock-strategy.ts
@@ -23,6 +23,14 @@ export const mockStrategy: Strategy = {
           sub: "foo",
           email: "foo@example.com",
         };
+      // Mimics an Entra/waad mismatch: the `email` claim is sourced from the
+      // `mail` attribute and differs from the sign-in identifier (upn /
+      // preferred_username). Used to assert the full claim set is captured.
+      case "entra-mismatch":
+        return {
+          sub: "entra-oid-123",
+          email: "mail-attr@contoso.com",
+        };
       case "vipps-user@example.com":
         return {
           sub: "vipps-456",
@@ -55,5 +63,36 @@ export const mockStrategy: Strategy = {
           email: "hello@example.com",
         };
     }
+  },
+  // Backward-compatible: returns raw: null for every existing code (so the
+  // callback keeps its prior profileData shape), and the full upstream claim
+  // set only for the `entra-mismatch` code used by the capture test.
+  validateAuthorizationCodeAndGetUserWithRaw: async (
+    ctx,
+    connection,
+    code: string,
+    codeVerifier?: string,
+  ) => {
+    const userinfo = await mockStrategy.validateAuthorizationCodeAndGetUser(
+      ctx,
+      connection,
+      code,
+      codeVerifier,
+    );
+    if (code === "entra-mismatch") {
+      return {
+        userinfo,
+        raw: {
+          sub: userinfo.sub,
+          email: userinfo.email,
+          preferred_username: "alice@contoso.com",
+          upn: "alice@contoso.com",
+          unique_name: "alice@contoso.com",
+          oid: "00000000-aaaa-bbbb-cccc-111111111111",
+          tid: "contoso-tenant-guid",
+        },
+      };
+    }
+    return { userinfo, raw: null };
   },
 };

--- a/packages/kysely/migrate/migrations/2026-06-30T12:00:00_user_activity_and_user_column_cleanup.ts
+++ b/packages/kysely/migrate/migrations/2026-06-30T12:00:00_user_activity_and_user_column_cleanup.ts
@@ -1,0 +1,126 @@
+import { Kysely, sql } from "kysely";
+import { Database } from "../../src/db";
+import { migrationLog } from "../log";
+
+/**
+ * Bundles three forward-only schema changes into a single PlanetScale rebuild
+ * (see issue #1003). The read/write cutover to `user_activity` and the
+ * `profileData` enrichment land in follow-up PRs — this migration only changes
+ * the schema, it does not move or backfill any data.
+ *
+ * 1. Converts the large, unbounded, non-indexed `users` columns to TEXT so they
+ *    are stored off-page (relieves InnoDB row-size pressure and removes the
+ *    length cap that today truncates enriched profile data).
+ * 2. Right-sizes a few oversized `users` varchars.
+ * 3. Adds an (empty) `user_activity` entity for the write-often counters that
+ *    currently churn the `users` row on every login / failed password attempt.
+ *
+ * The column changes only matter on MySQL/PlanetScale — SQLite has TEXT
+ * affinity and ignores varchar lengths, so we branch on dialect like the other
+ * column-altering migrations in this folder.
+ */
+
+async function getDatabaseType(
+  db: Kysely<Database>,
+): Promise<"mysql" | "sqlite"> {
+  try {
+    await sql`SELECT VERSION()`.execute(db);
+    return "mysql";
+  } catch {
+    return "sqlite";
+  }
+}
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  const dbType = await getDatabaseType(db);
+
+  if (dbType === "mysql") {
+    migrationLog(
+      "Converting users blob columns to TEXT and right-sizing oversized varchars...",
+    );
+
+    // Unbounded, non-indexed payloads → TEXT.
+    await db.schema.alterTable("users").modifyColumn("profileData", "text").execute();
+    await db.schema.alterTable("users").modifyColumn("picture", "text").execute();
+
+    // app_metadata is NOT NULL and create.ts can insert `undefined`, relying on
+    // the column default. TEXT cannot take a *literal* default, so use a MySQL
+    // 8.0.13+ expression default: `DEFAULT ('{}')`.
+    await db.schema
+      .alterTable("users")
+      .modifyColumn("app_metadata", "text", (col) =>
+        col.notNull().defaultTo(sql`('{}')`),
+      )
+      .execute();
+
+    // Oversized varchars → right-sized. App-generated ISO timestamps are ≤29
+    // chars and locale codes are short, so there is no truncation risk.
+    await db.schema
+      .alterTable("users")
+      .modifyColumn("created_at", "varchar(35)", (col) => col.notNull())
+      .execute();
+    await db.schema
+      .alterTable("users")
+      .modifyColumn("updated_at", "varchar(35)", (col) => col.notNull())
+      .execute();
+    await db.schema.alterTable("users").modifyColumn("locale", "varchar(64)").execute();
+  }
+
+  // Additive on both dialects. Mirrors the `grants` FK pattern: references the
+  // (user_id, tenant_id) key on users with ON DELETE CASCADE so stats are
+  // cleaned up with the user. Counters are populated/read in a follow-up PR.
+  await db.schema
+    .createTable("user_activity")
+    .ifNotExists()
+    .addColumn("tenant_id", "varchar(255)", (col) => col.notNull())
+    .addColumn("user_id", "varchar(255)", (col) => col.notNull())
+    .addColumn("last_login", "varchar(35)")
+    .addColumn("last_ip", "varchar(45)") // right-sized for IPv6
+    .addColumn("login_count", "integer", (col) => col.notNull().defaultTo(0))
+    .addColumn("failed_logins", "text") // JSON array of lockout timestamps
+    .addColumn("last_password_reset", "varchar(35)")
+    .addPrimaryKeyConstraint("user_activity_pkey", ["tenant_id", "user_id"])
+    .addForeignKeyConstraint(
+      "user_activity_user_id_constraint",
+      ["user_id", "tenant_id"],
+      "users",
+      ["user_id", "tenant_id"],
+      (cb) => cb.onDelete("cascade"),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  const dbType = await getDatabaseType(db);
+
+  await db.schema.dropTable("user_activity").ifExists().execute();
+
+  if (dbType === "mysql") {
+    await db.schema
+      .alterTable("users")
+      .modifyColumn("profileData", "varchar(2048)")
+      .execute();
+    await db.schema
+      .alterTable("users")
+      .modifyColumn("picture", "varchar(2083)")
+      .execute();
+    await db.schema
+      .alterTable("users")
+      .modifyColumn("app_metadata", "varchar(4096)", (col) =>
+        col.notNull().defaultTo("{}"),
+      )
+      .execute();
+    await db.schema
+      .alterTable("users")
+      .modifyColumn("created_at", "varchar(255)", (col) => col.notNull())
+      .execute();
+    await db.schema
+      .alterTable("users")
+      .modifyColumn("updated_at", "varchar(255)", (col) => col.notNull())
+      .execute();
+    await db.schema
+      .alterTable("users")
+      .modifyColumn("locale", "varchar(255)")
+      .execute();
+  }
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -174,6 +174,7 @@ import * as o075_create_grants from "./2026-06-04T11:00:00_create_grants";
 import * as o076_default_first_party_true from "./2026-06-04T11:01:00_default_first_party_true";
 import * as o077_tenant_deployment_fields from "./2026-06-06T12:00:00_tenant_deployment_fields";
 import * as o078_tenant_database_version from "./2026-06-27T12:00:00_tenant_database_version";
+import * as o079_user_activity_and_user_column_cleanup from "./2026-06-30T12:00:00_user_activity_and_user_column_cleanup";
 
 // These need to be in alphabetic order
 export default {
@@ -353,4 +354,5 @@ export default {
   o076_default_first_party_true,
   o077_tenant_deployment_fields,
   o078_tenant_database_version,
+  o079_user_activity_and_user_column_cleanup,
 };

--- a/packages/kysely/src/db.ts
+++ b/packages/kysely/src/db.ts
@@ -513,6 +513,17 @@ export interface Database {
   prompt_settings: z.infer<typeof sqlPromptSettingSchema>;
   refresh_tokens: z.infer<typeof sqlRefreshTokensSchema>;
   users: z.infer<typeof sqlUserSchema>;
+  // Write-often counters split out of `users` (issue #1003). Populated/read in
+  // a follow-up PR; the table exists empty until then.
+  user_activity: {
+    tenant_id: string;
+    user_id: string;
+    last_login: string | null;
+    last_ip: string | null;
+    login_count: number;
+    failed_logins: string | null; // JSON array of lockout timestamps
+    last_password_reset: string | null;
+  };
   sessions: z.infer<typeof sqlSessionSchema>;
   tenants: z.infer<typeof sqlTenantSchema>;
   themes: z.infer<typeof sqlThemeSchema>;

--- a/packages/kysely/src/index.ts
+++ b/packages/kysely/src/index.ts
@@ -48,6 +48,7 @@ import { createOutboxAdapter } from "./outbox";
 import { createLogStreamsAdapter } from "./log-streams";
 import { createMigrationSourcesAdapter } from "./migrationSources";
 import { createProxyRoutesAdapter } from "./proxyRoutes";
+import { createUserActivityAdapter } from "./userActivity";
 
 export { migrateToLatest, migrateDown } from "../migrate/migrate";
 export type { Database } from "./db";
@@ -102,6 +103,7 @@ export default function createAdapters(
     universalLoginTemplates: createUniversalLoginTemplatesAdapter(db),
     customText: createCustomTextAdapter(db),
     users: createUsersAdapter(db),
+    userActivity: createUserActivityAdapter(db),
     organizations: createOrganizationsAdapter(db),
     organizationConnections: createOrganizationConnectionsAdapter(db),
     userOrganizations: createUserOrganizationsAdapter(db),

--- a/packages/kysely/src/userActivity/index.ts
+++ b/packages/kysely/src/userActivity/index.ts
@@ -1,0 +1,112 @@
+import { Kysely } from "kysely";
+import {
+  UserActivity,
+  UserActivityAdapter,
+  UserActivityUpdate,
+} from "@authhero/adapter-interfaces";
+import { Database } from "../db";
+
+type UserActivityRow = Database["user_activity"];
+
+function rowToActivity(row: UserActivityRow): UserActivity {
+  return {
+    user_id: row.user_id,
+    last_login: row.last_login ?? undefined,
+    last_ip: row.last_ip ?? undefined,
+    login_count: row.login_count,
+    failed_logins: row.failed_logins
+      ? (JSON.parse(row.failed_logins) as string[])
+      : undefined,
+    last_password_reset: row.last_password_reset ?? undefined,
+  };
+}
+
+// Maps the domain update onto storage columns, serializing failed_logins.
+// Only keys that are explicitly provided are included, so an upsert never
+// clobbers a field the caller didn't set.
+function toColumns(activity: UserActivityUpdate): {
+  last_login?: string;
+  last_ip?: string;
+  login_count?: number;
+  failed_logins?: string;
+  last_password_reset?: string;
+} {
+  const columns: {
+    last_login?: string;
+    last_ip?: string;
+    login_count?: number;
+    failed_logins?: string;
+    last_password_reset?: string;
+  } = {};
+  if (activity.last_login !== undefined) columns.last_login = activity.last_login;
+  if (activity.last_ip !== undefined) columns.last_ip = activity.last_ip;
+  if (activity.login_count !== undefined)
+    columns.login_count = activity.login_count;
+  if (activity.failed_logins !== undefined)
+    columns.failed_logins = JSON.stringify(activity.failed_logins);
+  if (activity.last_password_reset !== undefined)
+    columns.last_password_reset = activity.last_password_reset;
+  return columns;
+}
+
+export function createUserActivityAdapter(
+  db: Kysely<Database>,
+): UserActivityAdapter {
+  return {
+    async get(tenantId, userId) {
+      const row = await db
+        .selectFrom("user_activity")
+        .where("tenant_id", "=", tenantId)
+        .where("user_id", "=", userId)
+        .selectAll()
+        .executeTakeFirst();
+      return row ? rowToActivity(row) : null;
+    },
+
+    // No cross-dialect UPSERT helper exists in this codebase, so follow the
+    // grants adapter's select-then-insert-or-update pattern, with an
+    // insert-race fallback to update (concurrent first logins).
+    async upsert(tenantId, userId, activity) {
+      const columns = toColumns(activity);
+
+      const existing = await db
+        .selectFrom("user_activity")
+        .where("tenant_id", "=", tenantId)
+        .where("user_id", "=", userId)
+        .select("user_id")
+        .executeTakeFirst();
+
+      if (existing) {
+        if (Object.keys(columns).length === 0) return;
+        await db
+          .updateTable("user_activity")
+          .set(columns)
+          .where("tenant_id", "=", tenantId)
+          .where("user_id", "=", userId)
+          .execute();
+        return;
+      }
+
+      try {
+        await db
+          .insertInto("user_activity")
+          .values({
+            tenant_id: tenantId,
+            user_id: userId,
+            login_count: 0,
+            ...columns,
+          })
+          .execute();
+      } catch {
+        // Lost the insert race with a concurrent first write — update instead.
+        if (Object.keys(columns).length === 0) return;
+        await db
+          .updateTable("user_activity")
+          .set(columns)
+          .where("tenant_id", "=", tenantId)
+          .where("user_id", "=", userId)
+          .execute();
+      }
+    },
+  };
+}

--- a/packages/kysely/test/userActivity/crud.spec.ts
+++ b/packages/kysely/test/userActivity/crud.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+
+async function bootstrap(tenantId = "tenantId", userId = "auth2|user_1") {
+  const { data } = await getTestServer();
+  await data.tenants.create({
+    id: tenantId,
+    friendly_name: "Test Tenant",
+    audience: "https://example.com",
+    sender_email: "login@example.com",
+    sender_name: "SenderName",
+  });
+  await data.users.create(tenantId, {
+    user_id: userId,
+    email: "alice@example.com",
+    email_verified: true,
+    provider: "auth2",
+    connection: "Username-Password-Authentication",
+    is_social: false,
+    name: "Alice",
+  });
+  return { data, tenantId, userId };
+}
+
+describe("userActivity", () => {
+  it("returns null when no row exists", async () => {
+    const { data, tenantId, userId } = await bootstrap();
+    expect(await data.userActivity!.get(tenantId, userId)).toBeNull();
+  });
+
+  it("inserts on first upsert", async () => {
+    const { data, tenantId, userId } = await bootstrap();
+
+    await data.userActivity!.upsert(tenantId, userId, {
+      last_login: "2026-06-30T10:00:00.000Z",
+      last_ip: "203.0.113.7",
+      login_count: 1,
+    });
+
+    const activity = await data.userActivity!.get(tenantId, userId);
+    expect(activity).toMatchObject({
+      user_id: userId,
+      last_login: "2026-06-30T10:00:00.000Z",
+      last_ip: "203.0.113.7",
+      login_count: 1,
+    });
+  });
+
+  it("merge-updates without clobbering unset fields", async () => {
+    const { data, tenantId, userId } = await bootstrap();
+
+    await data.userActivity!.upsert(tenantId, userId, {
+      last_login: "2026-06-30T10:00:00.000Z",
+      last_ip: "203.0.113.7",
+      login_count: 1,
+    });
+    // Second login only bumps the counter + timestamps; last_ip stays unless set.
+    await data.userActivity!.upsert(tenantId, userId, {
+      last_login: "2026-06-30T11:00:00.000Z",
+      login_count: 2,
+    });
+
+    const activity = await data.userActivity!.get(tenantId, userId);
+    expect(activity).toMatchObject({
+      last_login: "2026-06-30T11:00:00.000Z",
+      last_ip: "203.0.113.7", // preserved
+      login_count: 2,
+    });
+  });
+
+  it("round-trips failed_logins as a JSON array", async () => {
+    const { data, tenantId, userId } = await bootstrap();
+
+    await data.userActivity!.upsert(tenantId, userId, {
+      failed_logins: ["2026-06-30T10:00:00.000Z", "2026-06-30T10:01:00.000Z"],
+    });
+
+    const activity = await data.userActivity!.get(tenantId, userId);
+    expect(activity?.failed_logins).toEqual([
+      "2026-06-30T10:00:00.000Z",
+      "2026-06-30T10:01:00.000Z",
+    ]);
+    // login_count defaults to 0 when the row is created by a non-login write.
+    expect(activity?.login_count).toBe(0);
+  });
+});


### PR DESCRIPTION
Expand phase of #1003. Schema + double-write only — deploy-ready; reads stay on the legacy `users` columns. Backfill is manual; a follow-up PR flips reads and drops the old fields.

## Migration (`@authhero/kysely-adapter`, `o079`, one online rebuild)
- Convert large non-indexed `users` columns `profileData`, `picture`, `app_metadata` from `varchar` → `TEXT` (enriched profile data no longer capped/truncated; relieves InnoDB row-size pressure). `app_metadata` keeps its `'{}'` default via a MySQL 8 expression default. MySQL-branched — no-op on SQLite/D1 (TEXT affinity already unbounded).
- Right-size oversized varchars: `created_at`/`updated_at` → `varchar(35)`, `locale` → `varchar(64)`.
- Add empty `user_activity` table (PK `(tenant_id, user_id)`, FK to `users` `ON DELETE CASCADE`) for the write-often counters.

## `user_activity` adapter
- **adapter-interfaces**: `UserActivity` type + **optional** `UserActivityAdapter` (`get` + merge-`upsert`) on `DataAdapters`. Optional so drizzle/other adapters are unaffected.
- **kysely**: implement the adapter (select-then-insert-or-update with an insert-race fallback, matching the `grants` pattern) and wire into `createAdapters`.

## authhero
- **Capture full upstream claims**: the connection callback now prefers each strategy's `validateAuthorizationCodeAndGetUserWithRaw` variant and persists the entire decoded claim set (id_token/userinfo claims — no tokens/secrets) to `profileData`, making `upn`/`preferred_username`/`unique_name`/`oid` durable (Auth0 `identities[].profileData` parity). Added a `WithRaw` variant to the `waad`/Entra strategy. Strategies without `WithRaw` are unchanged (`raw: null`).
- **Double-write** login counters (`last_login`, `last_ip`, `login_count`) to `user_activity` alongside the legacy `users` columns, guarded on the optional adapter.

## Tests
- kysely `userActivity` adapter: 4 deterministic tests (insert, merge-update preserving unset fields, `failed_logins` JSON round-trip, null).
- authhero: new profileData-capture test asserts the full claim set lands in `profileData` while `email` stays the (mismatched) `mail` claim; 44 mock-strategy specs pass.
- All packages typecheck clean.

### Caveat
The double-write isn't asserted through the full login flow — the login-path `waitUntil` writes aren't drained in that callback test harness (the existing `users.update` `login_count` bump isn't observable in tests either). It runs via `executionCtx.waitUntil` in production; coverage is at the adapter level + the wiring mirrors the existing `users.update`.

## Deferred to follow-up PRs
- Read cutover (hydrate Auth0 `UserResponse` from `user_activity`), manual backfill, dropping the moved `users` columns.
- `failed_logins` migration out of `app_metadata` (the riskier behavioral cutover).
- drizzle `user_activity` table (added when it's consumed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection sign-in now preserves more account details from enterprise providers, improving the information stored in user profiles.
  * Added support for tracking user login activity separately, including last login, IP address, and login count.

* **Bug Fixes**
  * Reduced risk of data loss by storing larger profile fields more safely.
  * Login activity updates now persist consistently even when some information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->