### PR TITLE
chore: add missing changeset for onExecutePostUserUpdate hook

### DIFF
--- a/.changeset/on-post-user-update-hook.md
+++ b/.changeset/on-post-user-update-hook.md
@@ -1,0 +1,5 @@
+---
+"authhero": minor
+---
+
+Add `onExecutePostUserUpdate` hook that fires after a user is updated (missing changeset for #1012).


### PR DESCRIPTION
PR #1012 (`feat(hooks): add onExecutePostUserUpdate hook`) merged without a changeset. This adds the missing `minor` changeset for `authhero` so the new hook gets released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a post-user-update hook that runs after a user profile is updated.
  * Included a minor release note update for the `authhero` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->