### PR TITLE
Cut login-activity counters over to user_activity (contract phase of #1003)

### DIFF
--- a/.changeset/tidy-donuts-cover.md
+++ b/.changeset/tidy-donuts-cover.md
@@ -1,0 +1,9 @@
+---
+"authhero": minor
+"@authhero/kysely-adapter": minor
+---
+
+Cut login-activity counters over to the user_activity table (contract phase of #1003)
+
+- `authhero`: `postUserLoginHook` now writes `last_login`/`last_ip`/`login_count` to `data.userActivity` when the adapter provides it (falling back to `users.update` for third-party adapters that don't). This removes the per-login rewrite of the users row and its user-update decorator chain from the login path.
+- `@authhero/kysely-adapter`: `users.get`/`users.list` now LEFT JOIN `user_activity` for the activity fields (missing row = never logged in, `login_count` 0); filtering and sorting on those fields via `q`/`sort` still works. `users.create`/`users.update` route any activity fields they receive to `user_activity`. A new migration drops the legacy `last_login`/`last_ip`/`login_count` columns from `users` — run the user_activity backfill script against each environment **before** applying it, since the drop discards any values that were never copied.

--- a/.changeset/wild-moons-shake.md
+++ b/.changeset/wild-moons-shake.md
@@ -1,0 +1,5 @@
+---
+"@authhero/drizzle": minor
+---
+
+Bring drizzle to parity with the user_activity split (issue #1003): new `user_activity` table (regenerated 0000 baseline) and `userActivity` adapter (`get`/`upsert`), users get/list LEFT JOIN the counters (missing row = never logged in), create/update route `last_login`/`last_ip`/`login_count` to `user_activity`, and the legacy columns are dropped from the `users` schema. Filtering/sorting on activity fields via `q`/`sort` resolves against the joined table.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,17 @@ export default [
     },
     rules: {
       "react/react-in-jsx-scope": "off", // Turn off the rule for requiring React in scope
+      // `_`-prefixed bindings and rest-sibling destructuring are the
+      // codebase's idiom for intentionally-discarded values.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   },
 ];

--- a/packages/authhero/src/hooks/post-user-login.ts
+++ b/packages/authhero/src/hooks/post-user-login.ts
@@ -23,7 +23,10 @@ import {
 } from "./codehooks";
 import { invokeHooks } from "./webhooks";
 import { createTokenAPI } from "./helpers/token-api";
-import { getConnectionInfo, resolveConnectionName } from "../helpers/connection";
+import {
+  getConnectionInfo,
+  resolveConnectionName,
+} from "../helpers/connection";
 import { waitUntil } from "../helpers/wait-until";
 
 // Type guard for webhook hooks
@@ -90,11 +93,11 @@ async function buildEnhancedEventObject(
   // Get organization information if available
   let organizationInfo:
     | {
-      id: string;
-      name: string;
-      display_name: string;
-      metadata: any;
-    }
+        id: string;
+        name: string;
+        display_name: string;
+        metadata: any;
+      }
     | undefined = undefined;
   try {
     if (loginSession.authParams?.organization) {
@@ -179,8 +182,8 @@ async function buildEnhancedEventObject(
     organization: organizationInfo,
     resource_server: params.authParams?.audience
       ? {
-        identifier: params.authParams.audience,
-      }
+          identifier: params.authParams.audience,
+        }
       : undefined,
     stats: {
       logins_count: user.login_count || 0,
@@ -251,7 +254,10 @@ export async function postUserLoginHook(
   // real connection signal is available — that fallback is what caused SSO
   // re-issues to mislabel linked-identity logins.
   const connection =
-    params?.authStrategy?.strategy || params?.authConnection || user.connection || "";
+    params?.authStrategy?.strategy ||
+    params?.authConnection ||
+    user.connection ||
+    "";
 
   // SUCCESS_LOGIN is emitted in the `finally` below — deferred so we can embed
   // `details.execution_id` when post-login actions ran (matches Auth0's model
@@ -268,22 +274,23 @@ export async function postUserLoginHook(
     const lastLogin = new Date().toISOString();
     const lastIp = ctx.var.ip || "";
     const loginCount = user.login_count + 1;
-    waitUntil(
-      ctx,
-      data.users.update(tenant_id, user.user_id, {
-        last_login: lastLogin,
-        last_ip: lastIp,
-        login_count: loginCount,
-      }),
-    );
-    // Expand/contract migration (issue #1003): double-write the same counters
-    // to the user_activity entity. Reads still come from the legacy `users`
-    // columns this phase; a later PR cuts reads over and drops the columns.
-    // Guarded because the adapter is optional (e.g. drizzle doesn't ship it).
+    // Contract phase of issue #1003: user_activity is the authoritative
+    // store for these counters. The users.update fallback only exists for
+    // third-party adapters without a userActivity implementation (all
+    // in-repo adapters ship one), which keep the legacy columns on users.
     if (data.userActivity) {
       waitUntil(
         ctx,
         data.userActivity.upsert(tenant_id, user.user_id, {
+          last_login: lastLogin,
+          last_ip: lastIp,
+          login_count: loginCount,
+        }),
+      );
+    } else {
+      waitUntil(
+        ctx,
+        data.users.update(tenant_id, user.user_id, {
           last_login: lastLogin,
           last_ip: lastIp,
           login_count: loginCount,
@@ -298,18 +305,18 @@ export async function postUserLoginHook(
     const enhancedEvent =
       params?.client && params?.authParams && loginSession
         ? await buildEnhancedEventObject(
-          ctx,
-          data,
-          tenant_id,
-          user,
-          loginSession,
-          {
-            client: params.client,
-            authParams: params.authParams,
-            authStrategy: params.authStrategy,
-            authConnection: params.authConnection,
-          },
-        )
+            ctx,
+            data,
+            tenant_id,
+            user,
+            loginSession,
+            {
+              client: params.client,
+              authParams: params.authParams,
+              authStrategy: params.authStrategy,
+              authConnection: params.authConnection,
+            },
+          )
         : null;
 
     // Trigger any onExecutePostLogin hooks defined in ctx.env.hooks
@@ -318,7 +325,7 @@ export async function postUserLoginHook(
 
       await ctx.env.hooks.onExecutePostLogin(enhancedEvent, {
         prompt: {
-          render: (_formId: string) => { },
+          render: (_formId: string) => {},
         },
         redirect: {
           sendUserTo: (

--- a/packages/authhero/src/hooks/post-user-login.ts
+++ b/packages/authhero/src/hooks/post-user-login.ts
@@ -96,7 +96,7 @@ async function buildEnhancedEventObject(
         id: string;
         name: string;
         display_name: string;
-        metadata: any;
+        metadata: Record<string, unknown>;
       }
     | undefined = undefined;
   try {

--- a/packages/authhero/test/routes/auth-api/authorize-call-counts.spec.ts
+++ b/packages/authhero/test/routes/auth-api/authorize-call-counts.spec.ts
@@ -329,14 +329,13 @@ describe("authorize — adapter call counts", () => {
     expect(counts["codes.create"] ?? 0).toBe(1);
 
     // The last-login bookkeeping write still happens (deferred via
-    // waitUntil; the test runner flushes it before the response leaves).
-    // Its user-update decorator chain reads the user once more (the second
-    // users.get) and commits the write inside data.transaction() — whose
-    // inner adapter the counting wrapper intentionally bypasses, so
-    // users.update itself never shows up in counts. Both ride along in the
-    // deferred promise, off the response path on Workers.
-    expect(counts["users.get"] ?? 0).toBe(2);
-    expect(counts["transaction()"] ?? 0).toBe(1);
+    // waitUntil; the test runner flushes it before the response leaves),
+    // but since the issue #1003 cutover it goes to userActivity.upsert —
+    // no user-update decorator chain, so no second users.get and no
+    // data.transaction() on the warm path.
+    expect(counts["users.get"] ?? 0).toBe(1);
+    expect(counts["userActivity.upsert"] ?? 0).toBe(1);
+    expect(counts["transaction()"] ?? 0).toBe(0);
 
     // Middleware fallbacks must not fire: resume resolves its tenant from
     // the state artifact (single-tenant auto-detect is skipped).

--- a/packages/drizzle/drizzle/0000_init.sql
+++ b/packages/drizzle/drizzle/0000_init.sql
@@ -136,9 +136,6 @@ CREATE TABLE `users` (
 	`created_at` text(35) NOT NULL,
 	`updated_at` text(35) NOT NULL,
 	`linked_to` text(255),
-	`last_ip` text(255),
-	`login_count` integer NOT NULL,
-	`last_login` text(255),
 	`registration_completed_at` text(35),
 	`provider` text(255) NOT NULL,
 	`connection` text(255),
@@ -167,6 +164,18 @@ CREATE INDEX `users_email_index` ON `users` (`email`);--> statement-breakpoint
 CREATE INDEX `users_linked_to_index` ON `users` (`linked_to`);--> statement-breakpoint
 CREATE INDEX `users_name_index` ON `users` (`name`);--> statement-breakpoint
 CREATE INDEX `users_phone_tenant_provider_index` ON `users` (`tenant_id`,`phone_number`,`provider`);--> statement-breakpoint
+CREATE TABLE `user_activity` (
+	`tenant_id` text(255) NOT NULL,
+	`user_id` text(255) NOT NULL,
+	`last_login` text(35),
+	`last_ip` text(45),
+	`login_count` integer DEFAULT 0 NOT NULL,
+	`failed_logins` text,
+	`last_password_reset` text(35),
+	PRIMARY KEY(`tenant_id`, `user_id`),
+	FOREIGN KEY (`user_id`,`tenant_id`) REFERENCES `users`(`user_id`,`tenant_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
 CREATE TABLE `authentication_codes` (
 	`tenant_id` text(191) NOT NULL,
 	`code` text(255) PRIMARY KEY NOT NULL,

--- a/packages/drizzle/drizzle/meta/0000_snapshot.json
+++ b/packages/drizzle/drizzle/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "aa362ef7-2aa5-43c2-822c-5e9ffd5ec7e5",
+  "id": "f5a5b35e-cf8e-4fe4-afe9-ec2d33b03c33",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "tenants": {
@@ -952,27 +952,6 @@
           "notNull": false,
           "autoincrement": false
         },
-        "last_ip": {
-          "name": "last_ip",
-          "type": "text(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "login_count": {
-          "name": "login_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "last_login": {
-          "name": "last_login",
-          "type": "text(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
         "registration_completed_at": {
           "name": "registration_completed_at",
           "type": "text(35)",
@@ -1176,6 +1155,90 @@
             "tenant_id"
           ],
           "name": "users_tenants"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_activity": {
+      "name": "user_activity",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "text(35)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "text(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "login_count": {
+          "name": "login_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_logins": {
+          "name": "failed_logins",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_password_reset": {
+          "name": "last_password_reset",
+          "type": "text(35)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_constraint": {
+          "name": "user_activity_user_id_constraint",
+          "tableFrom": "user_activity",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id",
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "tenant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_activity_pkey": {
+          "columns": [
+            "tenant_id",
+            "user_id"
+          ],
+          "name": "user_activity_pkey"
         }
       },
       "uniqueConstraints": {},

--- a/packages/drizzle/drizzle/meta/_journal.json
+++ b/packages/drizzle/drizzle/meta/_journal.json
@@ -5,7 +5,7 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1781946733503,
+      "when": 1783004771436,
       "tag": "0000_init",
       "breakpoints": true
     }

--- a/packages/drizzle/src/adapters/index.ts
+++ b/packages/drizzle/src/adapters/index.ts
@@ -37,6 +37,7 @@ import { createTenantsAdapter } from "./tenants";
 import { createThemesAdapter } from "./themes";
 import { createUniversalLoginTemplatesAdapter } from "./universalLoginTemplates";
 import { createUsersAdapter } from "./users";
+import { createUserActivityAdapter } from "./userActivity";
 import { createUserRolesAdapter } from "./userRoles";
 import { createUserOrganizationsAdapter } from "./userOrganizations";
 import { createStatsAdapter } from "./stats";
@@ -90,6 +91,7 @@ export default function createAdapters(
     themes: createThemesAdapter(db),
     universalLoginTemplates: createUniversalLoginTemplatesAdapter(db),
     users: createUsersAdapter(db),
+    userActivity: createUserActivityAdapter(db),
     userRoles: createUserRolesAdapter(db),
     userOrganizations: createUserOrganizationsAdapter(db),
     stats: createStatsAdapter(db),

--- a/packages/drizzle/src/adapters/userActivity.ts
+++ b/packages/drizzle/src/adapters/userActivity.ts
@@ -1,0 +1,91 @@
+import { and, eq } from "drizzle-orm";
+import type {
+  UserActivity,
+  UserActivityAdapter,
+  UserActivityUpdate,
+} from "@authhero/adapter-interfaces";
+import { userActivity } from "../schema/sqlite";
+import type { DrizzleDb } from "./types";
+
+// Maps the domain update onto storage columns, serializing failed_logins.
+// Only keys that are explicitly provided are included, so an upsert never
+// clobbers a field the caller didn't set. Mirrors the kysely adapter.
+function toColumns(activity: UserActivityUpdate): {
+  last_login?: string;
+  last_ip?: string;
+  login_count?: number;
+  failed_logins?: string;
+  last_password_reset?: string;
+} {
+  const columns: {
+    last_login?: string;
+    last_ip?: string;
+    login_count?: number;
+    failed_logins?: string;
+    last_password_reset?: string;
+  } = {};
+  if (activity.last_login !== undefined)
+    columns.last_login = activity.last_login;
+  if (activity.last_ip !== undefined) columns.last_ip = activity.last_ip;
+  if (activity.login_count !== undefined)
+    columns.login_count = activity.login_count;
+  if (activity.failed_logins !== undefined)
+    columns.failed_logins = JSON.stringify(activity.failed_logins);
+  if (activity.last_password_reset !== undefined)
+    columns.last_password_reset = activity.last_password_reset;
+  return columns;
+}
+
+export function createUserActivityAdapter(db: DrizzleDb): UserActivityAdapter {
+  return {
+    async get(tenantId: string, userId: string): Promise<UserActivity | null> {
+      const row = await db
+        .select()
+        .from(userActivity)
+        .where(
+          and(
+            eq(userActivity.tenant_id, tenantId),
+            eq(userActivity.user_id, userId),
+          ),
+        )
+        .get();
+
+      if (!row) return null;
+
+      return {
+        user_id: row.user_id,
+        last_login: row.last_login ?? undefined,
+        last_ip: row.last_ip ?? undefined,
+        login_count: row.login_count,
+        failed_logins: row.failed_logins
+          ? (JSON.parse(row.failed_logins) as string[])
+          : undefined,
+        last_password_reset: row.last_password_reset ?? undefined,
+      };
+    },
+
+    async upsert(
+      tenantId: string,
+      userId: string,
+      activity: UserActivityUpdate,
+    ): Promise<void> {
+      const columns = toColumns(activity);
+      const insert = db.insert(userActivity).values({
+        tenant_id: tenantId,
+        user_id: userId,
+        login_count: 0,
+        ...columns,
+      });
+
+      if (Object.keys(columns).length === 0) {
+        await insert.onConflictDoNothing();
+        return;
+      }
+
+      await insert.onConflictDoUpdate({
+        target: [userActivity.tenant_id, userActivity.user_id],
+        set: columns,
+      });
+    },
+  };
+}

--- a/packages/drizzle/src/adapters/users.ts
+++ b/packages/drizzle/src/adapters/users.ts
@@ -10,11 +10,17 @@ import {
 import { nanoid } from "nanoid";
 import { HTTPException } from "hono/http-exception";
 import type { User, ListParams } from "@authhero/adapter-interfaces";
-import { users, passwords, authenticationMethods } from "../schema/sqlite";
+import {
+  users,
+  userActivity,
+  passwords,
+  authenticationMethods,
+} from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import { buildLuceneFilter, sanitizeLuceneQuery } from "../helpers/filter";
+import { createUserActivityAdapter } from "./userActivity";
 import type { DrizzleDb } from "./types";
-import { runAtomic } from "./atomic";
+import { runAtomic, type AtomicStatementList } from "./atomic";
 
 // Fields users.list() accepts in `q`. Excludes `tenant_id` so a clause like
 // `q=tenant_id:other` cannot reach arbitrary columns. Mirrors the kysely
@@ -45,6 +51,47 @@ const ALLOWED_Q_FIELDS = [
 
 // buildLuceneFilter routes bare-string tokens through this list (LIKE search).
 const SEARCHABLE_COLUMNS = ["email", "name", "phone_number", "user_id"];
+
+// Activity counters live in the joined user_activity table (issue #1003);
+// everything else resolves against users. This map feeds buildLuceneFilter
+// and sorting so each public field hits the right table's column.
+const ACTIVITY_FIELDS = new Set(["last_login", "last_ip", "login_count"]);
+
+const FILTER_COLUMNS: Record<string, unknown> = Object.fromEntries(
+  ALLOWED_Q_FIELDS.map((field) => [
+    field,
+    ACTIVITY_FIELDS.has(field)
+      ? (userActivity as any)[field]
+      : (users as any)[field],
+  ]),
+);
+
+// Join predicate reused by get/list; user_activity is 1:1 with users (PK is
+// tenant_id+user_id) so a LEFT JOIN never fans out rows. A missing row means
+// the user never logged in.
+function activityJoin() {
+  return and(
+    eq(userActivity.tenant_id, users.tenant_id),
+    eq(userActivity.user_id, users.user_id),
+  );
+}
+
+// Merge a joined row back into the flat user shape sqlToUser expects.
+function withActivity<T extends Record<string, unknown>>(
+  userRow: T,
+  activityRow: {
+    last_login: string | null;
+    last_ip: string | null;
+    login_count: number;
+  } | null,
+) {
+  return {
+    ...userRow,
+    last_login: activityRow?.last_login,
+    last_ip: activityRow?.last_ip,
+    login_count: activityRow?.login_count ?? 0,
+  };
+}
 
 function userToIdentity(sqlUser: any, isPrimary: boolean) {
   const identity: any = {
@@ -117,9 +164,6 @@ export function createUsersAdapter(db: DrizzleDb) {
       phone_verified: params.phone_verified ?? false,
       username: params.username,
       linked_to: params.linked_to,
-      last_ip: params.last_ip,
-      login_count: params.login_count ?? 0,
-      last_login: params.last_login,
       provider: params.provider,
       connection: params.connection,
       email_verified: params.email_verified ?? false,
@@ -144,13 +188,34 @@ export function createUsersAdapter(db: DrizzleDb) {
 
     const passwordId = params.password ? nanoid() : undefined;
 
+    // Callers that record a login at creation time (e.g. lazy Auth0
+    // migration, social sign-up) pass activity fields — those live in
+    // user_activity (issue #1003), not on the users row.
+    const hasActivity =
+      params.last_login !== undefined ||
+      params.last_ip !== undefined ||
+      params.login_count !== undefined;
+
     try {
+      // Insert the user and its activity/password rows atomically so all
+      // succeed or all roll back. runAtomic uses db.batch() on D1 and
+      // BEGIN/COMMIT on better-sqlite3.
+      const statements: AtomicStatementList = [
+        db.insert(users).values(sqlData),
+      ];
+      if (hasActivity) {
+        statements.push(
+          db.insert(userActivity).values({
+            tenant_id,
+            user_id: params.user_id,
+            last_login: params.last_login,
+            last_ip: params.last_ip,
+            login_count: params.login_count ?? 0,
+          }),
+        );
+      }
       if (params.password && passwordId) {
-        // Insert the user and its password atomically so both succeed or both
-        // roll back. runAtomic uses db.batch() on D1 and BEGIN/COMMIT on
-        // better-sqlite3.
-        await runAtomic(db, [
-          db.insert(users).values(sqlData),
+        statements.push(
           db.insert(passwords).values({
             id: passwordId,
             tenant_id,
@@ -161,7 +226,11 @@ export function createUsersAdapter(db: DrizzleDb) {
             created_at: now,
             updated_at: now,
           }),
-        ]);
+        );
+      }
+
+      if (statements.length > 1) {
+        await runAtomic(db, statements);
       } else {
         await db.insert(users).values(sqlData);
       }
@@ -178,7 +247,12 @@ export function createUsersAdapter(db: DrizzleDb) {
       });
     }
 
-    return sqlToUser(sqlData);
+    return sqlToUser({
+      ...sqlData,
+      last_login: params.last_login,
+      last_ip: params.last_ip,
+      login_count: params.login_count ?? 0,
+    });
   };
 
   return {
@@ -189,6 +263,7 @@ export function createUsersAdapter(db: DrizzleDb) {
       const result = await db
         .select()
         .from(users)
+        .leftJoin(userActivity, activityJoin())
         .where(and(eq(users.tenant_id, tenant_id), eq(users.user_id, user_id)))
         .get();
 
@@ -203,7 +278,10 @@ export function createUsersAdapter(db: DrizzleDb) {
         )
         .all();
 
-      return sqlToUser(result, linked);
+      return sqlToUser(
+        withActivity(result.users, result.user_activity),
+        linked,
+      );
     },
 
     async update(
@@ -211,6 +289,20 @@ export function createUsersAdapter(db: DrizzleDb) {
       user_id: string,
       params: Partial<User>,
     ): Promise<boolean> {
+      // Activity counters live in user_activity (issue #1003). Route them
+      // there so callers that still pass them keep working.
+      if (
+        params.last_login !== undefined ||
+        params.last_ip !== undefined ||
+        params.login_count !== undefined
+      ) {
+        await createUserActivityAdapter(db).upsert(tenant_id, user_id, {
+          last_login: params.last_login,
+          last_ip: params.last_ip,
+          login_count: params.login_count,
+        });
+      }
+
       const updateData: any = {
         updated_at: new Date().toISOString(),
       };
@@ -227,9 +319,6 @@ export function createUsersAdapter(db: DrizzleDb) {
         "phone_number",
         "username",
         "linked_to",
-        "last_ip",
-        "login_count",
-        "last_login",
         "provider",
         "connection",
         "locale",
@@ -295,7 +384,7 @@ export function createUsersAdapter(db: DrizzleDb) {
         const sanitized = sanitizeLuceneQuery(q, ALLOWED_Q_FIELDS);
         if (sanitized) {
           const filter = buildLuceneFilter(
-            users,
+            FILTER_COLUMNS,
             sanitized,
             SEARCHABLE_COLUMNS,
           );
@@ -305,18 +394,26 @@ export function createUsersAdapter(db: DrizzleDb) {
 
       const whereClause = and(...conditions);
 
-      let query = db.select().from(users).where(whereClause).$dynamic();
+      let query = db
+        .select()
+        .from(users)
+        .leftJoin(userActivity, activityJoin())
+        .where(whereClause)
+        .$dynamic();
 
       if (sort?.sort_by) {
-        const col = (users as any)[sort.sort_by];
+        const col = FILTER_COLUMNS[sort.sort_by];
         if (col) {
           query = query.orderBy(
-            sort.sort_order === "desc" ? desc(col) : asc(col),
+            sort.sort_order === "desc" ? desc(col as any) : asc(col as any),
           );
         }
       }
 
-      const results = await query.offset(page * per_page).limit(per_page);
+      const joinedResults = await query.offset(page * per_page).limit(per_page);
+      const results = joinedResults.map((row) =>
+        withActivity(row.users, row.user_activity),
+      );
 
       // Fetch linked users for these results
       const primaryIds = results.map((r) => r.user_id);
@@ -343,9 +440,12 @@ export function createUsersAdapter(db: DrizzleDb) {
         return { users: mapped };
       }
 
+      // The where clause may reference joined user_activity columns, so the
+      // count query needs the same join (1:1, so counts are unaffected).
       const [countResult] = await db
         .select({ count: countFn() })
         .from(users)
+        .leftJoin(userActivity, activityJoin())
         .where(whereClause);
 
       return {
@@ -389,6 +489,16 @@ export function createUsersAdapter(db: DrizzleDb) {
             and(
               eq(passwords.tenant_id, tenant_id),
               inArray(passwords.user_id, allUserIds),
+            ),
+          ),
+        // Delete activity counters for all users (don't rely on FK cascades —
+        // the rest of this cascade is explicit for the same reason)
+        db
+          .delete(userActivity)
+          .where(
+            and(
+              eq(userActivity.tenant_id, tenant_id),
+              inArray(userActivity.user_id, allUserIds),
             ),
           ),
         // Delete linked users — by the same captured IDs the credential

--- a/packages/drizzle/src/adapters/users.ts
+++ b/packages/drizzle/src/adapters/users.ts
@@ -17,7 +17,13 @@ import {
   authenticationMethods,
 } from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
-import { buildLuceneFilter, sanitizeLuceneQuery } from "../helpers/filter";
+import {
+  buildLuceneFilter,
+  sanitizeLuceneQuery,
+  coalescedExpr,
+  isCoalescedNumericColumn,
+  type CoalescedNumericColumn,
+} from "../helpers/filter";
 import { createUserActivityAdapter } from "./userActivity";
 import type { DrizzleDb } from "./types";
 import { runAtomic, type AtomicStatementList } from "./atomic";
@@ -60,9 +66,17 @@ const ACTIVITY_FIELDS = new Set(["last_login", "last_ip", "login_count"]);
 const FILTER_COLUMNS: Record<string, unknown> = Object.fromEntries(
   ALLOWED_Q_FIELDS.map((field) => [
     field,
-    ACTIVITY_FIELDS.has(field)
-      ? (userActivity as any)[field]
-      : (users as any)[field],
+    field === "login_count"
+      ? // list/get present a missing activity row as login_count 0, so
+        // filters and sorts must treat NULL as 0 too — otherwise
+        // `q=login_count:0` would skip users who never logged in.
+        ({
+          coalesce: userActivity.login_count,
+          defaultValue: 0,
+        } satisfies CoalescedNumericColumn)
+      : ACTIVITY_FIELDS.has(field)
+        ? (userActivity as any)[field]
+        : (users as any)[field],
   ]),
 );
 
@@ -404,8 +418,9 @@ export function createUsersAdapter(db: DrizzleDb) {
       if (sort?.sort_by) {
         const col = FILTER_COLUMNS[sort.sort_by];
         if (col) {
+          const expr = isCoalescedNumericColumn(col) ? coalescedExpr(col) : col;
           query = query.orderBy(
-            sort.sort_order === "desc" ? desc(col as any) : asc(col as any),
+            sort.sort_order === "desc" ? desc(expr as any) : asc(expr as any),
           );
         }
       }

--- a/packages/drizzle/src/adapters/users.ts
+++ b/packages/drizzle/src/adapters/users.ts
@@ -4,9 +4,11 @@ import {
   count as countFn,
   asc,
   desc,
+  getTableColumns,
   inArray,
   isNull,
 } from "drizzle-orm";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 import { nanoid } from "nanoid";
 import { HTTPException } from "hono/http-exception";
 import type { User, ListParams } from "@authhero/adapter-interfaces";
@@ -63,7 +65,14 @@ const SEARCHABLE_COLUMNS = ["email", "name", "phone_number", "user_id"];
 // and sorting so each public field hits the right table's column.
 const ACTIVITY_FIELDS = new Set(["last_login", "last_ip", "login_count"]);
 
-const FILTER_COLUMNS: Record<string, unknown> = Object.fromEntries(
+const USER_COLUMNS: Record<string, AnySQLiteColumn> = getTableColumns(users);
+const ACTIVITY_COLUMNS: Record<string, AnySQLiteColumn> =
+  getTableColumns(userActivity);
+
+const FILTER_COLUMNS: Record<
+  string,
+  AnySQLiteColumn | CoalescedNumericColumn | undefined
+> = Object.fromEntries(
   ALLOWED_Q_FIELDS.map((field) => [
     field,
     field === "login_count"
@@ -75,8 +84,8 @@ const FILTER_COLUMNS: Record<string, unknown> = Object.fromEntries(
           defaultValue: 0,
         } satisfies CoalescedNumericColumn)
       : ACTIVITY_FIELDS.has(field)
-        ? (userActivity as any)[field]
-        : (users as any)[field],
+        ? ACTIVITY_COLUMNS[field]
+        : USER_COLUMNS[field],
   ]),
 );
 
@@ -303,20 +312,6 @@ export function createUsersAdapter(db: DrizzleDb) {
       user_id: string,
       params: Partial<User>,
     ): Promise<boolean> {
-      // Activity counters live in user_activity (issue #1003). Route them
-      // there so callers that still pass them keep working.
-      if (
-        params.last_login !== undefined ||
-        params.last_ip !== undefined ||
-        params.login_count !== undefined
-      ) {
-        await createUserActivityAdapter(db).upsert(tenant_id, user_id, {
-          last_login: params.last_login,
-          last_ip: params.last_ip,
-          login_count: params.login_count,
-        });
-      }
-
       const updateData: any = {
         updated_at: new Date().toISOString(),
       };
@@ -374,7 +369,27 @@ export function createUsersAdapter(db: DrizzleDb) {
         .where(and(eq(users.tenant_id, tenant_id), eq(users.user_id, user_id)))
         .returning();
 
-      return results.length > 0;
+      if (results.length === 0) {
+        return false;
+      }
+
+      // Activity counters live in user_activity (issue #1003). Route them
+      // there so callers that still pass them keep working — but only after
+      // the users update confirmed the row exists, so a missing user never
+      // gains an orphaned activity row.
+      if (
+        params.last_login !== undefined ||
+        params.last_ip !== undefined ||
+        params.login_count !== undefined
+      ) {
+        await createUserActivityAdapter(db).upsert(tenant_id, user_id, {
+          last_login: params.last_login,
+          last_ip: params.last_ip,
+          login_count: params.login_count,
+        });
+      }
+
+      return true;
     },
 
     async list(tenant_id: string, params?: ListParams) {
@@ -420,7 +435,7 @@ export function createUsersAdapter(db: DrizzleDb) {
         if (col) {
           const expr = isCoalescedNumericColumn(col) ? coalescedExpr(col) : col;
           query = query.orderBy(
-            sort.sort_order === "desc" ? desc(expr as any) : asc(expr as any),
+            sort.sort_order === "desc" ? desc(expr) : asc(expr),
           );
         }
       }

--- a/packages/drizzle/src/helpers/filter.ts
+++ b/packages/drizzle/src/helpers/filter.ts
@@ -14,7 +14,36 @@ import {
   SQL,
   sql,
 } from "drizzle-orm";
-import type { SQLiteTableWithColumns } from "drizzle-orm/sqlite-core";
+import type {
+  AnySQLiteColumn,
+  SQLiteTableWithColumns,
+} from "drizzle-orm/sqlite-core";
+
+// A filter target backed by a nullable LEFT-JOINed column that the public
+// shape presents with a numeric default (e.g. `login_count` -> 0 when the
+// user has no user_activity row). Comparisons wrap the column in COALESCE so
+// rows without a joined row still match, and bind the operand as a number: a
+// COALESCE expression has no column affinity in SQLite, so a string operand
+// would compare as text and never match.
+export type CoalescedNumericColumn = {
+  coalesce: AnySQLiteColumn;
+  defaultValue: number;
+};
+
+export function isCoalescedNumericColumn(
+  value: unknown,
+): value is CoalescedNumericColumn {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "coalesce" in value &&
+    "defaultValue" in value
+  );
+}
+
+export function coalescedExpr(mapping: CoalescedNumericColumn): SQL {
+  return sql`coalesce(${mapping.coalesce}, ${mapping.defaultValue})`;
+}
 
 // Strip field-scoped clauses (`field:value`, `-field:value`, `_exists_:field`,
 // `field=value`) whose field is not in `allowedFields`. Bare-string tokens are
@@ -105,6 +134,10 @@ export function buildLuceneFilter<
   likeFields: string[] = [],
 ): SQL | undefined {
   const likeSet = new Set(likeFields);
+  const toNumericOperand = (value: string): string | number => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : value;
+  };
 
   // Handle OR queries
   const orParts = query.split(/ OR /i);
@@ -120,6 +153,9 @@ export function buildLuceneFilter<
           const cleanValue = value.replace(/^"(.*)"$/, "$1").trim();
           const col = (table as any)[fieldName];
           if (!col) return null;
+          if (isCoalescedNumericColumn(col)) {
+            return eq(coalescedExpr(col), toNumericOperand(cleanValue));
+          }
           return likeSet.has(fieldName)
             ? like(col, `%${cleanValue}%`)
             : eq(col, cleanValue);
@@ -218,7 +254,13 @@ export function buildLuceneFilter<
 
   for (const { key, value, isNegation, isExistsQuery, operator } of filters) {
     if (key) {
-      const col = (table as any)[key];
+      const mapped = (table as any)[key];
+      // `_exists_` still checks the raw column — "no activity row" is the
+      // meaningful NULL there, and COALESCE would make it never-null.
+      const isCoalesced = isCoalescedNumericColumn(mapped);
+      const col = isCoalesced ? mapped.coalesce : mapped;
+      const lhs = isCoalesced ? coalescedExpr(mapped) : mapped;
+      const operand = isCoalesced ? toNumericOperand(value) : value;
       if (!col) {
         // Use raw SQL for unknown columns
         if (isExistsQuery) {
@@ -246,36 +288,36 @@ export function buildLuceneFilter<
       } else if (isNegation) {
         switch (operator) {
           case ">":
-            conditions.push(lte(col, value));
+            conditions.push(lte(lhs, operand));
             break;
           case ">=":
-            conditions.push(lt(col, value));
+            conditions.push(lt(lhs, operand));
             break;
           case "<":
-            conditions.push(gte(col, value));
+            conditions.push(gte(lhs, operand));
             break;
           case "<=":
-            conditions.push(gt(col, value));
+            conditions.push(gt(lhs, operand));
             break;
           default:
-            conditions.push(ne(col, value));
+            conditions.push(ne(lhs, operand));
         }
       } else {
         switch (operator) {
           case ">":
-            conditions.push(gt(col, value));
+            conditions.push(gt(lhs, operand));
             break;
           case ">=":
-            conditions.push(gte(col, value));
+            conditions.push(gte(lhs, operand));
             break;
           case "<":
-            conditions.push(lt(col, value));
+            conditions.push(lt(lhs, operand));
             break;
           case "<=":
-            conditions.push(lte(col, value));
+            conditions.push(lte(lhs, operand));
             break;
           default:
-            conditions.push(eq(col, value));
+            conditions.push(eq(lhs, operand));
         }
       }
     } else if (value) {

--- a/packages/drizzle/src/helpers/filter.ts
+++ b/packages/drizzle/src/helpers/filter.ts
@@ -11,13 +11,14 @@ import {
   or,
   isNull,
   isNotNull,
+  is,
+  getTableColumns,
+  Column,
   SQL,
   sql,
 } from "drizzle-orm";
-import type {
-  AnySQLiteColumn,
-  SQLiteTableWithColumns,
-} from "drizzle-orm/sqlite-core";
+import { SQLiteTable } from "drizzle-orm/sqlite-core";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 
 // A filter target backed by a nullable LEFT-JOINed column that the public
 // shape presents with a numeric default (e.g. `login_count` -> 0 when the
@@ -125,14 +126,17 @@ export function sanitizeLuceneQuery(
  * several tables (e.g. users + user_activity) so each public field resolves to
  * a column of the right table.
  */
-export function buildLuceneFilter<
-  T extends SQLiteTableWithColumns<any> | Record<string, unknown>,
->(
-  table: T,
+export function buildLuceneFilter(
+  table: SQLiteTable | Record<string, unknown>,
   query: string,
   searchableColumns: string[],
   likeFields: string[] = [],
 ): SQL | undefined {
+  // Normalize to a plain field→value record so the lookups below stay typed;
+  // `is()` + `getTableColumns()` avoid reaching into the table via `any`.
+  const columns: Record<string, unknown> = is(table, SQLiteTable)
+    ? getTableColumns(table)
+    : table;
   const likeSet = new Set(likeFields);
   const toNumericOperand = (value: string): string | number => {
     const num = Number(value);
@@ -151,18 +155,18 @@ export function buildLuceneFilter<
           if (!field || !value) return null;
           const fieldName = field.trim();
           const cleanValue = value.replace(/^"(.*)"$/, "$1").trim();
-          const col = (table as any)[fieldName];
-          if (!col) return null;
+          const col = columns[fieldName];
           if (isCoalescedNumericColumn(col)) {
             return eq(coalescedExpr(col), toNumericOperand(cleanValue));
           }
+          if (!is(col, Column)) return null;
           return likeSet.has(fieldName)
             ? like(col, `%${cleanValue}%`)
             : eq(col, cleanValue);
         }
         return null;
       })
-      .filter(Boolean) as SQL[];
+      .filter((condition): condition is SQL => condition !== null);
 
     if (conditions.length === 0) return undefined;
     return or(...conditions);
@@ -254,12 +258,15 @@ export function buildLuceneFilter<
 
   for (const { key, value, isNegation, isExistsQuery, operator } of filters) {
     if (key) {
-      const mapped = (table as any)[key];
+      const mapped = columns[key];
       // `_exists_` still checks the raw column — "no activity row" is the
       // meaningful NULL there, and COALESCE would make it never-null.
       const isCoalesced = isCoalescedNumericColumn(mapped);
-      const col = isCoalesced ? mapped.coalesce : mapped;
-      const lhs = isCoalesced ? coalescedExpr(mapped) : mapped;
+      const col = isCoalesced
+        ? mapped.coalesce
+        : is(mapped, Column)
+          ? mapped
+          : undefined;
       const operand = isCoalesced ? toNumericOperand(value) : value;
       if (!col) {
         // Use raw SQL for unknown columns
@@ -276,6 +283,10 @@ export function buildLuceneFilter<
         }
         continue;
       }
+
+      // Interpolating a Column into `sql` renders its qualified name, so both
+      // arms produce the same SQL a bare-column operator call would.
+      const lhs: SQL = isCoalesced ? coalescedExpr(mapped) : sql`${col}`;
 
       if (isExistsQuery) {
         conditions.push(isNegation ? isNull(col) : isNotNull(col));
@@ -328,13 +339,13 @@ export function buildLuceneFilter<
 
       const searchConditions = columnsToSearch
         .map((colName) => {
-          const col = (table as any)[colName];
-          if (!col) return null;
+          const col = columns[colName];
+          if (!is(col, Column)) return null;
           return colName === "user_id"
             ? eq(col, value)
             : like(col, `%${value}%`);
         })
-        .filter(Boolean) as SQL[];
+        .filter((condition): condition is SQL => condition !== null);
 
       if (searchConditions.length > 0) {
         conditions.push(or(...searchConditions)!);

--- a/packages/drizzle/src/helpers/filter.ts
+++ b/packages/drizzle/src/helpers/filter.ts
@@ -91,8 +91,14 @@ export function sanitizeLuceneQuery(
  * - Quoted values: field:"value with spaces"
  * - likeFields: fields matched with substring LIKE instead of exact equality
  *   (e.g. free-text log descriptions), mirroring the kysely adapter.
+ *
+ * `table` can also be a plain field→column map. Use that when the query joins
+ * several tables (e.g. users + user_activity) so each public field resolves to
+ * a column of the right table.
  */
-export function buildLuceneFilter<T extends SQLiteTableWithColumns<any>>(
+export function buildLuceneFilter<
+  T extends SQLiteTableWithColumns<any> | Record<string, unknown>,
+>(
   table: T,
   query: string,
   searchableColumns: string[],

--- a/packages/drizzle/src/schema/sqlite/index.ts
+++ b/packages/drizzle/src/schema/sqlite/index.ts
@@ -16,6 +16,7 @@ export * from "./actions";
 
 // Users & Authentication
 export * from "./users";
+export * from "./userActivity";
 export * from "./sessions";
 
 // Clients & Grants

--- a/packages/drizzle/src/schema/sqlite/userActivity.ts
+++ b/packages/drizzle/src/schema/sqlite/userActivity.ts
@@ -1,0 +1,38 @@
+import {
+  sqliteTable,
+  text,
+  integer,
+  primaryKey,
+  foreignKey,
+} from "drizzle-orm/sqlite-core";
+import { users } from "./users";
+
+/**
+ * Write-often per-user counters split out of the `users` row (issue #1003) so
+ * the profile row isn't rewritten on every login / failed password attempt.
+ * 1:1 with a user; a missing row means the user never logged in. Mirrors the
+ * kysely adapter's `user_activity` table.
+ */
+export const userActivity = sqliteTable(
+  "user_activity",
+  {
+    tenant_id: text("tenant_id", { length: 255 }).notNull(),
+    user_id: text("user_id", { length: 255 }).notNull(),
+    last_login: text("last_login", { length: 35 }),
+    last_ip: text("last_ip", { length: 45 }), // right-sized for IPv6
+    login_count: integer("login_count").notNull().default(0),
+    failed_logins: text("failed_logins"), // JSON array of lockout timestamps
+    last_password_reset: text("last_password_reset", { length: 35 }),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.tenant_id, table.user_id],
+      name: "user_activity_pkey",
+    }),
+    foreignKey({
+      columns: [table.user_id, table.tenant_id],
+      foreignColumns: [users.user_id, users.tenant_id],
+      name: "user_activity_user_id_constraint",
+    }).onDelete("cascade"),
+  ],
+);

--- a/packages/drizzle/src/schema/sqlite/users.ts
+++ b/packages/drizzle/src/schema/sqlite/users.ts
@@ -28,9 +28,8 @@ export const users = sqliteTable(
     created_at: text("created_at", { length: 35 }).notNull(),
     updated_at: text("updated_at", { length: 35 }).notNull(),
     linked_to: text("linked_to", { length: 255 }),
-    last_ip: text("last_ip", { length: 255 }),
-    login_count: integer("login_count").notNull(),
-    last_login: text("last_login", { length: 255 }),
+    // last_login/last_ip/login_count live in the user_activity table
+    // (issue #1003), not on the users row.
     registration_completed_at: text("registration_completed_at", {
       length: 35,
     }),

--- a/packages/drizzle/test/adapters/users.test.ts
+++ b/packages/drizzle/test/adapters/users.test.ts
@@ -202,10 +202,18 @@ describe("users adapter", () => {
       login_count: 0,
     });
 
+    // login_count at create time seeds a user_activity row, so the remove
+    // below must clean it up too.
+    expect(
+      await data.userActivity!.get("tenant1", "auth0|user1"),
+    ).not.toBeNull();
+
     const removed = await data.users.remove("tenant1", "auth0|user1");
     expect(removed).toBe(true);
 
     const fetched = await data.users.get("tenant1", "auth0|user1");
     expect(fetched).toBeNull();
+
+    expect(await data.userActivity!.get("tenant1", "auth0|user1")).toBeNull();
   });
 });

--- a/packages/drizzle/test/adapters/users.test.ts
+++ b/packages/drizzle/test/adapters/users.test.ts
@@ -126,6 +126,52 @@ describe("users adapter", () => {
     expect(none.users).toHaveLength(0);
   });
 
+  it("treats users without an activity row as login_count 0 in filters and sorts", async () => {
+    // get/list present a missing user_activity row as login_count 0, so
+    // filters and sorts must match that shape (COALESCE, not the raw NULL).
+    await data.users.create("tenant1", {
+      user_id: "auth0|never",
+      email: "never@example.com",
+      email_verified: true,
+      is_social: false,
+      provider: "auth0",
+    });
+    await data.users.create("tenant1", {
+      user_id: "auth0|active",
+      email: "active@example.com",
+      email_verified: true,
+      is_social: false,
+      provider: "auth0",
+    });
+    await data.userActivity!.upsert("tenant1", "auth0|active", {
+      login_count: 5,
+    });
+
+    const neverLoggedIn = await data.users.list("tenant1", {
+      q: "login_count:0",
+    });
+    expect(neverLoggedIn.users.map((u) => u.user_id)).toEqual(["auth0|never"]);
+
+    const below = await data.users.list("tenant1", { q: "login_count:<5" });
+    expect(below.users.map((u) => u.user_id)).toEqual(["auth0|never"]);
+
+    const ascending = await data.users.list("tenant1", {
+      sort: { sort_by: "login_count", sort_order: "asc" },
+    });
+    expect(ascending.users.map((u) => u.user_id)).toEqual([
+      "auth0|never",
+      "auth0|active",
+    ]);
+
+    const descending = await data.users.list("tenant1", {
+      sort: { sort_by: "login_count", sort_order: "desc" },
+    });
+    expect(descending.users.map((u) => u.user_id)).toEqual([
+      "auth0|active",
+      "auth0|never",
+    ]);
+  });
+
   it("persists activity fields passed at creation time", async () => {
     // e.g. lazy Auth0 migration records the login on the created user.
     await data.users.create("tenant1", {

--- a/packages/drizzle/test/adapters/users.test.ts
+++ b/packages/drizzle/test/adapters/users.test.ts
@@ -76,6 +76,76 @@ describe("users adapter", () => {
     expect(result.users.length).toBe(2);
   });
 
+  it("stores activity counters in user_activity and reads them back", async () => {
+    await data.users.create("tenant1", {
+      user_id: "auth0|user1",
+      email: "active@example.com",
+      email_verified: true,
+      is_social: false,
+      provider: "auth0",
+    });
+
+    // No activity yet: missing user_activity row coalesces to 0.
+    const fresh = await data.users.get("tenant1", "auth0|user1");
+    expect(fresh!.login_count).toBe(0);
+    expect(fresh!.last_login).toBeUndefined();
+
+    // The post-login write path.
+    await data.userActivity!.upsert("tenant1", "auth0|user1", {
+      last_login: "2026-07-02T10:00:00.000Z",
+      last_ip: "1.2.3.4",
+      login_count: 3,
+    });
+
+    const activity = await data.userActivity!.get("tenant1", "auth0|user1");
+    expect(activity).toMatchObject({
+      last_login: "2026-07-02T10:00:00.000Z",
+      last_ip: "1.2.3.4",
+      login_count: 3,
+    });
+
+    // users.get merges the counters via the join.
+    const fetched = await data.users.get("tenant1", "auth0|user1");
+    expect(fetched!.login_count).toBe(3);
+    expect(fetched!.last_login).toBe("2026-07-02T10:00:00.000Z");
+    expect(fetched!.last_ip).toBe("1.2.3.4");
+
+    // Legacy callers passing counters through users.update are routed too.
+    await data.users.update("tenant1", "auth0|user1", { login_count: 4 });
+    const updated = await data.users.get("tenant1", "auth0|user1");
+    expect(updated!.login_count).toBe(4);
+    // A partial upsert must not clobber other activity fields.
+    expect(updated!.last_ip).toBe("1.2.3.4");
+
+    // Filtering and sorting on activity fields resolve against the join.
+    const filtered = await data.users.list("tenant1", {
+      q: "login_count:>0",
+    });
+    expect(filtered.users.map((u) => u.user_id)).toEqual(["auth0|user1"]);
+    const none = await data.users.list("tenant1", { q: "login_count:>10" });
+    expect(none.users).toHaveLength(0);
+  });
+
+  it("persists activity fields passed at creation time", async () => {
+    // e.g. lazy Auth0 migration records the login on the created user.
+    await data.users.create("tenant1", {
+      user_id: "auth0|migrated",
+      email: "migrated@example.com",
+      email_verified: true,
+      is_social: false,
+      provider: "auth0",
+      last_login: "2026-07-01T00:00:00.000Z",
+      last_ip: "5.6.7.8",
+    });
+
+    const fetched = await data.users.get("tenant1", "auth0|migrated");
+    expect(fetched!.last_login).toBe("2026-07-01T00:00:00.000Z");
+    expect(fetched!.last_ip).toBe("5.6.7.8");
+
+    const activity = await data.userActivity!.get("tenant1", "auth0|migrated");
+    expect(activity!.last_login).toBe("2026-07-01T00:00:00.000Z");
+  });
+
   it("should remove a user", async () => {
     await data.users.create("tenant1", {
       user_id: "auth0|user1",

--- a/packages/kysely/migrate/migrations/2026-07-02T12:00:00_drop_user_activity_columns_from_users.ts
+++ b/packages/kysely/migrate/migrations/2026-07-02T12:00:00_drop_user_activity_columns_from_users.ts
@@ -1,4 +1,4 @@
-import { Kysely } from "kysely";
+import { Kysely, sql } from "kysely";
 import { Database } from "../../src/db";
 
 /**
@@ -31,4 +31,27 @@ export async function down(db: Kysely<Database>): Promise<void> {
     .alterTable("users")
     .addColumn("login_count", "integer", (col) => col.notNull().defaultTo(0))
     .execute();
+
+  // Rehydrate the re-added columns from user_activity so a rollback restores
+  // the counters instead of leaving them empty. Raw SQL because the columns
+  // no longer exist on the Database type; correlated subqueries against a
+  // different table work on both SQLite/D1 and MySQL.
+  await sql`
+    UPDATE users SET
+      last_login = (
+        SELECT ua.last_login FROM user_activity ua
+        WHERE ua.tenant_id = users.tenant_id AND ua.user_id = users.user_id
+      ),
+      last_ip = (
+        SELECT ua.last_ip FROM user_activity ua
+        WHERE ua.tenant_id = users.tenant_id AND ua.user_id = users.user_id
+      ),
+      login_count = COALESCE(
+        (
+          SELECT ua.login_count FROM user_activity ua
+          WHERE ua.tenant_id = users.tenant_id AND ua.user_id = users.user_id
+        ),
+        0
+      )
+  `.execute(db);
 }

--- a/packages/kysely/migrate/migrations/2026-07-02T12:00:00_drop_user_activity_columns_from_users.ts
+++ b/packages/kysely/migrate/migrations/2026-07-02T12:00:00_drop_user_activity_columns_from_users.ts
@@ -1,0 +1,34 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/db";
+
+/**
+ * Contract phase of the user_activity split (issue #1003): the counters were
+ * backfilled into `user_activity` and all reads/writes have been cut over, so
+ * the legacy `users` columns can go. Requires the backfill script to have run
+ * against the environment first — dropping the columns discards any values
+ * that were never copied.
+ *
+ * Plain DROP COLUMN works on both dialects (SQLite ≥3.35 / D1 / MySQL); none
+ * of these columns are indexed.
+ */
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("users").dropColumn("last_login").execute();
+  await db.schema.alterTable("users").dropColumn("last_ip").execute();
+  await db.schema.alterTable("users").dropColumn("login_count").execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("users")
+    .addColumn("last_login", "varchar(35)")
+    .execute();
+  await db.schema
+    .alterTable("users")
+    .addColumn("last_ip", "varchar(45)")
+    .execute();
+  await db.schema
+    .alterTable("users")
+    .addColumn("login_count", "integer", (col) => col.notNull().defaultTo(0))
+    .execute();
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -175,6 +175,7 @@ import * as o076_default_first_party_true from "./2026-06-04T11:01:00_default_fi
 import * as o077_tenant_deployment_fields from "./2026-06-06T12:00:00_tenant_deployment_fields";
 import * as o078_tenant_database_version from "./2026-06-27T12:00:00_tenant_database_version";
 import * as o079_user_activity_and_user_column_cleanup from "./2026-06-30T12:00:00_user_activity_and_user_column_cleanup";
+import * as o080_drop_user_activity_columns_from_users from "./2026-07-02T12:00:00_drop_user_activity_columns_from_users";
 
 // These need to be in alphabetic order
 export default {
@@ -355,4 +356,5 @@ export default {
   o077_tenant_deployment_fields,
   o078_tenant_database_version,
   o079_user_activity_and_user_column_cleanup,
+  o080_drop_user_activity_columns_from_users,
 };

--- a/packages/kysely/src/db.ts
+++ b/packages/kysely/src/db.ts
@@ -110,15 +110,19 @@ const sqlPasswordSchema = z.object({
   is_current: z.number(),
 });
 
-export const sqlUserSchema = userSchema.extend({
-  email_verified: z.number(),
-  phone_verified: z.number().optional().nullable(),
-  is_social: z.number(),
-  app_metadata: z.string(),
-  user_metadata: z.string(),
-  address: z.string().optional().nullable(),
-  tenant_id: z.string(),
-});
+// last_login/last_ip/login_count live in the user_activity table (issue
+// #1003), not on the users row.
+export const sqlUserSchema = userSchema
+  .omit({ last_login: true, last_ip: true, login_count: true })
+  .extend({
+    email_verified: z.number(),
+    phone_verified: z.number().optional().nullable(),
+    is_social: z.number(),
+    app_metadata: z.string(),
+    user_metadata: z.string(),
+    address: z.string().optional().nullable(),
+    tenant_id: z.string(),
+  });
 
 const sqlHookSchema = z.object({
   tenant_id: z.string(),
@@ -513,8 +517,9 @@ export interface Database {
   prompt_settings: z.infer<typeof sqlPromptSettingSchema>;
   refresh_tokens: z.infer<typeof sqlRefreshTokensSchema>;
   users: z.infer<typeof sqlUserSchema>;
-  // Write-often counters split out of `users` (issue #1003). Populated/read in
-  // a follow-up PR; the table exists empty until then.
+  // Write-often counters split out of `users` (issue #1003). This is the
+  // authoritative store for last_login/last_ip/login_count; a missing row
+  // means the user never logged in.
   user_activity: {
     tenant_id: string;
     user_id: string;

--- a/packages/kysely/src/helpers/filter.ts
+++ b/packages/kysely/src/helpers/filter.ts
@@ -1,5 +1,22 @@
-import { Kysely, SelectQueryBuilder } from "kysely";
+import { Kysely, SelectQueryBuilder, sql } from "kysely";
 import { Database } from "../db";
+
+// A field backed by a nullable LEFT-JOINed column that the public shape
+// presents with a numeric default (e.g. `login_count` -> 0 when the user has
+// no user_activity row). Comparisons wrap the column in COALESCE so rows
+// without a joined row still match, and bind the operand as a number: a
+// COALESCE expression has no column affinity in SQLite, so a string operand
+// would compare as text and never match.
+export type CoalescedNumericField = {
+  column: string;
+  defaultValue: number;
+};
+
+export type FieldMapping = string | CoalescedNumericField;
+
+export function coalescedRef(field: CoalescedNumericField) {
+  return sql`coalesce(${sql.ref(field.column)}, ${sql.lit(field.defaultValue)})`;
+}
 
 // Reverse Lucene escaping on a value operand: a backslash followed by a Lucene
 // reserved character is a literal of that character (e.g. `auth0|abc\-123` ->
@@ -78,11 +95,31 @@ export function luceneFilter<DB, TB extends keyof DB, O>(
   // Maps a public field name to a qualified column ref (e.g.
   // `login_count` -> `user_activity.login_count`). Needed when the query
   // joins tables that share column names, where an unqualified ref would be
-  // ambiguous. Fields not in the map are used as-is.
-  fieldMap: Record<string, string> = {},
+  // ambiguous. Fields not in the map are used as-is. A CoalescedNumericField
+  // value additionally makes comparisons NULL-aware (see its doc above).
+  fieldMap: Record<string, FieldMapping> = {},
 ) {
   const likeSet = new Set(likeFields);
-  const toColumn = (field: string): string => fieldMap[field] ?? field;
+  const toColumn = (field: string): string => {
+    const mapped = fieldMap[field];
+    if (mapped === undefined) return field;
+    return typeof mapped === "string" ? mapped : mapped.column;
+  };
+  // Left-hand side for comparison clauses; unlike toColumn this wraps
+  // coalesced fields in their COALESCE expression.
+  const toLhs = (field: string) => {
+    const mapped = fieldMap[field];
+    if (mapped === undefined || typeof mapped === "string") {
+      return mapped ?? field;
+    }
+    return coalescedRef(mapped);
+  };
+  const toOperand = (field: string, value: string): string | number => {
+    const mapped = fieldMap[field];
+    if (mapped === undefined || typeof mapped === "string") return value;
+    const num = Number(value);
+    return Number.isFinite(num) ? num : value;
+  };
   // Split by OR first to handle OR queries
   const orParts = query.split(/ OR /i);
 
@@ -104,7 +141,11 @@ export function luceneFilter<DB, TB extends keyof DB, O>(
             if (likeSet.has(fieldName)) {
               return eb(toColumn(fieldName) as any, "like", `%${cleanValue}%`);
             }
-            return eb(toColumn(fieldName) as any, "=", cleanValue);
+            return eb(
+              toLhs(fieldName) as any,
+              "=",
+              toOperand(fieldName, cleanValue),
+            );
           }
           return null;
         })
@@ -210,6 +251,8 @@ export function luceneFilter<DB, TB extends keyof DB, O>(
   filters.forEach(({ key, value, isNegation, isExistsQuery, operator }) => {
     if (key) {
       const column = toColumn(key);
+      const lhs = toLhs(key);
+      const operand = toOperand(key, value);
       if (isExistsQuery) {
         if (isNegation) {
           qb = qb.where(column as any, "is", null);
@@ -228,22 +271,22 @@ export function luceneFilter<DB, TB extends keyof DB, O>(
         if (isNegation) {
           switch (operator) {
             case ">":
-              qb = qb.where(column as any, "<=", value);
+              qb = qb.where(lhs as any, "<=", operand);
               break;
             case ">=":
-              qb = qb.where(column as any, "<", value);
+              qb = qb.where(lhs as any, "<", operand);
               break;
             case "<":
-              qb = qb.where(column as any, ">=", value);
+              qb = qb.where(lhs as any, ">=", operand);
               break;
             case "<=":
-              qb = qb.where(column as any, ">", value);
+              qb = qb.where(lhs as any, ">", operand);
               break;
             default:
-              qb = qb.where(column as any, "!=", value);
+              qb = qb.where(lhs as any, "!=", operand);
           }
         } else {
-          qb = qb.where(column as any, operator as any, value);
+          qb = qb.where(lhs as any, operator as any, operand);
         }
       }
     } else if (value) {

--- a/packages/kysely/src/helpers/filter.ts
+++ b/packages/kysely/src/helpers/filter.ts
@@ -67,14 +67,22 @@ export function sanitizeLuceneQuery(
   return sanitizePart(query);
 }
 
-export function luceneFilter<TB extends keyof Database>(
+// Generic over the query builder's DB type (not just `Database`) because
+// left-joined builders carry a widened DB type with nullable joined columns.
+export function luceneFilter<DB, TB extends keyof DB, O>(
   db: Kysely<Database>,
-  qb: SelectQueryBuilder<Database, TB, {}>,
+  qb: SelectQueryBuilder<DB, TB, O>,
   query: string,
   searchableColumns: string[],
   likeFields: string[] = [],
+  // Maps a public field name to a qualified column ref (e.g.
+  // `login_count` -> `user_activity.login_count`). Needed when the query
+  // joins tables that share column names, where an unqualified ref would be
+  // ambiguous. Fields not in the map are used as-is.
+  fieldMap: Record<string, string> = {},
 ) {
   const likeSet = new Set(likeFields);
+  const toColumn = (field: string): string => fieldMap[field] ?? field;
   // Split by OR first to handle OR queries
   const orParts = query.split(/ OR /i);
 
@@ -94,9 +102,9 @@ export function luceneFilter<TB extends keyof Database>(
               value.replace(/^"(.*)"$/, "$1").trim(),
             );
             if (likeSet.has(fieldName)) {
-              return eb(fieldName as any, "like", `%${cleanValue}%`);
+              return eb(toColumn(fieldName) as any, "like", `%${cleanValue}%`);
             }
-            return eb(fieldName as any, "=", cleanValue);
+            return eb(toColumn(fieldName) as any, "=", cleanValue);
           }
           return null;
         })
@@ -201,17 +209,18 @@ export function luceneFilter<TB extends keyof Database>(
   // Apply filters to the query builder
   filters.forEach(({ key, value, isNegation, isExistsQuery, operator }) => {
     if (key) {
+      const column = toColumn(key);
       if (isExistsQuery) {
         if (isNegation) {
-          qb = qb.where(key as any, "is", null);
+          qb = qb.where(column as any, "is", null);
         } else {
-          qb = qb.where(key as any, "is not", null);
+          qb = qb.where(column as any, "is not", null);
         }
       } else if (likeSet.has(key) && operator === "=") {
         // Substring match for free-text fields (e.g. log descriptions),
         // where exact-match is rarely useful.
         qb = qb.where(
-          key as any,
+          column as any,
           isNegation ? "not like" : "like",
           `%${value}%`,
         );
@@ -219,22 +228,22 @@ export function luceneFilter<TB extends keyof Database>(
         if (isNegation) {
           switch (operator) {
             case ">":
-              qb = qb.where(key as any, "<=", value);
+              qb = qb.where(column as any, "<=", value);
               break;
             case ">=":
-              qb = qb.where(key as any, "<", value);
+              qb = qb.where(column as any, "<", value);
               break;
             case "<":
-              qb = qb.where(key as any, ">=", value);
+              qb = qb.where(column as any, ">=", value);
               break;
             case "<=":
-              qb = qb.where(key as any, ">", value);
+              qb = qb.where(column as any, ">", value);
               break;
             default:
-              qb = qb.where(key as any, "!=", value);
+              qb = qb.where(column as any, "!=", value);
           }
         } else {
-          qb = qb.where(key as any, operator as any, value);
+          qb = qb.where(column as any, operator as any, value);
         }
       }
     } else if (value) {
@@ -243,8 +252,8 @@ export function luceneFilter<TB extends keyof Database>(
         eb.or(
           searchableColumns.map((col) =>
             col === "user_id"
-              ? eb(ref(col), "=", value) // Exact match for user_id (e.g. "auth0|12345")
-              : eb(ref(col), "like", `%${value}%`),
+              ? eb(ref(toColumn(col)), "=", value) // Exact match for user_id (e.g. "auth0|12345")
+              : eb(ref(toColumn(col)), "like", `%${value}%`),
           ),
         ),
       );

--- a/packages/kysely/src/helpers/filter.ts
+++ b/packages/kysely/src/helpers/filter.ts
@@ -100,17 +100,19 @@ export function luceneFilter<DB, TB extends keyof DB, O>(
   fieldMap: Record<string, FieldMapping> = {},
 ) {
   const likeSet = new Set(likeFields);
+  const { ref } = db.dynamic;
   const toColumn = (field: string): string => {
     const mapped = fieldMap[field];
     if (mapped === undefined) return field;
     return typeof mapped === "string" ? mapped : mapped.column;
   };
   // Left-hand side for comparison clauses; unlike toColumn this wraps
-  // coalesced fields in their COALESCE expression.
+  // coalesced fields in their COALESCE expression. Dynamic references go
+  // through `db.dynamic.ref` so runtime-resolved column names stay typed.
   const toLhs = (field: string) => {
     const mapped = fieldMap[field];
     if (mapped === undefined || typeof mapped === "string") {
-      return mapped ?? field;
+      return ref(mapped ?? field);
     }
     return coalescedRef(mapped);
   };
@@ -139,19 +141,19 @@ export function luceneFilter<DB, TB extends keyof DB, O>(
               value.replace(/^"(.*)"$/, "$1").trim(),
             );
             if (likeSet.has(fieldName)) {
-              return eb(toColumn(fieldName) as any, "like", `%${cleanValue}%`);
+              return eb(ref(toColumn(fieldName)), "like", `%${cleanValue}%`);
             }
             return eb(
-              toLhs(fieldName) as any,
+              toLhs(fieldName),
               "=",
               toOperand(fieldName, cleanValue),
             );
           }
           return null;
         })
-        .filter(Boolean);
+        .filter((condition) => condition !== null);
 
-      return eb.or(conditions as any);
+      return eb.or(conditions);
     });
   }
 
@@ -250,47 +252,42 @@ export function luceneFilter<DB, TB extends keyof DB, O>(
   // Apply filters to the query builder
   filters.forEach(({ key, value, isNegation, isExistsQuery, operator }) => {
     if (key) {
-      const column = toColumn(key);
+      const column = ref(toColumn(key));
       const lhs = toLhs(key);
       const operand = toOperand(key, value);
       if (isExistsQuery) {
         if (isNegation) {
-          qb = qb.where(column as any, "is", null);
+          qb = qb.where(column, "is", null);
         } else {
-          qb = qb.where(column as any, "is not", null);
+          qb = qb.where(column, "is not", null);
         }
       } else if (likeSet.has(key) && operator === "=") {
         // Substring match for free-text fields (e.g. log descriptions),
         // where exact-match is rarely useful.
-        qb = qb.where(
-          column as any,
-          isNegation ? "not like" : "like",
-          `%${value}%`,
-        );
+        qb = qb.where(column, isNegation ? "not like" : "like", `%${value}%`);
       } else {
         if (isNegation) {
           switch (operator) {
             case ">":
-              qb = qb.where(lhs as any, "<=", operand);
+              qb = qb.where(lhs, "<=", operand);
               break;
             case ">=":
-              qb = qb.where(lhs as any, "<", operand);
+              qb = qb.where(lhs, "<", operand);
               break;
             case "<":
-              qb = qb.where(lhs as any, ">=", operand);
+              qb = qb.where(lhs, ">=", operand);
               break;
             case "<=":
-              qb = qb.where(lhs as any, ">", operand);
+              qb = qb.where(lhs, ">", operand);
               break;
             default:
-              qb = qb.where(lhs as any, "!=", operand);
+              qb = qb.where(lhs, "!=", operand);
           }
         } else {
-          qb = qb.where(lhs as any, operator as any, operand);
+          qb = qb.where(lhs, operator, operand);
         }
       }
     } else if (value) {
-      const { ref } = db.dynamic;
       qb = qb.where((eb) =>
         eb.or(
           searchableColumns.map((col) =>

--- a/packages/kysely/src/users/create.ts
+++ b/packages/kysely/src/users/create.ts
@@ -11,13 +11,21 @@ export function create(db: Kysely<Database>) {
     options?: CreateOptions,
   ): Promise<User> => {
     const importMetadata = options?.importMetadata;
-    const { identities, phone_verified, password, ...rest } = user as User &
-      Pick<UserInsert, "password">;
+    const {
+      identities,
+      phone_verified,
+      password,
+      // Activity counters are stored in user_activity, not on the users row
+      // (issue #1003) — split them off and write them separately below.
+      last_login,
+      last_ip,
+      login_count,
+      ...rest
+    } = user as User & Pick<UserInsert, "password">;
 
     const now = new Date().toISOString();
     const sqlUser = {
       ...rest,
-      login_count: rest.login_count ?? 0,
       created_at: importMetadata?.created_at ?? rest.created_at ?? now,
       updated_at: importMetadata?.updated_at ?? rest.updated_at ?? now,
       user_id: importMetadata?.id ?? rest.user_id,
@@ -34,6 +42,27 @@ export function create(db: Kysely<Database>) {
     try {
       const execute = async (trx: Kysely<Database>) => {
         await trx.insertInto("users").values(sqlUser).execute();
+
+        // Callers that record a login at creation time (e.g. lazy Auth0
+        // migration, social sign-up) pass activity fields — persist them in
+        // the same transaction so the user never exists without them.
+        if (
+          sqlUser.user_id &&
+          (last_login !== undefined ||
+            last_ip !== undefined ||
+            login_count !== undefined)
+        ) {
+          await trx
+            .insertInto("user_activity")
+            .values({
+              tenant_id: tenantId,
+              user_id: sqlUser.user_id,
+              last_login: last_login ?? null,
+              last_ip: last_ip ?? null,
+              login_count: login_count ?? 0,
+            })
+            .execute();
+        }
 
         if (password && sqlUser.user_id) {
           const passwordRecord = {
@@ -68,6 +97,9 @@ export function create(db: Kysely<Database>) {
 
     return {
       ...sqlUser,
+      last_login,
+      last_ip,
+      login_count: login_count ?? 0,
       // TODO: check if this is correct. Should it be optional?
       email: sqlUser.email || "",
       email_verified: sqlUser.email_verified === 1,

--- a/packages/kysely/src/users/get.ts
+++ b/packages/kysely/src/users/get.ts
@@ -9,9 +9,21 @@ export function get(db: Kysely<Database>) {
     const [sqlUser, linkedUsers] = await Promise.all([
       db
         .selectFrom("users")
+        // Activity counters live in user_activity (issue #1003). A missing
+        // row means the user never logged in, so LEFT JOIN and coalesce.
+        .leftJoin("user_activity", (join) =>
+          join
+            .onRef("user_activity.tenant_id", "=", "users.tenant_id")
+            .onRef("user_activity.user_id", "=", "users.user_id"),
+        )
         .where("users.tenant_id", "=", tenantId)
         .where("users.user_id", "=", user_id)
-        .selectAll()
+        .selectAll("users")
+        .select([
+          "user_activity.last_login",
+          "user_activity.last_ip",
+          "user_activity.login_count",
+        ])
         .executeTakeFirst(),
       db
         .selectFrom("users")
@@ -37,6 +49,9 @@ export function get(db: Kysely<Database>) {
           ? sqlUser.phone_verified === 1
           : undefined,
       is_social: sqlUser.is_social === 1,
+      last_login: sqlUser.last_login ?? undefined,
+      last_ip: sqlUser.last_ip ?? undefined,
+      login_count: sqlUser.login_count ?? 0,
       app_metadata: JSON.parse(sqlUser.app_metadata),
       user_metadata: JSON.parse(sqlUser.user_metadata),
       address: sqlUser.address ? JSON.parse(sqlUser.address) : undefined,

--- a/packages/kysely/src/users/list.ts
+++ b/packages/kysely/src/users/list.ts
@@ -1,5 +1,10 @@
 import { Kysely } from "kysely";
-import { luceneFilter, sanitizeLuceneQuery } from "../helpers/filter";
+import {
+  luceneFilter,
+  sanitizeLuceneQuery,
+  coalescedRef,
+  FieldMapping,
+} from "../helpers/filter";
 import { removeNullProperties } from "../helpers/remove-nulls";
 import { userToIdentity } from "./user-to-identity";
 import { Database } from "../db";
@@ -38,10 +43,17 @@ const ALLOWED_Q_FIELDS = [
 // unqualified refs ambiguous after the join, so every field is qualified.
 const ACTIVITY_FIELDS = new Set(["last_login", "last_ip", "login_count"]);
 
-const FIELD_MAP: Record<string, string> = Object.fromEntries(
-  ALLOWED_Q_FIELDS.map((field) => [
+const FIELD_MAP: Record<string, FieldMapping> = Object.fromEntries(
+  ALLOWED_Q_FIELDS.map((field): [string, FieldMapping] => [
     field,
-    ACTIVITY_FIELDS.has(field) ? `user_activity.${field}` : `users.${field}`,
+    field === "login_count"
+      ? // list/get present a missing activity row as login_count 0, so
+        // filters and sorts must treat NULL as 0 too — otherwise
+        // `q=login_count:0` would skip users who never logged in.
+        { column: "user_activity.login_count", defaultValue: 0 }
+      : ACTIVITY_FIELDS.has(field)
+        ? `user_activity.${field}`
+        : `users.${field}`,
   ]),
 );
 
@@ -85,8 +97,9 @@ export function list(db: Kysely<Database>) {
 
     if (sort && sort.sort_by) {
       const { ref } = db.dynamic;
+      const mapped = FIELD_MAP[sort.sort_by] ?? sort.sort_by;
       query = query.orderBy(
-        ref(FIELD_MAP[sort.sort_by] ?? sort.sort_by),
+        typeof mapped === "string" ? ref(mapped) : coalescedRef(mapped),
         sort.sort_order,
       );
     }

--- a/packages/kysely/src/users/list.ts
+++ b/packages/kysely/src/users/list.ts
@@ -8,7 +8,7 @@ import getCountAsInt from "../utils/getCountAsInt";
 
 // Fields users.list() accepts in `q`. Excludes `tenant_id` so a clause like
 // `q=tenant_id:other` cannot cross tenant boundaries; everything else here
-// maps to a real column on the users table.
+// maps to a real column on the users or user_activity table.
 const ALLOWED_Q_FIELDS = [
   "user_id",
   "email",
@@ -33,6 +33,18 @@ const ALLOWED_Q_FIELDS = [
   "updated_at",
 ];
 
+// Activity counters live in the joined user_activity table (issue #1003);
+// everything else resolves against users. Shared column names (user_id) make
+// unqualified refs ambiguous after the join, so every field is qualified.
+const ACTIVITY_FIELDS = new Set(["last_login", "last_ip", "login_count"]);
+
+const FIELD_MAP: Record<string, string> = Object.fromEntries(
+  ALLOWED_Q_FIELDS.map((field) => [
+    field,
+    ACTIVITY_FIELDS.has(field) ? `user_activity.${field}` : `users.${field}`,
+  ]),
+);
+
 // luceneFilter routes bare-string tokens through this list (LIKE search).
 // Keep narrow — every column here is publicly searchable via `q`.
 const SEARCHABLE_COLUMNS = ["email", "name", "phone_number", "user_id"];
@@ -44,25 +56,51 @@ export function list(db: Kysely<Database>) {
   ): Promise<ListUsersResponse> => {
     const { page = 0, per_page = 50, include_totals = false, sort, q } = params;
 
-    let query = db.selectFrom("users").where("users.tenant_id", "=", tenantId);
+    let query = db
+      .selectFrom("users")
+      // 1:1 join (user_activity PK is tenant_id+user_id), so no row fanout.
+      // A missing row means the user never logged in.
+      .leftJoin("user_activity", (join) =>
+        join
+          .onRef("user_activity.tenant_id", "=", "users.tenant_id")
+          .onRef("user_activity.user_id", "=", "users.user_id"),
+      )
+      .where("users.tenant_id", "=", tenantId);
     if (q) {
       // Sanitize first so only whitelisted fields reach luceneFilter;
       // otherwise a clause like `q=tenant_id:other` would emit SQL against
       // arbitrary columns and could cross tenant boundaries.
       const sanitized = sanitizeLuceneQuery(q, ALLOWED_Q_FIELDS);
       if (sanitized) {
-        query = luceneFilter(db, query, sanitized, SEARCHABLE_COLUMNS);
+        query = luceneFilter(
+          db,
+          query,
+          sanitized,
+          SEARCHABLE_COLUMNS,
+          [],
+          FIELD_MAP,
+        );
       }
     }
 
     if (sort && sort.sort_by) {
       const { ref } = db.dynamic;
-      query = query.orderBy(ref(sort.sort_by), sort.sort_order);
+      query = query.orderBy(
+        ref(FIELD_MAP[sort.sort_by] ?? sort.sort_by),
+        sort.sort_order,
+      );
     }
 
     const filteredQuery = query.offset(page * per_page).limit(per_page);
 
-    const users = await filteredQuery.selectAll().execute();
+    const users = await filteredQuery
+      .selectAll("users")
+      .select([
+        "user_activity.last_login",
+        "user_activity.last_ip",
+        "user_activity.login_count",
+      ])
+      .execute();
 
     const userIds = users.map((u) => u.user_id);
 
@@ -88,6 +126,7 @@ export function list(db: Kysely<Database>) {
         phone_verified:
           user.phone_verified !== null ? user.phone_verified === 1 : undefined,
         is_social: user.is_social === 1,
+        login_count: user.login_count ?? 0,
         app_metadata: JSON.parse(user.app_metadata),
         user_metadata: JSON.parse(user.user_metadata),
         address: user.address ? JSON.parse(user.address) : undefined,

--- a/packages/kysely/src/users/update.ts
+++ b/packages/kysely/src/users/update.ts
@@ -1,16 +1,24 @@
-import { PostUsersBody } from "@authhero/adapter-interfaces";
+import { PostUsersBody, User } from "@authhero/adapter-interfaces";
 import { Kysely } from "kysely";
 import { Database } from "../db";
 import { flattenObject } from "../utils/flatten";
+import { createUserActivityAdapter } from "../userActivity";
 
 export function update(db: Kysely<Database>) {
+  const userActivity = createUserActivityAdapter(db);
+
   return async (
     tenant_id: string,
     user_id: string,
-    user: Partial<PostUsersBody>,
+    user: Partial<PostUsersBody & User>,
   ): Promise<boolean> => {
+    // Activity counters live in user_activity (issue #1003). Split them off
+    // so callers that still pass them (e.g. adapters without a userActivity
+    // implementation went through this path historically) keep working.
+    const { last_login, last_ip, login_count, ...profileFields } = user;
+
     const sqlUser = flattenObject({
-      ...user,
+      ...profileFields,
       updated_at: new Date().toISOString(),
       app_metadata: user.app_metadata
         ? JSON.stringify(user.app_metadata)
@@ -26,6 +34,18 @@ export function update(db: Kysely<Database>) {
             : 0
           : undefined,
     });
+
+    if (
+      last_login !== undefined ||
+      last_ip !== undefined ||
+      login_count !== undefined
+    ) {
+      await userActivity.upsert(tenant_id, user_id, {
+        last_login,
+        last_ip,
+        login_count,
+      });
+    }
 
     const results = await db
       .updateTable("users")

--- a/packages/kysely/src/users/update.ts
+++ b/packages/kysely/src/users/update.ts
@@ -5,12 +5,14 @@ import { flattenObject } from "../utils/flatten";
 import { createUserActivityAdapter } from "../userActivity";
 
 export function update(db: Kysely<Database>) {
-  const userActivity = createUserActivityAdapter(db);
-
   return async (
     tenant_id: string,
     user_id: string,
-    user: Partial<PostUsersBody & User>,
+    // Only widened with the activity fields — a broader type (e.g.
+    // Partial<User>) would let non-column fields like `identities` leak into
+    // flattenObject() and the .set() below.
+    user: Partial<PostUsersBody> &
+      Partial<Pick<User, "last_login" | "last_ip" | "login_count">>,
   ): Promise<boolean> => {
     // Activity counters live in user_activity (issue #1003). Split them off
     // so callers that still pass them (e.g. adapters without a userActivity
@@ -35,25 +37,39 @@ export function update(db: Kysely<Database>) {
           : undefined,
     });
 
-    if (
-      last_login !== undefined ||
-      last_ip !== undefined ||
-      login_count !== undefined
-    ) {
-      await userActivity.upsert(tenant_id, user_id, {
-        last_login,
-        last_ip,
-        login_count,
-      });
+    // Update the user row first and only write activity once the row is
+    // confirmed to exist — in one transaction, so a missing user never gains
+    // an orphaned activity row and a failed activity write rolls both back.
+    const execute = async (trx: Kysely<Database>): Promise<boolean> => {
+      const [result] = await trx
+        .updateTable("users")
+        .set(sqlUser)
+        .where("users.tenant_id", "=", tenant_id)
+        .where("users.user_id", "=", user_id)
+        .execute();
+
+      if (!result || result.numUpdatedRows === 0n) {
+        return false;
+      }
+
+      if (
+        last_login !== undefined ||
+        last_ip !== undefined ||
+        login_count !== undefined
+      ) {
+        await createUserActivityAdapter(trx).upsert(tenant_id, user_id, {
+          last_login,
+          last_ip,
+          login_count,
+        });
+      }
+
+      return true;
+    };
+
+    if (db.isTransaction) {
+      return execute(db);
     }
-
-    const results = await db
-      .updateTable("users")
-      .set(sqlUser)
-      .where("users.tenant_id", "=", tenant_id)
-      .where("users.user_id", "=", user_id)
-      .execute();
-
-    return results.length === 1;
+    return db.transaction().execute(execute);
   };
 }

--- a/packages/kysely/test/users/index.spec.ts
+++ b/packages/kysely/test/users/index.spec.ts
@@ -173,4 +173,82 @@ describe("users", () => {
       ]);
     });
   });
+
+  describe("login_count filtering and sorting", () => {
+    // login_count lives in the LEFT-JOINed user_activity table and a missing
+    // row is presented as 0, so filters and sorts must treat NULL as 0.
+    async function seed() {
+      const { data } = await getTestServer();
+
+      await data.tenants.create({
+        id: "t1",
+        friendly_name: "Tenant t1",
+        audience: "https://t1.example.com",
+        sender_email: "login@t1.example.com",
+        sender_name: "SenderName",
+      });
+
+      for (const user_id of ["email|never", "email|active"]) {
+        await data.users.create("t1", {
+          user_id,
+          email: `${user_id.slice(6)}@example.com`,
+          email_verified: true,
+          is_social: false,
+          app_metadata: {},
+          user_metadata: {},
+          connection: Strategy.USERNAME_PASSWORD,
+          provider: "authhero",
+        });
+      }
+
+      // Gives email|active a user_activity row; email|never has none.
+      await data.users.update("t1", "email|active", { login_count: 5 });
+
+      return data;
+    }
+
+    it("matches users without an activity row on login_count:0", async () => {
+      const data = await seed();
+
+      const neverLoggedIn = await data.users.list("t1", {
+        q: "login_count:0",
+      });
+      expect(neverLoggedIn.users.map((u) => u.user_id)).toEqual([
+        "email|never",
+      ]);
+
+      const active = await data.users.list("t1", { q: "login_count:5" });
+      expect(active.users.map((u) => u.user_id)).toEqual(["email|active"]);
+    });
+
+    it("treats a missing activity row as 0 in range filters", async () => {
+      const data = await seed();
+
+      const below = await data.users.list("t1", { q: "login_count:<5" });
+      expect(below.users.map((u) => u.user_id)).toEqual(["email|never"]);
+
+      const above = await data.users.list("t1", { q: "login_count:>0" });
+      expect(above.users.map((u) => u.user_id)).toEqual(["email|active"]);
+    });
+
+    it("sorts users without an activity row as 0", async () => {
+      const data = await seed();
+
+      const ascending = await data.users.list("t1", {
+        sort: { sort_by: "login_count", sort_order: "asc" },
+      });
+      expect(ascending.users.map((u) => u.user_id)).toEqual([
+        "email|never",
+        "email|active",
+      ]);
+
+      const descending = await data.users.list("t1", {
+        sort: { sort_by: "login_count", sort_order: "desc" },
+      });
+      expect(descending.users.map((u) => u.user_id)).toEqual([
+        "email|active",
+        "email|never",
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Contract phase of the `user_activity` split (#1003). The counters were backfilled in production; this PR cuts reads/writes over and drops the legacy `users` columns.

- **authhero**: `postUserLoginHook` writes `last_login`/`last_ip`/`login_count` via `data.userActivity.upsert`; `users.update` remains only as a fallback for third-party adapters without a `userActivity` implementation. This removes the per-login rewrite of the users row (and its user-update decorator chain + transaction) from the login path.
- **@authhero/kysely-adapter**: `users.get`/`users.list` LEFT JOIN `user_activity` (1:1 on the PK; missing row = never logged in, `login_count` 0). Filtering (`q=login_count:>5`, `_exists_:last_login`) and sorting on activity fields resolve against the joined table via a new field→column map in `luceneFilter` (also needed to disambiguate `user_id` post-join). `users.create`/`users.update` route any activity fields they receive to `user_activity`. New migration drops `last_login`/`last_ip`/`login_count` from `users`.
- **@authhero/drizzle**: brought to parity — `user_activity` table (regenerated `0000` baseline per this package's convention), `userActivity` adapter (`get`/`upsert` with native `ON CONFLICT`), joined reads, routed writes, explicit activity-row cleanup in `remove()`.

The management API user shape is unchanged (Auth0-compatible `last_login`/`logins_count` still present), so the admin UI needs no changes.

## Deployment notes

- **Run the `user_activity` backfill script before applying the kysely migration** — the column drop discards any values never copied. (Already done for prod.)
- Deploy the new adapter + core together, then run the migration. The new code runs fine against the pre-drop schema; old code against a cut-over database would read stale `users` columns.
- Local drizzle dev databases must be recreated: the `0000` baseline was regenerated in place.

## Test plan

- [x] kysely: 246/246 tests pass
- [x] authhero: 1704/1704 pass — the adapter-call-count floor test was updated because the warm login path genuinely got cheaper (one fewer `users.get`, no `data.transaction()`)
- [x] drizzle: 47/47 pass, including new coverage for the upsert/get roundtrip, join-backed reads, partial-upsert semantics, activity-field filtering, and create-time activity persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login activity is now stored separately (including last login/IP and login count), with APIs reflecting “never logged in” when no activity record exists.
  * User listing/search can filter and sort by login activity fields (treating missing activity as `0`).

* **Bug Fixes**
  * Login activity updates avoid double-writing and keep values consistent across login, create, and update flows.
  * Activity-aware queries now correctly handle missing activity rows.

* **Tests**
  * Updated and expanded coverage for activity persistence, filtering/sorting, and warm-cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->