### PR TITLE
Fix local dev experience for create-authhero scaffolds

### DIFF
--- a/.changeset/admin-same-origin-protocol.md
+++ b/.changeset/admin-same-origin-protocol.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": patch
+---
+
+Fix the admin UI calling http://localhost:3000/oauth/token when served from an https auth server. buildUrlWithProtocol now follows the page's own protocol for same-origin domains and defaults other schemeless domains to https instead of forcing http for loopback hosts; an explicit http:// URL is still respected for local servers.

--- a/.changeset/local-admin-ui-portal-link.md
+++ b/.changeset/local-admin-ui-portal-link.md
@@ -1,0 +1,5 @@
+---
+"create-authhero": patch
+---
+
+Point the local template's startup banner at the bundled admin UI (https://localhost:3000/admin) instead of the hosted portal at local.authhero.net when @authhero/admin is installed, and fix the CLI success messages to use https URLs matching the local dev server. Documentation links now point to https://docs.authhero.net instead of the outdated https://authhero.net/docs.

--- a/.changeset/login-wrong-credentials-message.md
+++ b/.changeset/login-wrong-credentials-message.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Show "Wrong username or password" on the combined login screen when the password is wrong, instead of leaking the raw i18n key "wrong-credentials". The screen translates against the login.login prompt whose Auth0 locale key is camelCase (wrongCredentials); the kebab-case key only exists for the login-id and login-password prompts.

--- a/.changeset/setup-validation-and-https-admin.md
+++ b/.changeset/setup-validation-and-https-admin.md
@@ -1,0 +1,6 @@
+---
+"authhero": patch
+"create-authhero": patch
+---
+
+The /setup screen now shows an error message when the password is too short (or the identifier is empty) instead of failing with a bare 400 the widget can't display. The local template's generated app.ts defaults the admin UI config to the https issuer so the admin UI no longer links to http://localhost:3000, and the seed script includes the https://localhost:3000 callback and logout URLs.

--- a/apps/admin/src/utils/domainUtils.test.ts
+++ b/apps/admin/src/utils/domainUtils.test.ts
@@ -1,5 +1,47 @@
+// @vitest-environment jsdom
+// @vitest-environment-options {"url": "https://localhost:3000/admin"}
 import { describe, it, expect } from "vitest";
-import { deriveTenantSubdomainUrl } from "./domainUtils";
+import { buildUrlWithProtocol, deriveTenantSubdomainUrl } from "./domainUtils";
+
+describe("buildUrlWithProtocol", () => {
+  it("follows the page protocol for a same-origin domain without scheme", () => {
+    // The bundled admin UI is served from the auth server itself (here
+    // https://localhost:3000/admin), so its API must use the same protocol.
+    expect(buildUrlWithProtocol("localhost:3000")).toBe(
+      "https://localhost:3000",
+    );
+  });
+
+  it("defaults to https for other domains without scheme", () => {
+    expect(buildUrlWithProtocol("localhost:4000")).toBe(
+      "https://localhost:4000",
+    );
+    expect(buildUrlWithProtocol("auth.example.com")).toBe(
+      "https://auth.example.com",
+    );
+  });
+
+  it("preserves an explicit http scheme for loopback hosts", () => {
+    expect(buildUrlWithProtocol("http://localhost:8787")).toBe(
+      "http://localhost:8787",
+    );
+    expect(buildUrlWithProtocol("http://127.0.0.1:3000")).toBe(
+      "http://127.0.0.1:3000",
+    );
+  });
+
+  it("upgrades an explicit http scheme to https for non-loopback hosts", () => {
+    expect(buildUrlWithProtocol("http://auth.example.com")).toBe(
+      "https://auth.example.com",
+    );
+  });
+
+  it("preserves an explicit https scheme", () => {
+    expect(buildUrlWithProtocol("https://localhost:3000")).toBe(
+      "https://localhost:3000",
+    );
+  });
+});
 
 describe("deriveTenantSubdomainUrl", () => {
   it("prefixes the tenant id as a subdomain", () => {

--- a/apps/admin/src/utils/domainUtils.ts
+++ b/apps/admin/src/utils/domainUtils.ts
@@ -192,9 +192,12 @@ export const getClientIdFromStorage = (domain: string): string => {
 
 /**
  * Constructs a full URL with the appropriate protocol
- * - Uses http:// for localhost and 127.0.0.1 (no self-signed certs needed locally)
- * - Uses https:// for all other domains
- * - Upgrades http:// to https:// for non-loopback hosts
+ * - Preserves an explicit http:// for loopback hosts; upgrades it to https://
+ *   for everything else
+ * - Without a scheme, a domain matching the page's own host follows the page
+ *   protocol (the bundled admin UI is always same-origin with its API), and
+ *   any other host gets https:// — local templates serve TLS, and plain-http
+ *   servers can still be reached with an explicit http:// URL
  */
 export const buildUrlWithProtocol = (domain: string): string => {
   const trimmedDomain = domain.trim();
@@ -222,9 +225,9 @@ export const buildUrlWithProtocol = (domain: string): string => {
     return trimmedDomain;
   }
 
-  // No scheme provided — use http for loopback, https otherwise
-  if (isLoopback(parsed.hostname)) {
-    return `http://${trimmedDomain}`;
+  // No scheme provided — same-origin domains follow the page protocol
+  if (typeof window !== "undefined" && parsed.host === window.location.host) {
+    return `${window.location.protocol}//${trimmedDomain}`;
   }
 
   return `https://${trimmedDomain}`;

--- a/packages/authhero/src/routes/setup.tsx
+++ b/packages/authhero/src/routes/setup.tsx
@@ -184,11 +184,14 @@ export default function createSetupApp(config: AuthHeroConfig) {
         body: {
           content: {
             "application/json": {
+              // Field rules are checked in the handler so failures render the
+              // setup screen with an error message instead of a bare 400 the
+              // widget can't display.
               schema: z.object({
                 data: z.object({
-                  identifier: z.string().trim().min(1),
-                  password: z.string().min(8),
-                  confirm_password: z.string().min(8),
+                  identifier: z.string().trim(),
+                  password: z.string(),
+                  confirm_password: z.string(),
                   name: z.string().optional(),
                 }),
               }),
@@ -212,14 +215,23 @@ export default function createSetupApp(config: AuthHeroConfig) {
       const { identifier, password, confirm_password, name } =
         ctx.req.valid("json").data;
 
-      // Validate passwords match
-      if (password !== confirm_password) {
-        const errorScreen = getSetupScreen("Passwords do not match.");
+      const respondWithError = (error: string) => {
+        const errorScreen = getSetupScreen(error);
         const accept = ctx.req.header("Accept") || "";
         if (accept.includes("application/json")) {
           return ctx.json({ screen: errorScreen });
         }
         return renderSetupPage(ctx, errorScreen, "setup");
+      };
+
+      if (!identifier) {
+        return respondWithError("Please enter an admin username or email.");
+      }
+      if (password.length < 8) {
+        return respondWithError("Password must be at least 8 characters.");
+      }
+      if (password !== confirm_password) {
+        return respondWithError("Passwords do not match.");
       }
 
       // Determine if identifier is an email or username

--- a/packages/authhero/src/routes/universal-login/screens/login.ts
+++ b/packages/authhero/src/routes/universal-login/screens/login.ts
@@ -697,13 +697,13 @@ export const loginScreenDefinition: ScreenDefinition = {
       } catch (e: unknown) {
         const authError = e as AuthError;
 
-        let errorMessage = authError.message || m["wrong-credentials"]();
+        let errorMessage = authError.message || m.wrongCredentials();
 
         if (
           authError.code === "INVALID_PASSWORD" ||
           authError.code === "USER_NOT_FOUND"
         ) {
-          errorMessage = m["wrong-credentials"]();
+          errorMessage = m.wrongCredentials();
         } else if (authError.code === "EMAIL_NOT_VERIFIED") {
           errorMessage = m.unverifiedEmail();
         } else if (authError.code === "TOO_MANY_FAILED_LOGINS") {

--- a/packages/authhero/test/routes/universal-login/screens-login.spec.ts
+++ b/packages/authhero/test/routes/universal-login/screens-login.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { testClient } from "hono/testing";
+import bcryptjs from "bcryptjs";
 import { getTestServer } from "../../helpers/test-server";
 import { u2Screen } from "../../helpers/u2-screen";
+import { USERNAME_PASSWORD_PROVIDER } from "../../../src/constants";
 import {
   AuthorizationResponseType,
   Strategy,
@@ -188,5 +190,50 @@ describe("login screen - passwordless button", () => {
     // The SSR HTML should contain the passwordless button as an <a> in social-buttons
     expect(html).toContain("login-passwordless-identifier");
     expect(html).toContain("social-buttons");
+  });
+});
+
+describe("login screen - wrong password", () => {
+  it("should show a translated error message, not the raw i18n key", async () => {
+    const { u2App, oauthApp, env } = await getTestServer({
+      mockEmail: true,
+      testTenantLanguage: "en",
+    });
+
+    await env.data.users.create("tenantId", {
+      email: "wrongpw@example.com",
+      email_verified: true,
+      name: "Wrong PW User",
+      nickname: "wrongpw",
+      picture: "https://example.com/test.png",
+      connection: Strategy.USERNAME_PASSWORD,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      is_social: false,
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|wrongPwUserId`,
+    });
+    await env.data.passwords.create("tenantId", {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|wrongPwUserId`,
+      password: await bcryptjs.hash("Password1!", 10),
+      algorithm: "bcrypt",
+    });
+
+    // The test server creates the connection with the username-password
+    // provider strategy, but the combined login screen checks for
+    // strategy === Strategy.USERNAME_PASSWORD.
+    await env.data.connections.update("tenantId", Strategy.USERNAME_PASSWORD, {
+      strategy: Strategy.USERNAME_PASSWORD,
+    });
+
+    const oauthClient = testClient(oauthApp, env);
+    const state = await getLoginState(oauthClient);
+
+    const response = await u2Screen(u2App, env, "login").$post({
+      query: { state },
+      form: { username: "wrongpw@example.com", password: "not-the-password" },
+    });
+
+    const html = await response.text();
+    expect(html).toContain("Wrong username or password");
+    expect(html).not.toContain("wrong-credentials");
   });
 });

--- a/packages/create-authhero/README.md
+++ b/packages/create-authhero/README.md
@@ -256,7 +256,7 @@ Use conventional commits for automatic versioning:
 
 ## Documentation
 
-For more information, visit [https://authhero.net/docs](https://authhero.net/docs)
+For more information, visit [https://docs.authhero.net](https://docs.authhero.net)
 
 ## License
 

--- a/packages/create-authhero/src/index.ts
+++ b/packages/create-authhero/src/index.ts
@@ -408,7 +408,13 @@ function generateLocalSeedFileContent(
     "https://local.authhero.net/auth-callback",
     "http://localhost:5173/auth-callback",
     "http://localhost:3000/auth-callback",
-    ...(adminUi ? ["http://localhost:3000/admin/auth-callback"] : []),
+    "https://localhost:3000/auth-callback",
+    ...(adminUi
+      ? [
+          "http://localhost:3000/admin/auth-callback",
+          "https://localhost:3000/admin/auth-callback",
+        ]
+      : []),
   ];
   const conformanceCallbacks = conformance
     ? [
@@ -423,6 +429,7 @@ function generateLocalSeedFileContent(
     "https://local.authhero.net",
     "http://localhost:5173",
     "http://localhost:3000",
+    "https://localhost:3000",
   ];
   const conformanceLogoutUrls = conformance
     ? ["https://localhost:8443/", "https://localhost.emobix.co.uk:8443/"]
@@ -698,7 +705,7 @@ const adminIndexPath = path.join(adminDistPath, "index.html");
   // Add admin UI handler if the package is installed
   if (fs.existsSync(adminIndexPath)) {
     const issuer =
-      process.env.ISSUER || \`http://localhost:\${process.env.PORT || 3000}/\`;
+      process.env.ISSUER || \`https://localhost:\${process.env.PORT || 3000}/\`;
     const rawHtml = fs.readFileSync(adminIndexPath, "utf-8")
       .replace(/src="\\.\\//g, 'src="/admin/')
       .replace(/href="\\.\\//g, 'href="/admin/');
@@ -1453,13 +1460,19 @@ function printProxySuccessMessage(): void {
 /**
  * Prints nice output at the end of setup for local/sqlite
  */
-function printLocalSuccessMessage(): void {
+function printLocalSuccessMessage(adminUi?: boolean): void {
   console.log("\n" + "─".repeat(50));
-  console.log("✅ Self-signed certificates generated with openssl");
-  console.log("⚠️  You may need to trust the certificate in your browser");
-  console.log("🔐 AuthHero server running at http://localhost:3000");
-  console.log("📚 API documentation available at http://localhost:3000/docs");
-  console.log("🚀 Open http://localhost:3000/setup to complete initial setup");
+  console.log("🔐 AuthHero server running at https://localhost:3000");
+  console.log("⚠️  Uses a self-signed certificate — you may need to trust it");
+  console.log("📚 API documentation available at https://localhost:3000/docs");
+  console.log(
+    "🚀 Open https://localhost:3000/setup to complete initial setup",
+  );
+  if (adminUi) {
+    console.log("🛠️  Admin UI available at https://localhost:3000/admin");
+  } else {
+    console.log("🌐 Portal available at https://local.authhero.net");
+  }
   console.log("─".repeat(50) + "\n");
 }
 
@@ -2000,7 +2013,7 @@ ENCRYPTION_KEY=${generateEncryptionKey()}
           } else if (setupType === "proxy") {
             printProxySuccessMessage();
           } else {
-            printLocalSuccessMessage();
+            printLocalSuccessMessage(adminUi);
           }
           console.log("🚀 Starting development server...\n");
           await runCommand(`${packageManager} run dev`, projectPath);
@@ -2025,7 +2038,7 @@ ENCRYPTION_KEY=${generateEncryptionKey()}
           } else if (setupType === "proxy") {
             printProxySuccessMessage();
           } else {
-            printLocalSuccessMessage();
+            printLocalSuccessMessage(adminUi);
           }
         }
       } catch (error) {
@@ -2043,7 +2056,7 @@ ENCRYPTION_KEY=${generateEncryptionKey()}
         console.log("  npm run migrate");
         console.log("  npm run dev");
         console.log(
-          "\nOpen http://localhost:3000/setup to complete initial setup",
+          "\nOpen https://localhost:3000/setup to complete initial setup",
         );
       } else if (setupType === "cloudflare") {
         console.log("  npm install");
@@ -2116,7 +2129,12 @@ ENCRYPTION_KEY=${generateEncryptionKey()}
             : setupType === "cloudflare-wfp-tenant"
               ? 3002
               : 3000;
-      console.log(`\nServer will be available at: http://localhost:${port}`);
+      // The proxy template serves plain http; all other templates run their
+      // dev server with TLS (self-signed certs / wrangler --local-protocol).
+      const protocol = setupType === "proxy" ? "http" : "https";
+      console.log(
+        `\nServer will be available at: ${protocol}://localhost:${port}`,
+      );
 
       if (conformance) {
         console.log("\n🧪 OpenID Conformance Suite Testing:");
@@ -2135,7 +2153,7 @@ ENCRYPTION_KEY=${generateEncryptionKey()}
         console.log(`  4. Use alias: ${conformanceAlias}`);
       }
 
-      console.log("\nFor more information, visit: https://authhero.net/docs\n");
+      console.log("\nFor more information, visit: https://docs.authhero.net\n");
     }
   });
 

--- a/packages/create-authhero/templates/aws-sst/README.md
+++ b/packages/create-authhero/templates/aws-sst/README.md
@@ -158,6 +158,6 @@ npm run decrypt -- "enc:v1:..."   # decrypt a stored value using ENCRYPTION_KEY 
 ## Learn More
 
 - [SST Documentation](https://sst.dev/docs)
-- [AuthHero Documentation](https://authhero.net/docs)
+- [AuthHero Documentation](https://docs.authhero.net)
 - [AWS Lambda](https://docs.aws.amazon.com/lambda/)
 - [DynamoDB](https://docs.aws.amazon.com/dynamodb/)

--- a/packages/create-authhero/templates/cloudflare-control-plane/README.md
+++ b/packages/create-authhero/templates/cloudflare-control-plane/README.md
@@ -55,5 +55,5 @@ npm run seed      # seed the control plane tenant + admin
 npm run dev
 ```
 
-See [Control Plane Defaults](https://authhero.net/docs/customization/multi-tenancy/control-plane-defaults)
+See [Control Plane Defaults](https://docs.authhero.net/customization/multi-tenancy/control-plane-defaults)
 for the full architecture and request flows.

--- a/packages/create-authhero/templates/cloudflare-wfp-tenant/README.md
+++ b/packages/create-authhero/templates/cloudflare-wfp-tenant/README.md
@@ -58,5 +58,5 @@ wrangler secret put CONTROL_PLANE_ENCRYPTION_KEY  --name tenant-<id>-auth
 
 After the Worker and its D1 exist, run the control plane's
 `sync-defaults` for this tenant so its inherited rows are populated. See the
-[Control Plane Defaults](https://authhero.net/docs/customization/multi-tenancy/control-plane-defaults)
+[Control Plane Defaults](https://docs.authhero.net/customization/multi-tenancy/control-plane-defaults)
 docs for the full flow.

--- a/packages/create-authhero/templates/cloudflare/README.md
+++ b/packages/create-authhero/templates/cloudflare/README.md
@@ -189,7 +189,7 @@ routes = [
 ]
 ```
 
-For more information, visit [https://authhero.net/docs](https://authhero.net/docs).
+For more information, visit [https://docs.authhero.net](https://docs.authhero.net).
 
 ## CI/CD with GitHub Actions
 

--- a/packages/create-authhero/templates/local/README.md
+++ b/packages/create-authhero/templates/local/README.md
@@ -69,4 +69,4 @@ npm run gen:key                   # print a fresh base64 key
 npm run decrypt -- "enc:v1:..."   # decrypt a stored value using ENCRYPTION_KEY from .env
 ```
 
-For more information, visit [https://authhero.net/docs](https://authhero.net/docs).
+For more information, visit [https://docs.authhero.net](https://docs.authhero.net).

--- a/packages/create-authhero/templates/local/src/index.ts
+++ b/packages/create-authhero/templates/local/src/index.ts
@@ -9,6 +9,7 @@ import fs from "fs";
 import path from "path";
 import { execFileSync } from "child_process";
 import https from "https";
+import { fileURLToPath } from "url";
 
 // Generate self-signed certificates for local HTTPS if they don't exist
 const certDir = path.join(process.cwd(), ".certs");
@@ -130,9 +131,22 @@ const issuer = process.env.ISSUER || `https://localhost:${port}/`;
 // Get or generate certificates
 const { key, cert } = ensureCertificates();
 
+// Point at the locally installed admin UI when the @authhero/admin package is
+// present (same check as app.ts); fall back to the hosted portal otherwise.
+const hasLocalAdminUi = fs.existsSync(
+  path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../node_modules/@authhero/admin/dist/index.html",
+  ),
+);
+
 console.log(`🔐 AuthHero server running at https://localhost:${port}`);
 console.log(`📚 API documentation available at https://localhost:${port}/docs`);
-console.log(`🌐 Portal available at https://local.authhero.net`);
+if (hasLocalAdminUi) {
+  console.log(`🛠️  Admin UI available at https://localhost:${port}/admin`);
+} else {
+  console.log(`🌐 Portal available at https://local.authhero.net`);
+}
 
 serve({
   fetch: (request) => {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - apps/*
   - packages/*
+  # Scaffolded by `pnpm --filter create-authhero dev` (--workspace mode);
+  # matches nothing on a clean clone.
+  - packages/create-authhero/auth-server
   - docker
 onlyBuiltDependencies:
   - better-sqlite3


### PR DESCRIPTION
Fixes a series of issues hit while scaffolding a fresh local environment with `create-authhero` and logging into the bundled admin UI.

## create-authhero

- The startup banner and CLI success messages now point at the bundled admin UI (`https://localhost:3000/admin`) instead of the hosted portal at `local.authhero.net` when `@authhero/admin` is installed, and use https URLs matching what the local template actually serves.
- The generated `app.ts` defaulted the admin config issuer to `http://localhost:3000`, so the admin UI was configured with an http domain on an https-only server. It now defaults to https, and the seed script includes the `https://localhost:3000` callback/logout URLs.
- Documentation links updated from `authhero.net/docs` to `https://docs.authhero.net`.
- Restored the `packages/create-authhero/auth-server` workspace glob (removed in e0cd4497), which had broken the package's `dev` script — `pnpm -w install --filter auth-server...` matched nothing so migrate/dev silently did nothing. The glob matches nothing on a clean clone.

## @authhero/admin

- `buildUrlWithProtocol` forced `http://` for schemeless loopback domains, so the token exchange after login called `http://localhost:3000/oauth/token` and failed with "Failed to fetch" (navigations get auto-upgraded to https by the browser; `fetch` doesn't). Schemeless domains matching the page's own host now follow the page protocol — always correct for the bundled admin UI — and other schemeless domains default to https. An explicit `http://` is still respected for loopback hosts. Added unit tests.

## authhero

- The `/setup` screen rejected short passwords via the OpenAPI schema layer, returning a bare 400 the widget can't display (error with no text). Field rules moved into the handler so short-password / empty-identifier / mismatch all render the setup screen with a visible message.
- The combined login screen showed the literal string `wrong-credentials` on a wrong password: it translates against the `login.login` prompt whose Auth0 key is camelCase `wrongCredentials`; the kebab-case key only exists for `login-id`/`login-password`. The i18n proxy returns the raw key for missing translations, and nothing in the build runs tsc, so the type error went unnoticed. Fixed and covered with a regression test; audited all universal-login screens for other key mismatches (none).

## Notes

- While debugging, found that the kysely adapter's `promptSettings.get` coerces a missing row to `identifier_first: false` (drizzle returns `true`, matching the schema default), which is why kysely-backed servers default to the combined login screen. Deliberately left as-is to preserve the current login UX — changing it would flip existing deployments to identifier-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local project setup now shows the correct admin portal and setup URLs for HTTPS-based development.
  * Documentation links across setup and templates now point to the updated docs site.

* **Bug Fixes**
  * Login now shows a clear “Wrong username or password” message instead of a raw error key.
  * Setup validation now displays friendly errors for missing identifiers, short passwords, and mismatched passwords.
  * Admin URLs now use the right protocol for local, same-origin, and non-local domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->