### PR TITLE
feat(hooks): add onExecutePostUserUpdate hook

### DIFF
--- a/packages/authhero/src/hooks/user-update.ts
+++ b/packages/authhero/src/hooks/user-update.ts
@@ -274,6 +274,38 @@ export function createUserUpdateHooks(
       });
     }
 
+    // Post-update JS hook runs after the commit (and any post-user-update
+    // template hooks) so consumers observe the persisted record — e.g. to
+    // force-sync a downstream cache that pulls from the updated user rather
+    // than being handed the new values. Failures are logged, never thrown:
+    // the update is already committed.
+    if (ctx.env.hooks?.onExecutePostUserUpdate) {
+      try {
+        const updatedUser = await data.users.get(tenant_id, user_id);
+        await ctx.env.hooks.onExecutePostUserUpdate(
+          {
+            ctx,
+            tenant: { id: tenant_id },
+            user_id,
+            user: updatedUser
+              ? stripInternalUserFields(updatedUser)
+              : undefined,
+            updates,
+            request,
+          },
+          {
+            token: createTokenAPI(ctx, tenant_id),
+          },
+        );
+      } catch (err) {
+        logMessage(ctx, tenant_id, {
+          type: LogTypes.ACTIONS_EXECUTION_FAILED,
+          description: `Post user update hook failed: ${err instanceof Error ? err.message : "Unknown error"}`,
+          userId: user_id,
+        });
+      }
+    }
+
     return true;
   };
 }

--- a/packages/authhero/src/types/Hooks.ts
+++ b/packages/authhero/src/types/Hooks.ts
@@ -233,6 +233,15 @@ export type OnExecutePreUserUpdate = (
   api: OnExecutePreUserUpdateAPI,
 ) => Promise<void>;
 
+export type OnExecutePostUserUpdateAPI = {
+  token: TokenAPI;
+};
+
+export type OnExecutePostUserUpdate = (
+  event: HookEvent & { user_id: string; updates: Partial<User> },
+  api: OnExecutePostUserUpdateAPI,
+) => Promise<void>;
+
 export type OnExecutePostLoginAPI = {
   prompt: {
     render: (formId: string) => void;
@@ -325,6 +334,7 @@ export type Hooks = {
   onExecutePreUserRegistration?: OnExecutePreUserRegistration;
   onExecutePostUserRegistration?: OnExecutePostUserRegistration;
   onExecutePreUserUpdate?: OnExecutePreUserUpdate;
+  onExecutePostUserUpdate?: OnExecutePostUserUpdate;
   onExecutePostLogin?: OnExecutePostLogin;
   onExecutePreUserDeletion?: OnExecutePreUserDeletion;
   onExecutePostUserDeletion?: OnExecutePostUserDeletion;

--- a/packages/authhero/test/hooks/on-post-user-update.spec.ts
+++ b/packages/authhero/test/hooks/on-post-user-update.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+import { HookEvent, OnExecutePostUserUpdateAPI } from "../../src/types/Hooks";
+import { testClient } from "hono/testing";
+import { getAdminToken } from "../helpers/token";
+import { User, Strategy } from "@authhero/adapter-interfaces";
+
+describe("on-post-user-update-hook", () => {
+  it("fires after the commit with the persisted user and applied updates", async () => {
+    let capturedUser: User | undefined;
+    let capturedUpdates: Partial<User> | undefined;
+
+    const { env, managementApp } = await getTestServer({
+      hooks: {
+        onExecutePostUserUpdate: async (
+          event: HookEvent & { user_id: string; updates: Partial<User> },
+          _api: OnExecutePostUserUpdateAPI,
+        ) => {
+          capturedUser = event.user;
+          capturedUpdates = event.updates;
+        },
+      },
+    });
+
+    const client = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const createUserResponse = await client.users.$post(
+      {
+        json: {
+          email: "test-post-update@example.com",
+          connection: Strategy.USERNAME_PASSWORD,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(createUserResponse.status).toBe(201);
+    const createdUser = await createUserResponse.json();
+
+    const updateUserResponse = await client.users[":user_id"].$patch(
+      {
+        json: {
+          given_name: "Updated Name",
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+        param: {
+          user_id: createdUser.user_id,
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(updateUserResponse.status).toBe(200);
+
+    // The hook sees the applied change in `updates`...
+    expect(capturedUpdates?.given_name).toBe("Updated Name");
+    // ...and the persisted user reflects it (fetched after the commit).
+    expect(capturedUser?.given_name).toBe("Updated Name");
+    expect(capturedUser?.user_id).toBe(createdUser.user_id);
+  });
+
+  it("does not fail the update when the hook throws (update already committed)", async () => {
+    const { env, managementApp } = await getTestServer({
+      hooks: {
+        onExecutePostUserUpdate: async () => {
+          throw new Error("post-update hook boom");
+        },
+      },
+    });
+
+    const client = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const createUserResponse = await client.users.$post(
+      {
+        json: {
+          email: "test-post-update-throw@example.com",
+          connection: Strategy.USERNAME_PASSWORD,
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(createUserResponse.status).toBe(201);
+    const createdUser = await createUserResponse.json();
+
+    const updateUserResponse = await client.users[":user_id"].$patch(
+      {
+        json: {
+          given_name: "Persisted Despite Hook",
+        },
+        header: {
+          "tenant-id": "tenantId",
+        },
+        param: {
+          user_id: createdUser.user_id,
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    // Update succeeds even though the post-update hook threw.
+    expect(updateUserResponse.status).toBe(200);
+    const updatedUser = (await updateUserResponse.json()) as Partial<User>;
+    expect(updatedUser.given_name).toBe("Persisted Despite Hook");
+  });
+});


### PR DESCRIPTION
## What

Adds an `onExecutePostUserUpdate` JS hook, the post-commit counterpart to the existing `onExecutePreUserUpdate`.

- New `OnExecutePostUserUpdate` / `OnExecutePostUserUpdateAPI` types + the `onExecutePostUserUpdate?` slot on `Hooks`.
- Fired in `createUserUpdateHooks` **after** the update transaction commits (and after any `post-user-update` template hooks), passing the freshly-fetched persisted `user` plus the applied `updates`.
- Hook failures are logged (`ACTIONS_EXECUTION_FAILED`), never thrown — the update is already committed. Same policy as `onExecutePostUserDeletion`.

## Why

A pre-update hook only sees the *old* persisted values, so it can't drive **pull-based** propagation — e.g. telling a downstream service to re-read the updated user from auth. The concrete driver: Sesamy's `auth` force-syncs the profile cache on email change; doing that in the pre-update hook re-reads auth *before* the new email is committed and caches stale data. A post-commit hook fixes that.

## Testing

- New `test/hooks/on-post-user-update.spec.ts` — verifies the hook fires after commit with the persisted user + applied updates, and that a throwing hook does not fail the update. Both pass.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a post-user-update hook that runs after a user profile update is saved.
  * The hook now receives the latest updated user data, the applied changes, and token-related helpers.

* **Bug Fixes**
  * Hook failures no longer block a completed user update.
  * Errors from the new post-update hook are safely logged so the request can still succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->