### PR TITLE
fix(authhero): resume DCR connect flow after cold-user login (#1006)

### DIFF
--- a/.changeset/connect-flow-cold-login-continuation.md
+++ b/.changeset/connect-flow-cold-login-continuation.md
@@ -1,0 +1,9 @@
+---
+"authhero": patch
+---
+
+Fix the DCR `/connect/start` consent flow for cold (no-session) users (issue #1006).
+
+A user who entered the connect flow without an existing session was bounced to login, authenticated, and then dead-ended with `State not found` / `Redirect uri not found for this response mode.` instead of returning to consent — because the connect login session carries no `redirect_uri`/`response_type` and nothing resumed the connect screen after login.
+
+Login completion now detects a connect login session (via `state_data.connect`) and, once the user is authenticated (and MFA satisfied), redirects back to `/u2/connect/start` with the auth cookie set instead of attempting a front-channel OAuth response. The social callback's `redirect_uri` guard is likewise relaxed for connect sessions. Covers both the passwordless (email OTP) and social login paths.

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -45,6 +45,7 @@ import renderAuthIframe from "../utils/authIframe";
 import { formPostResponse } from "../utils/form-post";
 import { calculateScopesAndPermissions } from "../helpers/scopes-permissions";
 import { getMissingConsentScopes } from "../helpers/consent";
+import { isConnectLoginSession } from "../helpers/dcr/connect-state";
 import {
   buildScopeClaims,
   buildRequestedClaims,
@@ -1737,6 +1738,30 @@ export async function createFrontChannelAuthResponse(
           });
         }
       }
+    }
+
+    // ========================================================================
+    // CONNECT (DCR consent) CONTINUATION
+    // ========================================================================
+    // A /connect/start login session is not a real OAuth request: it carries
+    // no redirect_uri/response_type and exists only to authenticate the user
+    // for the DCR consent screen. Once the user is authenticated (and MFA, if
+    // required, has been satisfied above), hand control back to the connect
+    // screen instead of issuing tokens — there is no redirect_uri to honor.
+    // The auth cookie is set here so the consent screen resolves the session
+    // we just authenticated.
+    if (session_id && isConnectLoginSession(currentLoginSession.state_data)) {
+      const connectHeaders = new Headers();
+      serializeAuthCookie(
+        client.tenant.id,
+        session_id,
+        ctx.var.host || "",
+      ).forEach((cookie) => connectHeaders.append("set-cookie", cookie));
+      connectHeaders.set(
+        "location",
+        `/u2/connect/start?state=${encodeURIComponent(params.loginSession.id)}`,
+      );
+      return new Response(null, { status: 302, headers: connectHeaders });
     }
   }
 

--- a/packages/authhero/src/authentication-flows/connection.ts
+++ b/packages/authhero/src/authentication-flows/connection.ts
@@ -25,6 +25,7 @@ import { prefetchClientBundle } from "../helpers/prefetch-client-bundle";
 import { isCimdClientId } from "../helpers/cimd";
 import { getOrCreateUserByProvider } from "../helpers/users";
 import { finalizeAuthenticatedSession } from "./common";
+import { isConnectLoginSession } from "../helpers/dcr/connect-state";
 import { setTenantId } from "../helpers/set-tenant-id";
 import { writeTryConnectionResult } from "./try-connection";
 import { nanoid } from "nanoid";
@@ -186,7 +187,15 @@ export async function connectionCallback(
 
   ctx.set("connection", connection.name);
 
-  if (!loginSession.authParams.redirect_uri) {
+  // A /connect/start login session carries no redirect_uri — it authenticates
+  // the user for the DCR consent flow rather than issuing tokens. Skip the
+  // redirect_uri requirement for it; finalizeAuthenticatedSession →
+  // /authorize/resume → createFrontChannelAuthResponse hands control back to
+  // the connect screen.
+  if (
+    !isConnectLoginSession(loginSession.state_data) &&
+    !loginSession.authParams.redirect_uri
+  ) {
     await logMessage(ctx, client.tenant.id, {
       type: LogTypes.FAILED_LOGIN,
       description: "Redirect URI not defined",

--- a/packages/authhero/src/helpers/dcr/connect-state.ts
+++ b/packages/authhero/src/helpers/dcr/connect-state.ts
@@ -1,0 +1,23 @@
+/**
+ * A `/connect/start` login session stashes its DCR consent context under
+ * `state_data.connect` (see routes/auth-api/connect-start.ts). Such a session
+ * is NOT a real OAuth request — it carries no `redirect_uri`/`response_type`
+ * and exists only to authenticate the user for the DCR consent screen.
+ *
+ * Both the login-completion path (createFrontChannelAuthResponse) and the
+ * social callback (connectionCallback) use this predicate to recognize a
+ * connect session so they hand control back to `/u2/connect/start` instead of
+ * attempting a normal front-channel OAuth response (which would dead-end on
+ * the missing redirect_uri).
+ */
+export function isConnectLoginSession(
+  stateDataJson?: string | null,
+): boolean {
+  if (!stateDataJson) return false;
+  try {
+    const parsed = JSON.parse(stateDataJson) as { connect?: unknown };
+    return Boolean(parsed?.connect);
+  } catch {
+    return false;
+  }
+}

--- a/packages/authhero/test/authentication-flows/connect-continuation.spec.ts
+++ b/packages/authhero/test/authentication-flows/connect-continuation.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { testClient } from "hono/testing";
+import { AuthorizationResponseType } from "@authhero/adapter-interfaces";
+import { getTestServer } from "../helpers/test-server";
+import { isConnectLoginSession } from "../../src/helpers/dcr/connect-state";
+
+/**
+ * Regression coverage for #1006: a cold (no-session) user who enters the DCR
+ * `/connect/start` flow, gets bounced to login, and authenticates must be
+ * handed back to `/u2/connect/start` — NOT dead-ended on the missing
+ * redirect_uri. The connect login session carries `state_data.connect` and no
+ * redirect_uri/response_type.
+ */
+describe("connect flow login continuation", () => {
+  it("passwordless completion returns to /u2/connect/start with an auth cookie", async () => {
+    const { universalApp, env } = await getTestServer({ mockEmail: true });
+    const universalClient = testClient(universalApp, env);
+
+    // State after /connect/start bounced a cold user to login and they
+    // submitted their email: a connect login session (no redirect_uri, with a
+    // username) plus a live OTP code linked to it.
+    const loginSession = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+      authParams: {
+        client_id: "clientId",
+        username: "connect-user@example.com",
+        state: "csrf-abc",
+      },
+      csrf_token: "csrf-token",
+      state_data: JSON.stringify({
+        connect: {
+          integration_type: "wordpress",
+          domain: "publisher.com",
+          return_to: "https://publisher.com/wp-admin/connect-callback",
+          caller_state: "csrf-abc",
+        },
+      }),
+    });
+
+    await env.data.codes.create("tenantId", {
+      code_id: "123456",
+      code_type: "otp",
+      login_id: loginSession.id,
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const response = await universalClient.login["email-otp-challenge"].$post({
+      query: { state: loginSession.id },
+      form: { code: "123456" },
+    });
+
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    if (!location) throw new Error("No location header");
+    const url = new URL(location, "http://localhost");
+    expect(url.pathname).toBe("/u2/connect/start");
+    expect(url.searchParams.get("state")).toBe(loginSession.id);
+
+    // Auth cookie is set so the consent screen resolves the freshly
+    // authenticated session.
+    expect(response.headers.get("set-cookie")).toBeTruthy();
+
+    // The session must NOT have been completed as an OAuth request.
+    const after = await env.data.loginSessions.get("tenantId", loginSession.id);
+    expect(after?.state).not.toBe("completed");
+    expect(after?.session_id).toBeTruthy();
+  });
+
+  it("social completion returns to /u2/connect/start (redirect_uri guard relaxed)", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    // Connect login session (no redirect_uri) as created by /connect/start.
+    const loginSession = await env.data.loginSessions.create("tenantId", {
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+      authParams: { client_id: "clientId", state: "csrf-abc" },
+      csrf_token: "csrf-token",
+      state_data: JSON.stringify({
+        connect: {
+          domain: "publisher.com",
+          return_to: "https://publisher.com/wp-admin/connect-callback",
+          caller_state: "csrf-abc",
+        },
+      }),
+    });
+
+    // User picks the social connection on the connect login screen. /authorize
+    // hydrates the connect session and dispatches to the strategy.
+    const authorizeResponse = await oauthClient.authorize.$get(
+      {
+        query: {
+          client_id: "clientId",
+          connection: "mock-strategy",
+          state: loginSession.id,
+          response_type: AuthorizationResponseType.CODE,
+        },
+      },
+      { headers: { origin: "https://example.com" } },
+    );
+    expect(authorizeResponse.status).toBe(302);
+
+    // Social callback must NOT 403 on the missing redirect_uri — it finalizes
+    // and 302s to /authorize/resume.
+    const callbackResponse = await oauthClient.login.callback.$get({
+      query: { state: "code", code: "entra-mismatch" },
+    });
+    expect(callbackResponse.status).toBe(302);
+    const resumeLocation = callbackResponse.headers.get("location");
+    if (!resumeLocation) throw new Error("No resume location");
+    const resumeUrl = new URL(resumeLocation, "http://localhost");
+    expect(resumeUrl.pathname).toBe("/authorize/resume");
+
+    // Following resume hands control back to the connect screen.
+    const resumeResponse = await oauthApp.request(
+      `/authorize/resume?state=${encodeURIComponent(loginSession.id)}`,
+      { method: "GET" },
+      env,
+    );
+    expect(resumeResponse.status).toBe(302);
+    const finalUrl = new URL(
+      resumeResponse.headers.get("location")!,
+      "http://localhost",
+    );
+    expect(finalUrl.pathname).toBe("/u2/connect/start");
+    expect(finalUrl.searchParams.get("state")).toBe(loginSession.id);
+  });
+});
+
+describe("isConnectLoginSession", () => {
+  it("detects a connect session by state_data.connect", () => {
+    expect(
+      isConnectLoginSession(JSON.stringify({ connect: { domain: "x.com" } })),
+    ).toBe(true);
+  });
+
+  it("returns false for non-connect / empty / malformed state_data", () => {
+    expect(isConnectLoginSession(undefined)).toBe(false);
+    expect(isConnectLoginSession(null)).toBe(false);
+    expect(isConnectLoginSession("")).toBe(false);
+    expect(isConnectLoginSession(JSON.stringify({ mfa_verified: true }))).toBe(
+      false,
+    );
+    expect(isConnectLoginSession("{not json")).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #1006.

## Problem

The DCR `/connect/start` consent flow only works when the user **already has a session** on the tenant the flow runs against. A cold user — no existing session, which is exactly the external-developer case — gets bounced to login, authenticates, and then dead-ends with `State not found` / `Redirect uri not found for this response mode.` instead of returning to consent.

The connect login session carries no `redirect_uri`/`response_type` (its intent lives in `state_data.connect`), and nothing on the login-completion path resumed the connect screen — so completion tried to build a normal front-channel OAuth response and failed.

## Fix

- **New helper** `isConnectLoginSession(state_data)` (`helpers/dcr/connect-state.ts`) — recognizes a connect login session by its `state_data.connect` marker. Single source of truth for both paths.
- **Continuation** in `createFrontChannelAuthResponse` (`common.ts`): after the user is authenticated and MFA (if required) is satisfied, a connect session sets the auth cookie and 302s back to `/u2/connect/start?state=<id>` instead of issuing tokens. This is the single funnel both paths reach:
  - passwordless → `passwordlessGrant` → `createFrontChannelAuthResponse`
  - social → `connectionCallback` → `finalizeAuthenticatedSession` → `/authorize/resume` → `createFrontChannelAuthResponse`
- **Social early guard** in `connectionCallback` (`connection.ts`): the `redirect_uri`-required check is skipped for connect sessions so the social path reaches the continuation instead of throwing `Redirect URI not defined`.

## Tests

New `connect-continuation.spec.ts`:
- passwordless completion → asserts redirect to `/u2/connect/start`, auth cookie set, session not completed as an OAuth request
- social completion end-to-end (callback → resume → connect)
- `isConnectLoginSession` unit coverage

`authentication-flows/` + `universal-login/` suites pass (264 tests); the changed files typecheck clean.

## Scope / follow-ups (not in this PR)

- Requires the tenant's `default_client_id` to point at a proper interactive client (config change) — otherwise the anchor still resolves to a non-interactive client.
- Anchor-resolution hardening + auto-provisioned Default App → #1007.
- Fail-fast grant-type guard at `/authorize` for non-interactive clients → tracked in #1006's design notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the login-to-consent flow for cold users, so authentication now resumes the connect process instead of ending in an error.
  * Fixed both passwordless and social login paths to return users to the connect screen after signing in, including MFA.
  * Relaxed redirect handling for connect sessions so the flow no longer fails when a redirect value is unavailable.
* **Tests**
  * Added coverage for connect-flow continuation and session detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->