### PR TITLE
Add test suite for create-authhero and fix aws-sst package name

### DIFF
--- a/.changeset/eight-eyes-tease.md
+++ b/.changeset/eight-eyes-tease.md
@@ -1,0 +1,5 @@
+---
+"create-authhero": patch
+---
+
+Fix the aws-sst template to depend on `@authhero/aws-adapter` (the published package) instead of the non-existent `@authhero/aws`, and add a test suite that scaffolds every template and verifies the generated files, dependency names, and that generated/template code only imports things the authhero packages actually export.

--- a/packages/create-authhero/package.json
+++ b/packages/create-authhero/package.json
@@ -19,7 +19,9 @@
     "build": "tsc && vite build",
     "prepublishOnly": "pnpm build",
     "dev": "pnpm build && rm -rf auth-server && node dist/create-authhero.js auth-server --workspace --skip-install --skip-start && pnpm -w install --force --filter auth-server... && pnpm --filter auth-server migrate && pnpm --filter auth-server dev",
-    "start": "pnpm build && node dist/create-authhero.js"
+    "start": "pnpm build && node dist/create-authhero.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",
@@ -28,7 +30,8 @@
     "@types/node": "^20.19.41",
     "tsx": "^4.22.3",
     "typescript": "^5.5.2",
-    "vite": "^8.0.14"
+    "vite": "^8.0.14",
+    "vitest": "^4.1.7"
   },
   "dependencies": {
     "commander": "^12.1.0",

--- a/packages/create-authhero/src/index.ts
+++ b/packages/create-authhero/src/index.ts
@@ -354,7 +354,7 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
           decrypt: "node --env-file=.env scripts/decrypt-field.mjs",
         },
         dependencies: {
-          "@authhero/aws": v,
+          "@authhero/aws-adapter": v,
           ...(adminUi && { "@authhero/admin": v }),
           "@authhero/widget": v,
           "@aws-sdk/client-dynamodb": "^3.0.0",
@@ -1124,7 +1124,7 @@ function generateAwsSstSeedFileContent(
 
   return `import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
-import createAdapters from "@authhero/aws";
+import createAdapters from "@authhero/aws-adapter";
 import { seed, createEncryptedDataAdapter, loadEncryptionKey } from "authhero";
 
 async function main() {
@@ -1465,9 +1465,7 @@ function printLocalSuccessMessage(adminUi?: boolean): void {
   console.log("🔐 AuthHero server running at https://localhost:3000");
   console.log("⚠️  Uses a self-signed certificate — you may need to trust it");
   console.log("📚 API documentation available at https://localhost:3000/docs");
-  console.log(
-    "🚀 Open https://localhost:3000/setup to complete initial setup",
-  );
+  console.log("🚀 Open https://localhost:3000/setup to complete initial setup");
   if (adminUi) {
     console.log("🛠️  Admin UI available at https://localhost:3000/admin");
   } else {

--- a/packages/create-authhero/templates/aws-sst/src/index.ts
+++ b/packages/create-authhero/templates/aws-sst/src/index.ts
@@ -1,7 +1,7 @@
 import { handle } from "hono/aws-lambda";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
-import createAdapters from "@authhero/aws";
+import createAdapters from "@authhero/aws-adapter";
 import {
   DataAdapters,
   createEncryptedDataAdapter,

--- a/packages/create-authhero/templates/aws-sst/sst.config.ts
+++ b/packages/create-authhero/templates/aws-sst/sst.config.ts
@@ -61,7 +61,7 @@ export default $config({
         ENCRYPTION_KEY: process.env.ENCRYPTION_KEY ?? "",
       },
       nodejs: {
-        install: ["@authhero/aws"],
+        install: ["@authhero/aws-adapter"],
       },
     });
 

--- a/packages/create-authhero/test/generated-code.test.ts
+++ b/packages/create-authhero/test/generated-code.test.ts
@@ -1,0 +1,346 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  listTsFiles,
+  makeTempDir,
+  readJson,
+  repoRoot,
+  scaffold,
+  type ScaffoldResult,
+} from "./helpers";
+
+// These tests catch drift between the code create-authhero generates (or
+// copies from templates/) and the actual authhero packages: renamed exports,
+// removed functions, wrong package names, or template-string typos that
+// produce invalid TypeScript. The sibling packages must be built first
+// (`pnpm -r --filter './packages/**' build`).
+
+const cases = {
+  local: ["--template", "local"],
+  "local-multi": ["--template", "local", "--multi-tenant"],
+  "local-conformance": ["--template", "local", "--conformance"],
+  cloudflare: ["--template", "cloudflare"],
+  "cloudflare-multi": ["--template", "cloudflare", "--multi-tenant"],
+  "wfp-dispatcher": ["--template", "cloudflare-wfp-dispatcher"],
+  "wfp-tenant": ["--template", "cloudflare-wfp-tenant"],
+  "control-plane": ["--template", "cloudflare-control-plane"],
+  "aws-sst": ["--template", "aws-sst"],
+  proxy: ["--template", "proxy"],
+} as const;
+
+type CaseName = keyof typeof cases;
+
+// Relative imports that only exist after `npm install` (created by the
+// template's copy-assets.js postinstall step).
+const POSTINSTALL_MODULES = new Set(["./admin-index-html"]);
+
+let tempRoot: string;
+const projects = {} as Record<CaseName, ScaffoldResult>;
+
+beforeAll(async () => {
+  tempRoot = makeTempDir();
+  await Promise.all(
+    (Object.keys(cases) as CaseName[]).map(async (name) => {
+      projects[name] = await scaffold(name, [...cases[name]], tempRoot);
+      expect(projects[name].exitCode, projects[name].stderr).toBe(0);
+    }),
+  );
+}, 120_000);
+
+afterAll(() => {
+  if (tempRoot) fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+interface ParsedImport {
+  specifier: string;
+  defaultImport?: string;
+  namedImports: string[];
+  namespaceImport?: string;
+}
+
+function parseImports(filePath: string): ParsedImport[] {
+  const source = ts.createSourceFile(
+    filePath,
+    fs.readFileSync(filePath, "utf-8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const imports: ParsedImport[] = [];
+  for (const statement of source.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      continue;
+    }
+    const parsed: ParsedImport = {
+      specifier: statement.moduleSpecifier.text,
+      namedImports: [],
+    };
+    const clause = statement.importClause;
+    if (clause?.name) parsed.defaultImport = clause.name.text;
+    if (clause?.namedBindings) {
+      if (ts.isNamespaceImport(clause.namedBindings)) {
+        parsed.namespaceImport = clause.namedBindings.name.text;
+      } else {
+        for (const element of clause.namedBindings.elements) {
+          // For `import { a as b }`, the exported name is `a`.
+          parsed.namedImports.push((element.propertyName ?? element.name).text);
+        }
+      }
+    }
+    imports.push(parsed);
+  }
+  return imports;
+}
+
+interface PackageExports {
+  names: Set<string>;
+  hasDefault: boolean;
+  subpaths: Set<string>;
+  loadErrors: string[];
+}
+
+// Map published package names to their workspace directories.
+function workspaceDirFor(specifier: string): string | undefined {
+  const dirs = [
+    ...fs
+      .readdirSync(path.join(repoRoot, "packages"))
+      .map((d) => path.join(repoRoot, "packages", d)),
+    path.join(repoRoot, "apps", "admin"),
+  ];
+  for (const dir of dirs) {
+    const pkgJsonPath = path.join(dir, "package.json");
+    if (!fs.existsSync(pkgJsonPath)) continue;
+    if (readJson(pkgJsonPath).name === specifier) return dir;
+  }
+  return undefined;
+}
+
+const exportsCache = new Map<string, Promise<PackageExports>>();
+
+function getPackageExports(specifier: string): Promise<PackageExports> {
+  let cached = exportsCache.get(specifier);
+  if (!cached) {
+    cached = loadPackageExports(specifier);
+    exportsCache.set(specifier, cached);
+  }
+  return cached;
+}
+
+// Collect exported names from a .d.ts file, following `export * from` into
+// relative files and workspace packages (e.g. authhero re-exports all of
+// @authhero/adapter-interfaces).
+async function scanDts(
+  filePath: string,
+  result: PackageExports,
+  visited: Set<string>,
+): Promise<void> {
+  const resolved = fs.existsSync(filePath)
+    ? filePath
+    : [`${filePath}.d.ts`, path.join(filePath, "index.d.ts")].find((p) =>
+        fs.existsSync(p),
+      );
+  if (!resolved || visited.has(resolved)) return;
+  visited.add(resolved);
+
+  const dts = fs.readFileSync(resolved, "utf-8");
+  for (const match of dts.matchAll(
+    /export\s+(?:declare\s+)?(?:abstract\s+)?(?:function|const|let|var|class|interface|type|enum|namespace)\s+([A-Za-z0-9_$]+)/g,
+  )) {
+    result.names.add(match[1]!);
+  }
+  for (const list of dts.matchAll(/export\s+(?:type\s+)?\{([^}]+)\}/g)) {
+    for (const raw of list[1]!.split(",")) {
+      const token = raw.trim().replace(/^type\s+/, "");
+      if (!token) continue;
+      // `X as Y` exports the name Y; `X as default` exports default.
+      const parts = token.split(/\s+as\s+/);
+      const exported = (parts[1] ?? parts[0])!.trim();
+      if (exported === "default") result.hasDefault = true;
+      else result.names.add(exported);
+    }
+  }
+  if (/export\s+default\s/.test(dts)) result.hasDefault = true;
+
+  for (const reexport of dts.matchAll(
+    /export\s+(?:type\s+)?\*\s+from\s+["']([^"']+)["']/g,
+  )) {
+    const target = reexport[1]!;
+    if (target.startsWith(".")) {
+      await scanDts(
+        path.resolve(path.dirname(resolved), target),
+        result,
+        visited,
+      );
+    } else if (workspaceDirFor(target)) {
+      const nested = await getPackageExports(target);
+      for (const name of nested.names) result.names.add(name);
+    }
+  }
+}
+
+async function loadPackageExports(specifier: string): Promise<PackageExports> {
+  const dir = workspaceDirFor(specifier);
+  if (!dir) {
+    throw new Error(
+      `"${specifier}" is not a package in this workspace — ` +
+        `scaffolded code imports a package that does not exist`,
+    );
+  }
+  const pkg = readJson(path.join(dir, "package.json"));
+  const result: PackageExports = {
+    names: new Set(),
+    hasDefault: false,
+    subpaths: new Set(Object.keys(pkg.exports ?? {})),
+    loadErrors: [],
+  };
+
+  // Runtime exports from the built ESM bundle.
+  const entry = pkg.exports?.["."]?.import ?? pkg.module ?? pkg.main;
+  if (entry) {
+    const entryPath = path.join(dir, entry);
+    if (fs.existsSync(entryPath)) {
+      try {
+        const mod = await import(pathToFileURL(entryPath).href);
+        for (const name of Object.keys(mod)) result.names.add(name);
+        result.hasDefault = "default" in mod;
+      } catch (e) {
+        result.loadErrors.push(`import ${entry}: ${e}`);
+      }
+    } else {
+      result.loadErrors.push(`missing ${entry} — run pnpm -r build first`);
+    }
+  }
+
+  // Type exports from the bundled .d.ts (covers type-only names like
+  // AuthHeroConfig that have no runtime value).
+  const types = pkg.exports?.["."]?.types ?? pkg.types;
+  if (types && fs.existsSync(path.join(dir, types))) {
+    await scanDts(path.join(dir, types), result, new Set());
+  }
+
+  if (result.names.size === 0 && !result.hasDefault) {
+    throw new Error(
+      `Could not load any exports for "${specifier}" from ${dir}. ` +
+        `Build the workspace first (pnpm -r --filter './packages/**' build). ` +
+        `Errors: ${result.loadErrors.join("; ") || "none"}`,
+    );
+  }
+  return result;
+}
+
+function tsFilesFor(name: CaseName): string[] {
+  const { projectPath } = projects[name];
+  return [
+    ...listTsFiles(path.join(projectPath, "src")).map((f) =>
+      path.join("src", f),
+    ),
+    ...["sst.config.ts", "drizzle.config.ts"].filter((f) =>
+      fs.existsSync(path.join(projectPath, f)),
+    ),
+  ];
+}
+
+describe.each(Object.keys(cases) as CaseName[])("%s", (name) => {
+  it("produces syntactically valid TypeScript", () => {
+    const { projectPath } = projects[name];
+    for (const file of tsFilesFor(name)) {
+      const filePath = path.join(projectPath, file);
+      const { diagnostics } = ts.transpileModule(
+        fs.readFileSync(filePath, "utf-8"),
+        {
+          reportDiagnostics: true,
+          compilerOptions: {
+            target: ts.ScriptTarget.ESNext,
+            module: ts.ModuleKind.ESNext,
+          },
+        },
+      );
+      const errors = (diagnostics ?? []).map((d) =>
+        ts.flattenDiagnosticMessageText(d.messageText, "\n"),
+      );
+      expect(errors, `${file} should have no syntax errors`).toEqual([]);
+    }
+  });
+
+  it("only depends on @authhero packages that actually exist", () => {
+    const pkg = readJson(path.join(projects[name].projectPath, "package.json"));
+    const deps = Object.keys({
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    }).filter((d) => d === "authhero" || d.startsWith("@authhero/"));
+    for (const dep of deps) {
+      expect(
+        workspaceDirFor(dep),
+        `dependency "${dep}" does not match any workspace package name`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("relative imports resolve to files in the scaffold", () => {
+    const { projectPath } = projects[name];
+    for (const file of tsFilesFor(name)) {
+      for (const imp of parseImports(path.join(projectPath, file))) {
+        if (!imp.specifier.startsWith(".")) continue;
+        if (POSTINSTALL_MODULES.has(imp.specifier)) continue;
+        const base = path.resolve(
+          path.dirname(path.join(projectPath, file)),
+          imp.specifier,
+        );
+        const found = [
+          base,
+          `${base}.ts`,
+          `${base}.tsx`,
+          path.join(base, "index.ts"),
+        ].some((candidate) => fs.existsSync(candidate));
+        expect(
+          found,
+          `${file} imports "${imp.specifier}" which does not exist`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("imports from authhero packages that the packages actually export", async () => {
+    const { projectPath } = projects[name];
+    for (const file of tsFilesFor(name)) {
+      for (const imp of parseImports(path.join(projectPath, file))) {
+        const { specifier } = imp;
+        if (specifier !== "authhero" && !specifier.startsWith("@authhero/")) {
+          continue;
+        }
+
+        // Subpath imports (e.g. @authhero/drizzle/schema/sqlite) — verify
+        // the exports map exposes the subpath.
+        const match = specifier.match(/^(@authhero\/[^/]+)\/(.+)$/);
+        if (match) {
+          const exports = await getPackageExports(match[1]!);
+          expect(
+            exports.subpaths.has(`./${match[2]}`),
+            `${file}: "${match[1]}" does not export subpath "./${match[2]}"`,
+          ).toBe(true);
+          continue;
+        }
+
+        const exports = await getPackageExports(specifier);
+        if (imp.defaultImport) {
+          expect(
+            exports.hasDefault,
+            `${file}: "${specifier}" has no default export ` +
+              `(imported as ${imp.defaultImport})`,
+          ).toBe(true);
+        }
+        for (const namedImport of imp.namedImports) {
+          expect(
+            exports.names.has(namedImport),
+            `${file}: "${specifier}" does not export "${namedImport}"`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+});

--- a/packages/create-authhero/test/helpers.ts
+++ b/packages/create-authhero/test/helpers.ts
@@ -1,0 +1,97 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const packageRoot = path.resolve(__dirname, "..");
+export const repoRoot = path.resolve(packageRoot, "..", "..");
+
+// Run the CLI from source via tsx so tests exercise src/index.ts directly
+// without requiring a build. Template resolution falls back to ../templates
+// when running from src (see candidatePaths in src/index.ts).
+const tsxCli = path.join(packageRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const cliEntry = path.join(packageRoot, "src", "index.ts");
+
+export interface CliResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export function runCli(args: string[], cwd: string): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [tsxCli, cliEntry, ...args], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", reject);
+    child.on("close", (exitCode) => resolve({ exitCode, stdout, stderr }));
+  });
+}
+
+export interface ScaffoldResult extends CliResult {
+  projectPath: string;
+}
+
+export function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "create-authhero-test-"));
+}
+
+/**
+ * Scaffold a project non-interactively into a fresh temp directory.
+ * Install/migrate/start are always skipped — tests only inspect the
+ * generated files.
+ */
+export async function scaffold(
+  projectName: string,
+  flags: string[],
+  tempRoot: string,
+): Promise<ScaffoldResult> {
+  const result = await runCli(
+    [
+      projectName,
+      ...flags,
+      "--yes",
+      "--skip-install",
+      "--skip-migrate",
+      "--skip-start",
+    ],
+    tempRoot,
+  );
+  return { ...result, projectPath: path.join(tempRoot, projectName) };
+}
+
+export function readJson(filePath: string): Record<string, any> {
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+export function exists(projectPath: string, relative: string): boolean {
+  return fs.existsSync(path.join(projectPath, relative));
+}
+
+export function readFile(projectPath: string, relative: string): string {
+  return fs.readFileSync(path.join(projectPath, relative), "utf-8");
+}
+
+/** Recursively list every .ts file in a directory (relative paths). */
+export function listTsFiles(dir: string, base = dir): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules") continue;
+      out.push(...listTsFiles(full, base));
+    } else if (entry.name.endsWith(".ts")) {
+      out.push(path.relative(base, full));
+    }
+  }
+  return out;
+}

--- a/packages/create-authhero/test/scaffold.test.ts
+++ b/packages/create-authhero/test/scaffold.test.ts
@@ -1,0 +1,337 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  exists,
+  makeTempDir,
+  readFile,
+  readJson,
+  runCli,
+  scaffold,
+  type ScaffoldResult,
+} from "./helpers";
+
+// One scaffold per template / flag combination, created once and inspected by
+// many tests below.
+const cases = {
+  local: ["--template", "local"],
+  "local-workspace-multi": [
+    "--template",
+    "local",
+    "--workspace",
+    "--multi-tenant",
+  ],
+  "local-conformance": [
+    "--template",
+    "local",
+    "--conformance",
+    "--conformance-alias",
+    "my-alias",
+  ],
+  cloudflare: ["--template", "cloudflare"],
+  "cloudflare-ci": ["--template", "cloudflare", "--github-ci"],
+  "wfp-dispatcher": ["--template", "cloudflare-wfp-dispatcher"],
+  "wfp-tenant": ["--template", "cloudflare-wfp-tenant"],
+  "control-plane": ["--template", "cloudflare-control-plane"],
+  "aws-sst": ["--template", "aws-sst"],
+  proxy: ["--template", "proxy"],
+} as const;
+
+type CaseName = keyof typeof cases;
+
+let tempRoot: string;
+const projects = {} as Record<CaseName, ScaffoldResult>;
+
+beforeAll(async () => {
+  tempRoot = makeTempDir();
+  await Promise.all(
+    (Object.keys(cases) as CaseName[]).map(async (name) => {
+      projects[name] = await scaffold(name, [...cases[name]], tempRoot);
+    }),
+  );
+}, 120_000);
+
+afterAll(() => {
+  if (tempRoot) fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+function expectValidEncryptionKey(content: string, varName: string) {
+  const match = content.match(new RegExp(`^${varName}=(.+)$`, "m"));
+  expect(match, `${varName} should be present`).toBeTruthy();
+  const key = Buffer.from(match![1]!, "base64");
+  expect(key.length, `${varName} should be a base64 32-byte key`).toBe(32);
+}
+
+describe("scaffolding succeeds for every template", () => {
+  it.each(Object.keys(cases) as CaseName[])("%s exits 0", (name) => {
+    const { exitCode, stderr } = projects[name];
+    expect(exitCode, stderr).toBe(0);
+  });
+
+  it.each(Object.keys(cases) as CaseName[])(
+    "%s writes a valid package.json",
+    (name) => {
+      const pkg = readJson(
+        path.join(projects[name].projectPath, "package.json"),
+      );
+      expect(pkg.name).toBe(name);
+      expect(pkg.scripts.dev).toBeTruthy();
+    },
+  );
+});
+
+describe("local template", () => {
+  it("creates the expected files", () => {
+    const { projectPath } = projects.local;
+    for (const file of [
+      "package.json",
+      "tsconfig.json",
+      ".env",
+      "src/index.ts",
+      "src/app.ts",
+      "src/seed.ts",
+      "src/migrate.ts",
+      "scripts/generate-encryption-key.mjs",
+      "scripts/decrypt-field.mjs",
+    ]) {
+      expect(exists(projectPath, file), `${file} should exist`).toBe(true);
+    }
+  });
+
+  it("depends on the kysely adapter with published versions by default", () => {
+    const pkg = readJson(path.join(projects.local.projectPath, "package.json"));
+    expect(pkg.dependencies["@authhero/kysely-adapter"]).toBe("latest");
+    expect(pkg.dependencies.authhero).toBe("latest");
+    expect(pkg.dependencies["better-sqlite3"]).toBeTruthy();
+  });
+
+  it("enables the admin UI by default in non-interactive mode", () => {
+    const pkg = readJson(path.join(projects.local.projectPath, "package.json"));
+    expect(pkg.dependencies["@authhero/admin"]).toBeTruthy();
+    expect(readFile(projects.local.projectPath, "src/app.ts")).toContain(
+      "adminHandler",
+    );
+  });
+
+  it("generates a .env with a valid at-rest encryption key", () => {
+    expectValidEncryptionKey(
+      readFile(projects.local.projectPath, ".env"),
+      "ENCRYPTION_KEY",
+    );
+  });
+
+  it("generates a single-tenant app and seed", () => {
+    const { projectPath } = projects.local;
+    const app = readFile(projectPath, "src/app.ts");
+    expect(app).toContain("init(");
+    expect(app).not.toContain("initMultiTenant");
+    const seed = readFile(projectPath, "src/seed.ts");
+    expect(seed).toContain(`tenantId: "main"`);
+    expect(seed).toContain("isControlPlane: false");
+  });
+});
+
+describe("local template with --workspace --multi-tenant", () => {
+  it("uses workspace:* for all @authhero packages", () => {
+    const pkg = readJson(
+      path.join(projects["local-workspace-multi"].projectPath, "package.json"),
+    );
+    expect(pkg.dependencies.authhero).toBe("workspace:*");
+    for (const [dep, version] of Object.entries(pkg.dependencies)) {
+      if (dep.startsWith("@authhero/")) {
+        expect(version, dep).toBe("workspace:*");
+      }
+    }
+  });
+
+  it("wires up multi-tenancy", () => {
+    const { projectPath } = projects["local-workspace-multi"];
+    const pkg = readJson(path.join(projectPath, "package.json"));
+    expect(pkg.dependencies["@authhero/multi-tenancy"]).toBeTruthy();
+    const app = readFile(projectPath, "src/app.ts");
+    expect(app).toContain("initMultiTenant");
+    expect(app).toContain("control_plane");
+    const seed = readFile(projectPath, "src/seed.ts");
+    expect(seed).toContain(`tenantId: "control_plane"`);
+    expect(seed).toContain("isControlPlane: true");
+  });
+});
+
+describe("local template with --conformance", () => {
+  it("writes a conformance-config.json with the alias", () => {
+    const { projectPath } = projects["local-conformance"];
+    const config = readJson(path.join(projectPath, "conformance-config.json"));
+    expect(config.alias).toBe("my-alias");
+    expect(config.client.client_id).toBe("conformance-test");
+  });
+
+  it("seeds conformance clients and adds bcryptjs", () => {
+    const { projectPath } = projects["local-conformance"];
+    const pkg = readJson(path.join(projectPath, "package.json"));
+    expect(pkg.dependencies.bcryptjs).toBeTruthy();
+    const seed = readFile(projectPath, "src/seed.ts");
+    expect(seed).toContain("conformance-test");
+    expect(seed).toContain("/test/a/my-alias/callback");
+  });
+});
+
+describe("cloudflare template", () => {
+  it("creates wrangler + dev vars files", () => {
+    const { projectPath } = projects.cloudflare;
+    for (const file of [
+      "wrangler.toml",
+      "wrangler.local.toml",
+      ".dev.vars",
+      "drizzle.config.ts",
+      "copy-assets.js",
+      "seed-helper.js",
+      "src/index.ts",
+      "src/app.ts",
+      "src/seed.ts",
+    ]) {
+      expect(exists(projectPath, file), `${file} should exist`).toBe(true);
+    }
+  });
+
+  it("adds a generated ENCRYPTION_KEY to .dev.vars", () => {
+    const devVars = readFile(projects.cloudflare.projectPath, ".dev.vars");
+    expectValidEncryptionKey(devVars, "ENCRYPTION_KEY");
+    expect(devVars).not.toContain("CONTROL_PLANE_ENCRYPTION_KEY");
+  });
+
+  it("depends on the drizzle adapter", () => {
+    const pkg = readJson(
+      path.join(projects.cloudflare.projectPath, "package.json"),
+    );
+    expect(pkg.dependencies["@authhero/drizzle"]).toBeTruthy();
+    expect(pkg.devDependencies.wrangler).toBeTruthy();
+  });
+});
+
+describe("cloudflare template with --github-ci", () => {
+  it("creates workflows and semantic-release config", () => {
+    const { projectPath } = projects["cloudflare-ci"];
+    for (const file of [
+      ".github/workflows/unit-tests.yml",
+      ".github/workflows/deploy-dev.yml",
+      ".github/workflows/release.yml",
+      ".releaserc.json",
+    ]) {
+      expect(exists(projectPath, file), `${file} should exist`).toBe(true);
+    }
+    const pkg = readJson(path.join(projectPath, "package.json"));
+    expect(pkg.devDependencies["semantic-release"]).toBeTruthy();
+    expect(pkg.scripts["type-check"]).toBeTruthy();
+    expect(pkg.scripts.test).toBeTruthy();
+  });
+});
+
+describe("WFP dispatcher template", () => {
+  it("gets wrangler.local.toml but no .dev.vars (no at-rest data)", () => {
+    const { projectPath } = projects["wfp-dispatcher"];
+    expect(exists(projectPath, "wrangler.local.toml")).toBe(true);
+    expect(exists(projectPath, ".dev.vars")).toBe(false);
+  });
+
+  it("only depends on proxy + drizzle", () => {
+    const pkg = readJson(
+      path.join(projects["wfp-dispatcher"].projectPath, "package.json"),
+    );
+    expect(pkg.dependencies["@authhero/proxy"]).toBeTruthy();
+    expect(pkg.dependencies["@authhero/drizzle"]).toBeTruthy();
+    expect(pkg.dependencies.authhero).toBeUndefined();
+  });
+});
+
+describe.each(["wfp-tenant", "control-plane"] as const)(
+  "%s template",
+  (name) => {
+    it("generates both encryption keys in .dev.vars", () => {
+      const devVars = readFile(projects[name].projectPath, ".dev.vars");
+      expectValidEncryptionKey(devVars, "ENCRYPTION_KEY");
+      expectValidEncryptionKey(devVars, "CONTROL_PLANE_ENCRYPTION_KEY");
+    });
+
+    it("depends on authhero + multi-tenancy + drizzle", () => {
+      const pkg = readJson(
+        path.join(projects[name].projectPath, "package.json"),
+      );
+      expect(pkg.dependencies.authhero).toBeTruthy();
+      expect(pkg.dependencies["@authhero/multi-tenancy"]).toBeTruthy();
+      expect(pkg.dependencies["@authhero/drizzle"]).toBeTruthy();
+    });
+  },
+);
+
+describe("aws-sst template", () => {
+  it("creates the expected files", () => {
+    const { projectPath } = projects["aws-sst"];
+    for (const file of [
+      "sst.config.ts",
+      ".env",
+      "src/index.ts",
+      "src/app.ts",
+      "src/seed.ts",
+      "copy-assets.js",
+    ]) {
+      expect(exists(projectPath, file), `${file} should exist`).toBe(true);
+    }
+    expectValidEncryptionKey(readFile(projectPath, ".env"), "ENCRYPTION_KEY");
+  });
+
+  it("depends on the published aws adapter package name", () => {
+    const { projectPath } = projects["aws-sst"];
+    const pkg = readJson(path.join(projectPath, "package.json"));
+    // The package on npm is @authhero/aws-adapter — @authhero/aws does not
+    // exist and would fail `npm install` on every scaffolded project.
+    expect(pkg.dependencies["@authhero/aws-adapter"]).toBeTruthy();
+    expect(pkg.dependencies["@authhero/aws"]).toBeUndefined();
+    expect(readFile(projectPath, "src/seed.ts")).toContain(
+      `from "@authhero/aws-adapter"`,
+    );
+    expect(readFile(projectPath, "src/index.ts")).toContain(
+      `from "@authhero/aws-adapter"`,
+    );
+  });
+});
+
+describe("proxy template", () => {
+  it("creates a minimal static-config worker", () => {
+    const { projectPath } = projects.proxy;
+    expect(exists(projectPath, "wrangler.toml")).toBe(true);
+    expect(exists(projectPath, "src/index.ts")).toBe(true);
+    expect(exists(projectPath, "src/proxy.config.ts")).toBe(true);
+    expect(exists(projectPath, ".env")).toBe(false);
+    const pkg = readJson(path.join(projectPath, "package.json"));
+    expect(pkg.dependencies["@authhero/proxy"]).toBeTruthy();
+    expect(pkg.dependencies.authhero).toBeUndefined();
+  });
+});
+
+describe("error handling", () => {
+  it("fails when the target directory already exists", async () => {
+    const dir = makeTempDir();
+    try {
+      fs.mkdirSync(path.join(dir, "taken"));
+      const result = await scaffold("taken", ["--template", "local"], dir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain("already exists");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("rejects an unknown template", async () => {
+    const dir = makeTempDir();
+    try {
+      const result = await runCli(
+        ["bad-template", "--template", "nope", "--yes"],
+        dir,
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain("Invalid template");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/packages/create-authhero/vite.config.ts
+++ b/packages/create-authhero/vite.config.ts
@@ -1,9 +1,15 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 
 export default defineConfig({
   publicDir: "templates",
+  test: {
+    include: ["test/**/*.test.ts"],
+    // Tests spawn the CLI via tsx for each template, which is slow to boot.
+    testTimeout: 60_000,
+    hookTimeout: 120_000,
+  },
   build: {
     target: "node16",
     lib: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
         version: link:../../packages/ui-widget
       '@hono/node-server':
         specifier: latest
-        version: 2.0.5(hono@4.12.23)
+        version: 2.0.8(hono@4.12.23)
       '@hono/swagger-ui':
         specifier: ^0.5.0
         version: 0.5.3(hono@4.12.23)
@@ -585,7 +585,7 @@ importers:
         version: link:../packages/ui-widget
       '@hono/node-server':
         specifier: latest
-        version: 2.0.5(hono@4.12.23)
+        version: 2.0.8(hono@4.12.23)
       '@hono/swagger-ui':
         specifier: ^0.5.0
         version: 0.5.3(hono@4.12.23)
@@ -937,6 +937,9 @@ importers:
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@20.19.41)(jsdom@29.1.1)(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(vite@8.0.14(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/drizzle:
     dependencies:
@@ -1171,10 +1174,10 @@ importers:
         version: 4.12.23
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0)
       jest-cli:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0)
       tsx:
         specifier: ^4.22.3
         version: 4.22.3
@@ -2694,8 +2697,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/node-server@2.0.5':
-    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
+  '@hono/node-server@2.0.8':
+    resolution: {integrity: sha512-GuCWzLxwg218fy1JaHculFsdcuY12hxit83V+algozTPnwhNjLrRL/Alg9OYjLZLoUZ1rw/S4CdTMsnkSKCmFA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
@@ -12938,7 +12941,7 @@ snapshots:
     dependencies:
       hono: 4.12.23
 
-  '@hono/node-server@2.0.5(hono@4.12.23)':
+  '@hono/node-server@2.0.8(hono@4.12.23)':
     dependencies:
       hono: 4.12.23
 
@@ -13148,7 +13151,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -13161,14 +13164,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13193,7 +13196,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -13211,7 +13214,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -13233,7 +13236,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -13303,7 +13306,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -16002,7 +16005,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
 
   '@types/hast@3.0.4':
     dependencies:
@@ -16088,7 +16091,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
 
   '@types/stack-utils@2.0.3': {}
 
@@ -16096,7 +16099,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -16324,6 +16327,15 @@ snapshots:
     optionalDependencies:
       msw: 2.14.6(@types/node@20.19.41)(typescript@5.9.3)
       vite: 8.0.14(@types/node@20.19.41)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.7(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(vite@8.0.14(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@20.19.41)(typescript@5.9.3)
+      vite: 8.0.14(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.7(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
@@ -17196,13 +17208,13 @@ snapshots:
 
   country-list@2.4.1: {}
 
-  create-jest@29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0):
+  create-jest@29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -19079,7 +19091,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.1(babel-plugin-macros@3.1.0)
@@ -19099,16 +19111,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0):
+  jest-cli@29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)
+      create-jest: 29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -19118,7 +19130,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0):
+  jest-config@29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
@@ -19143,7 +19155,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -19172,7 +19184,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -19182,7 +19194,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -19221,7 +19233,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -19256,7 +19268,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -19284,7 +19296,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -19330,7 +19342,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -19349,7 +19361,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -19358,17 +19370,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0):
+  jest@29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)
+      jest-cli: 29.7.0(@types/node@22.19.19)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22850,6 +22862,34 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.14(@types/node@20.19.41)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.41
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.7(@types/node@20.19.41)(jsdom@29.1.1)(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(vite@8.0.14(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(vite@8.0.14(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.41

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -6,6 +6,7 @@ export default defineWorkspace([
   "./packages/kysely/vite.config.ts",
   "./packages/cloudflare/vite.config.ts",
   "./packages/authhero/vite.config.ts",
+  "./packages/create-authhero/vite.config.ts",
   // Excluded from vitest:
   // - packages/ui-widget: Uses Stencil's test runner (pnpm test in that package)
   // - test/routes: Legacy tests that need migration to a proper package


### PR DESCRIPTION
## Summary

`create-authhero` had no tests, and its generated `seed.ts`/`app.ts` are built from template strings that TypeScript never checks — so it broke from time to time without anyone noticing until a user scaffolded a project. This PR adds a vitest suite (84 tests, ~5s, no install/network needed) and fixes a real bug the suite caught immediately.

## Bug fix

The `aws-sst` template depended on and imported `@authhero/aws`, which does not exist on npm (404) — the published package is `@authhero/aws-adapter`. Every scaffolded aws-sst project failed at `npm install`.

## Tests

Both suites run the real CLI non-interactively (via tsx, from source) for all 7 templates plus flag combos, scaffolding into temp dirs with `--skip-install`:

**`test/scaffold.test.ts`** — per template: expected file tree, package.json deps/scripts, `--workspace` → `workspace:*`, multi-tenant vs single-tenant seed/app content, `--conformance` clients/config, `--github-ci` workflows, generated `.env`/`.dev.vars` encryption keys are valid 32-byte base64, and error cases (existing directory, unknown template).

**`test/generated-code.test.ts`** — the drift catcher. For every template it verifies the generated/copied TypeScript:
- is syntactically valid
- has resolvable relative imports (allowing postinstall-generated modules)
- only depends on `@authhero/*` packages that actually exist as workspace packages (this is what flags the `@authhero/aws` bug)
- only imports names the packages actually export — named/default imports are checked against the built packages' runtime exports and bundled `.d.ts` (following `export * from` re-exports, e.g. authhero re-exporting adapter-interfaces)

So renaming or removing an export like `seed`, `loadEncryptionKey`, or `initMultiTenant` now fails CI instead of a user's fresh scaffold.

## Wiring

- `"test": "vitest run"` in the package — picked up automatically by CI's existing `pnpm -r test` (which runs after `pnpm -r build`, so the built dists the drift test needs are present)
- registered in `vitest.workspace.ts`
- changeset included (patch)
- the existing CI wrangler dry-run smoke tests are unchanged — they cover the bundling layer these unit tests don't

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks for project scaffolding to help ensure generated apps are created correctly.
  * Expanded local test support for the project generator.

* **Bug Fixes**
  * Updated the AWS SST template to use the correct published package, improving generated project setup and imports.
  * Improved scaffold validation so generated files, dependencies, and exports are checked more reliably.

* **Tests**
  * Added comprehensive end-to-end coverage for template generation and failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->