### PR TITLE
Move failed-login lockout tracking to user_activity (phase 2 of #1003)

### DIFF
--- a/.changeset/failed-logins-user-activity.md
+++ b/.changeset/failed-logins-user-activity.md
@@ -1,0 +1,10 @@
+---
+"authhero": minor
+---
+
+Move failed-login lockout tracking from `app_metadata` to `user_activity` (phase 2 of #1003)
+
+- Failed-password strikes are now stored as ISO 8601 timestamps in `user_activity.failed_logins` instead of numeric epochs in `users.app_metadata.failed_logins`, so a failed attempt no longer rewrites the users row. Third-party adapters without a `userActivity` implementation keep the legacy `app_metadata` behavior.
+- The strike is now awaited before the 403 response is sent (previously fire-and-forget), so a terminated worker can't drop it.
+- Pre-cutover strikes in `app_metadata` are not read anymore (entries expire after 5 minutes, so no backfill is needed); a successful login or password reset removes the leftover `app_metadata.failed_logins` key.
+- Both reset-password flows now stamp `user_activity.last_password_reset` on a successful reset (previously nothing wrote it).

--- a/.changeset/hip-hoops-punch.md
+++ b/.changeset/hip-hoops-punch.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Move failed-login lockout tracking to user_activity, and harden the password flow: activity-store failures now fail open instead of blocking logins or replacing the invalid-password response, and `last_password_reset` is recorded on the linked primary account.

--- a/packages/authhero/src/authentication-flows/password.ts
+++ b/packages/authhero/src/authentication-flows/password.ts
@@ -40,23 +40,76 @@ import {
 import { findConnectionByName } from "../utils/connections";
 import { attemptUpstreamPasswordFallback } from "./auth0-migration";
 
+const FAILED_LOGIN_WINDOW_MS = 1000 * 60 * 5;
+const FAILED_LOGIN_LIMIT = 3;
+
+/**
+ * Filter lockout timestamps (ISO 8601 strings) down to those inside the
+ * 5-minute window. Unparseable entries are dropped.
+ */
+function getRecentFailedLogins(
+  failedLogins: string[] | undefined,
+  now: number,
+): string[] {
+  return (failedLogins ?? []).filter(
+    (ts) => now - Date.parse(ts) < FAILED_LOGIN_WINDOW_MS,
+  );
+}
+
+/**
+ * Legacy strikes: numeric epoch timestamps in `app_metadata.failed_logins`.
+ * Only read/written for third-party adapters without a `userActivity`
+ * implementation (all in-repo adapters ship one).
+ */
+function getRecentLegacyFailedLogins(user: User, now: number): number[] {
+  const failedLogins: unknown = user.app_metadata?.failed_logins;
+  if (!Array.isArray(failedLogins)) {
+    return [];
+  }
+  return failedLogins.filter(
+    (ts): ts is number =>
+      typeof ts === "number" && now - ts < FAILED_LOGIN_WINDOW_MS,
+  );
+}
+
+async function countRecentFailedLogins(
+  data: Bindings["data"],
+  tenantId: string,
+  primaryUser: User,
+): Promise<number> {
+  const now = Date.now();
+  if (data.userActivity) {
+    const activity = await data.userActivity.get(tenantId, primaryUser.user_id);
+    return getRecentFailedLogins(activity?.failed_logins, now).length;
+  }
+  return getRecentLegacyFailedLogins(primaryUser, now).length;
+}
+
 async function recordFailedLogin(
   data: Bindings["data"],
   tenantId: string,
-  primaryUser: any,
+  primaryUser: User,
 ): Promise<void> {
-  const appMetadata = primaryUser.app_metadata || {};
-  const failedLogins = appMetadata.failed_logins || [];
   const now = Date.now();
 
   // Add current timestamp and remove timestamps older than 5 minutes
-  const recentFailedLogins = [
-    ...failedLogins.filter((ts: number) => now - ts < 1000 * 60 * 5),
+  if (data.userActivity) {
+    const activity = await data.userActivity.get(tenantId, primaryUser.user_id);
+    const failedLogins = [
+      ...getRecentFailedLogins(activity?.failed_logins, now),
+      new Date(now).toISOString(),
+    ];
+    await data.userActivity.upsert(tenantId, primaryUser.user_id, {
+      failed_logins: failedLogins,
+    });
+    return;
+  }
+
+  const appMetadata = primaryUser.app_metadata || {};
+  appMetadata.failed_logins = [
+    ...getRecentLegacyFailedLogins(primaryUser, now),
     now,
   ];
-
-  appMetadata.failed_logins = recentFailedLogins;
-
   await data.users.update(tenantId, primaryUser.user_id, {
     app_metadata: appMetadata,
   });
@@ -87,15 +140,59 @@ export async function clearFailedLogins(
       return;
     }
 
+    if (data.userActivity) {
+      const activity = await data.userActivity.get(
+        tenantId,
+        primaryUser.user_id,
+      );
+      if (activity?.failed_logins && activity.failed_logins.length > 0) {
+        await data.userActivity.upsert(tenantId, primaryUser.user_id, {
+          failed_logins: [],
+        });
+      }
+    }
+
+    // Clears the legacy-fallback strikes for adapters without `userActivity`,
+    // and doubles as transitional cleanup elsewhere: strikes used to live in
+    // `app_metadata.failed_logins` (numeric epoch timestamps), so removing the
+    // leftover key converges old rows.
     const appMetadata = primaryUser.app_metadata || {};
-    if (appMetadata.failed_logins && appMetadata.failed_logins.length > 0) {
-      appMetadata.failed_logins = [];
+    if (
+      Array.isArray(appMetadata.failed_logins) &&
+      appMetadata.failed_logins.length > 0
+    ) {
+      delete appMetadata.failed_logins;
       await data.users.update(tenantId, primaryUser.user_id, {
         app_metadata: appMetadata,
       });
     }
   } catch (error) {
     console.error("Failed to clear failed_logins:", error);
+  }
+}
+
+/**
+ * Post-reset bookkeeping shared by the reset-password routes: clear the
+ * failed-login lockout (a successful reset proves the account owner is back
+ * in control) and stamp `last_password_reset` on the activity row. Both are
+ * best-effort — the password is already changed by the time this runs.
+ */
+export async function recordPasswordReset(
+  data: Bindings["data"],
+  tenantId: string,
+  user: User,
+): Promise<void> {
+  await clearFailedLogins(data, tenantId, user);
+
+  if (!data.userActivity) {
+    return;
+  }
+  try {
+    await data.userActivity.upsert(tenantId, user.user_id, {
+      last_password_reset: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Failed to record last_password_reset:", error);
   }
 }
 
@@ -106,15 +203,6 @@ function isRateLimitDecision(value: unknown): value is RateLimitDecision {
     "allowed" in value &&
     typeof value.allowed === "boolean"
   );
-}
-
-function getRecentFailedLogins(user: any): number[] {
-  const appMetadata = user.app_metadata || {};
-  const failedLogins = appMetadata.failed_logins || [];
-  const now = Date.now();
-
-  // Filter to only include timestamps within the last 5 minutes
-  return failedLogins.filter((ts: number) => now - ts < 1000 * 60 * 5);
 }
 
 export async function passwordGrant(
@@ -250,10 +338,14 @@ export async function passwordGrant(
   ctx.set("connection", user.connection);
   ctx.set("user_id", primaryUser.user_id);
 
-  // Check failed login attempts from app_metadata BEFORE validating password
-  const recentFailedLogins = getRecentFailedLogins(primaryUser);
+  // Check failed login attempts from user_activity BEFORE validating password
+  const recentFailedLogins = await countRecentFailedLogins(
+    data,
+    client.tenant.id,
+    primaryUser,
+  );
 
-  if (recentFailedLogins.length >= 3) {
+  if (recentFailedLogins >= FAILED_LOGIN_LIMIT) {
     logMessage(ctx, client.tenant.id, {
       // TODO: change to BLOCKED_ACCOUNT_EMAIL
       type: LogTypes.FAILED_LOGIN,
@@ -307,8 +399,9 @@ export async function passwordGrant(
       description: "Invalid password",
     });
 
-    // Record failed login attempt in app_metadata
-    recordFailedLogin(data, client.tenant.id, primaryUser);
+    // Record the failed-login strike in user_activity before responding, so a
+    // terminated worker can't drop it and let an attacker dodge the lockout.
+    await recordFailedLogin(data, client.tenant.id, primaryUser);
 
     // Note: Not marking session as FAILED - user can retry with correct password
 

--- a/packages/authhero/src/authentication-flows/password.ts
+++ b/packages/authhero/src/authentication-flows/password.ts
@@ -79,8 +79,17 @@ async function countRecentFailedLogins(
 ): Promise<number> {
   const now = Date.now();
   if (data.userActivity) {
-    const activity = await data.userActivity.get(tenantId, primaryUser.user_id);
-    return getRecentFailedLogins(activity?.failed_logins, now).length;
+    try {
+      const activity = await data.userActivity.get(
+        tenantId,
+        primaryUser.user_id,
+      );
+      return getRecentFailedLogins(activity?.failed_logins, now).length;
+    } catch (error) {
+      // Fail open: a transient activity-store read failure must never block
+      // valid logins. Fall back to the legacy strikes on the user row.
+      console.error("Failed to read failed_logins from user_activity:", error);
+    }
   }
   return getRecentLegacyFailedLogins(primaryUser, now).length;
 }
@@ -90,29 +99,39 @@ async function recordFailedLogin(
   tenantId: string,
   primaryUser: User,
 ): Promise<void> {
-  const now = Date.now();
+  // Best-effort: a storage failure here must not replace the invalid-password
+  // 403 with an error. The write is still awaited by the caller so it lands
+  // before the response is sent (a terminated worker can't drop it).
+  try {
+    const now = Date.now();
 
-  // Add current timestamp and remove timestamps older than 5 minutes
-  if (data.userActivity) {
-    const activity = await data.userActivity.get(tenantId, primaryUser.user_id);
-    const failedLogins = [
-      ...getRecentFailedLogins(activity?.failed_logins, now),
-      new Date(now).toISOString(),
+    // Add current timestamp and remove timestamps older than 5 minutes
+    if (data.userActivity) {
+      const activity = await data.userActivity.get(
+        tenantId,
+        primaryUser.user_id,
+      );
+      const failedLogins = [
+        ...getRecentFailedLogins(activity?.failed_logins, now),
+        new Date(now).toISOString(),
+      ];
+      await data.userActivity.upsert(tenantId, primaryUser.user_id, {
+        failed_logins: failedLogins,
+      });
+      return;
+    }
+
+    const appMetadata = primaryUser.app_metadata || {};
+    appMetadata.failed_logins = [
+      ...getRecentLegacyFailedLogins(primaryUser, now),
+      now,
     ];
-    await data.userActivity.upsert(tenantId, primaryUser.user_id, {
-      failed_logins: failedLogins,
+    await data.users.update(tenantId, primaryUser.user_id, {
+      app_metadata: appMetadata,
     });
-    return;
+  } catch (error) {
+    console.error("Failed to record failed login:", error);
   }
-
-  const appMetadata = primaryUser.app_metadata || {};
-  appMetadata.failed_logins = [
-    ...getRecentLegacyFailedLogins(primaryUser, now),
-    now,
-  ];
-  await data.users.update(tenantId, primaryUser.user_id, {
-    app_metadata: appMetadata,
-  });
 }
 
 /**
@@ -188,7 +207,17 @@ export async function recordPasswordReset(
     return;
   }
   try {
-    await data.userActivity.upsert(tenantId, user.user_id, {
+    // Activity lives on the primary account (like failed_logins above), so
+    // resolve the linked primary before stamping the reset timestamp.
+    const primaryUser = user.linked_to
+      ? await data.users.get(tenantId, user.linked_to)
+      : user;
+
+    if (!primaryUser) {
+      return;
+    }
+
+    await data.userActivity.upsert(tenantId, primaryUser.user_id, {
       last_password_reset: new Date().toISOString(),
     });
   } catch (error) {

--- a/packages/authhero/src/routes/universal-login/reset-password.tsx
+++ b/packages/authhero/src/routes/universal-login/reset-password.tsx
@@ -8,7 +8,7 @@ import { initJSXRoute } from "./common";
 import ResetPasswordPage from "../../components/ResetPasswordPage";
 import MessagePage from "../../components/MessagePage";
 import { getUsernamePasswordUser } from "../../utils/username-password-provider";
-import { clearFailedLogins } from "../../authentication-flows/password";
+import { recordPasswordReset } from "../../authentication-flows/password";
 import { logMessage } from "../../helpers/logging";
 import { defineRoute } from "../../utils/define-route";
 import {
@@ -239,10 +239,8 @@ const postRoot = defineRoute({
         });
       }
 
-      // Clear any failed-login lockout — a successful reset proves the account
-      // owner is back in control, so they shouldn't be blocked by stale strikes
-      // when they log in with the new password.
-      await clearFailedLogins(env.data, client.tenant.id, user);
+      // Clear any failed-login lockout and stamp last_password_reset.
+      await recordPasswordReset(env.data, client.tenant.id, user);
 
       // Log the successful password change
       await logMessage(ctx, client.tenant.id, {

--- a/packages/authhero/src/routes/universal-login/screens/reset-password.ts
+++ b/packages/authhero/src/routes/universal-login/screens/reset-password.ts
@@ -9,7 +9,7 @@ import { LogTypes, Strategy } from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult, ScreenDefinition } from "./types";
 import bcryptjs from "bcryptjs";
 import { getUsernamePasswordUser } from "../../../utils/username-password-provider";
-import { clearFailedLogins } from "../../../authentication-flows/password";
+import { recordPasswordReset } from "../../../authentication-flows/password";
 import { logMessage } from "../../../helpers/logging";
 import {
   getPasswordPolicy,
@@ -124,10 +124,8 @@ export async function executePasswordReset(params: {
       });
     }
 
-    // Clear any failed-login lockout — a successful reset proves the account
-    // owner is back in control, so they shouldn't be blocked by stale strikes
-    // when they log in with the new password.
-    await clearFailedLogins(env.data, client.tenant.id, user);
+    // Clear any failed-login lockout and stamp last_password_reset.
+    await recordPasswordReset(env.data, client.tenant.id, user);
 
     // Log the successful password change
     await logMessage(ctx, client.tenant.id, {

--- a/packages/authhero/test/authentication-flows/password.spec.ts
+++ b/packages/authhero/test/authentication-flows/password.spec.ts
@@ -6,7 +6,7 @@ import { USERNAME_PASSWORD_PROVIDER } from "../../src/constants";
 import { Strategy } from "@authhero/adapter-interfaces";
 
 describe("password authentication - failed login tracking", () => {
-  it("should reject a login after three failed attempts and record in app_metadata", async () => {
+  it("should reject a login after three failed attempts and record in user_activity", async () => {
     const { oauthApp, env } = await getTestServer();
     const oauthClient = testClient(oauthApp, env);
 
@@ -58,19 +58,27 @@ describe("password authentication - failed login tracking", () => {
 
     expect(blockedResponse.status).toEqual(403);
 
-    // Verify user has failed_logins in app_metadata
+    // Verify the strikes were recorded in user_activity
+    const activity = await env.data.userActivity.get(
+      "tenantId",
+      `${USERNAME_PASSWORD_PROVIDER}|userId`,
+    );
+    expect(activity?.failed_logins).toBeDefined();
+    expect(Array.isArray(activity?.failed_logins)).toBe(true);
+    expect(activity?.failed_logins?.length).toBeGreaterThanOrEqual(3);
+
+    // All timestamps should be parseable ISO 8601 strings
+    activity?.failed_logins?.forEach((ts) => {
+      expect(typeof ts).toBe("string");
+      expect(Number.isNaN(Date.parse(ts))).toBe(false);
+    });
+
+    // The users row is no longer touched on failed attempts
     const user = await env.data.users.get(
       "tenantId",
       `${USERNAME_PASSWORD_PROVIDER}|userId`,
     );
-    expect(user?.app_metadata?.failed_logins).toBeDefined();
-    expect(Array.isArray(user?.app_metadata?.failed_logins)).toBe(true);
-    expect(user?.app_metadata?.failed_logins?.length).toBeGreaterThanOrEqual(3);
-
-    // All timestamps should be numbers (milliseconds)
-    user?.app_metadata?.failed_logins?.forEach((ts: any) => {
-      expect(typeof ts).toBe("number");
-    });
+    expect(user?.app_metadata?.failed_logins).toBeUndefined();
   });
 
   it("should clear failed_logins after successful login", async () => {
@@ -109,13 +117,11 @@ describe("password authentication - failed login tracking", () => {
     expect(incorrectPasswordResponse.status).toEqual(403);
 
     // Verify failed login was recorded
-    let user = await env.data.users.get(
+    let activity = await env.data.userActivity.get(
       "tenantId",
       `${USERNAME_PASSWORD_PROVIDER}|userId2`,
     );
-    if (user?.app_metadata?.failed_logins) {
-      expect(user?.app_metadata?.failed_logins?.length).toBeGreaterThan(0);
-    }
+    expect(activity?.failed_logins?.length).toBeGreaterThan(0);
 
     // Now login successfully
     const successResponse = await oauthClient.co.authenticate.$post({
@@ -131,22 +137,66 @@ describe("password authentication - failed login tracking", () => {
     expect(successResponse.status).toEqual(200);
 
     // Verify failed_logins was cleared
-    user = await env.data.users.get(
+    activity = await env.data.userActivity.get(
       "tenantId",
       `${USERNAME_PASSWORD_PROVIDER}|userId2`,
     );
-    expect(user?.app_metadata?.failed_logins).toBeDefined();
-    // After successful login, failed_logins should be empty or cleared
-    if (user?.app_metadata?.failed_logins) {
-      expect(user?.app_metadata?.failed_logins?.length).toBe(0);
-    }
+    expect(activity?.failed_logins ?? []).toEqual([]);
+  });
+
+  it("should remove legacy app_metadata.failed_logins on successful login", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    const userId = `${USERNAME_PASSWORD_PROVIDER}|legacyUser`;
+    await env.data.users.create("tenantId", {
+      email: "legacy@example.com",
+      email_verified: true,
+      name: "Legacy User",
+      nickname: "Legacy User",
+      connection: Strategy.USERNAME_PASSWORD,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      is_social: false,
+      user_id: userId,
+    });
+    await env.data.passwords.create("tenantId", {
+      user_id: userId,
+      password: await bcryptjs.hash("CorrectPassword123!", 10),
+      algorithm: "bcrypt",
+    });
+
+    // Strikes from before the user_activity cutover: numeric epochs stored in
+    // app_metadata. They must not lock the user out (the lockout check reads
+    // user_activity), and a successful login should clean them up.
+    await env.data.users.update("tenantId", userId, {
+      app_metadata: {
+        failed_logins: [Date.now(), Date.now(), Date.now()],
+        other_key: "untouched",
+      },
+    });
+
+    const successResponse = await oauthClient.co.authenticate.$post({
+      json: {
+        client_id: "clientId",
+        credential_type: "http://auth0.com/oauth/grant-type/password-realm",
+        realm: Strategy.USERNAME_PASSWORD,
+        password: "CorrectPassword123!",
+        username: "legacy@example.com",
+      },
+    });
+    expect(successResponse.status).toEqual(200);
+
+    const user = await env.data.users.get("tenantId", userId);
+    expect(user?.app_metadata?.failed_logins).toBeUndefined();
+    expect(user?.app_metadata?.other_key).toBe("untouched");
   });
 
   it("should clean up timestamps older than 5 minutes", async () => {
-    const { env } = await getTestServer();
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
 
-    // Create the user
-    const testUser = await env.data.users.create("tenantId", {
+    const userId = `${USERNAME_PASSWORD_PROVIDER}|userId3`;
+    await env.data.users.create("tenantId", {
       email: "testuser3@example.com",
       email_verified: true,
       name: "Test User 3",
@@ -154,43 +204,40 @@ describe("password authentication - failed login tracking", () => {
       connection: Strategy.USERNAME_PASSWORD,
       provider: USERNAME_PASSWORD_PROVIDER,
       is_social: false,
-      user_id: `${USERNAME_PASSWORD_PROVIDER}|userId3`,
+      user_id: userId,
+    });
+    await env.data.passwords.create("tenantId", {
+      user_id: userId,
+      password: await bcryptjs.hash("CorrectPassword123!", 10),
+      algorithm: "bcrypt",
     });
 
-    // Manually add old timestamps
-    const appMetadata = testUser.app_metadata || {};
-    appMetadata.failed_logins = [
-      Date.now() - 1000 * 60 * 10, // 10 minutes ago
-      Date.now() - 1000 * 60 * 7, // 7 minutes ago
-      Date.now(), // now
-    ];
+    // Seed two expired strikes and one recent one. Three entries would be a
+    // lockout if the window weren't applied, so the wrong-password attempt
+    // below also proves expired strikes don't count toward the limit.
+    await env.data.userActivity.upsert("tenantId", userId, {
+      failed_logins: [
+        new Date(Date.now() - 1000 * 60 * 10).toISOString(), // 10 minutes ago
+        new Date(Date.now() - 1000 * 60 * 7).toISOString(), // 7 minutes ago
+        new Date(Date.now() - 1000 * 60).toISOString(), // 1 minute ago
+      ],
+    });
 
-    await env.data.users.update(
-      "tenantId",
-      `${USERNAME_PASSWORD_PROVIDER}|userId3`,
-      {
-        app_metadata: appMetadata,
+    const incorrectPasswordResponse = await oauthClient.co.authenticate.$post({
+      json: {
+        client_id: "clientId",
+        credential_type: "http://auth0.com/oauth/grant-type/password-realm",
+        realm: Strategy.USERNAME_PASSWORD,
+        password: "IncorrectPassword",
+        username: "testuser3@example.com",
       },
-    );
+    });
+    expect(incorrectPasswordResponse.status).toEqual(403);
 
-    // Verify we have 3 timestamps
-    let user = await env.data.users.get(
-      "tenantId",
-      `${USERNAME_PASSWORD_PROVIDER}|userId3`,
-    );
-    expect(user?.app_metadata?.failed_logins?.length).toBe(3);
-
-    // Now trigger the cleanup by recording a new failed login
-    // We'll do this by calling the passwordGrant function directly
-    // But for simplicity, let's just verify the cleanup logic works on retrieval
-    const failedLogins = user?.app_metadata?.failed_logins || [];
-    const now = Date.now();
-    const recentFailedLogins = failedLogins.filter(
-      (ts: number) => now - ts < 1000 * 60 * 5,
-    );
-
-    // Should only have 1 recent timestamp (the one recorded "now")
-    expect(recentFailedLogins.length).toBe(1);
+    // Recording the new strike prunes the expired ones: only the 1-minute-old
+    // seed and the just-recorded strike remain.
+    const activity = await env.data.userActivity.get("tenantId", userId);
+    expect(activity?.failed_logins?.length).toBe(2);
   });
 
   it("should track failed logins on linked users' primary account", async () => {
@@ -242,21 +289,18 @@ describe("password authentication - failed login tracking", () => {
 
     expect(incorrectPasswordResponse.status).toEqual(403);
 
-    // Verify failed login was recorded on PRIMARY user's app_metadata
-    const updatedPrimaryUser = await env.data.users.get(
+    // Verify the strike was recorded on the PRIMARY user's activity row
+    const primaryActivity = await env.data.userActivity.get(
       "tenantId",
       `${USERNAME_PASSWORD_PROVIDER}|primary`,
     );
-    if (updatedPrimaryUser?.app_metadata?.failed_logins) {
-      expect(
-        updatedPrimaryUser?.app_metadata?.failed_logins?.length,
-      ).toBeGreaterThan(0);
-    } else {
-      // If failed_logins doesn't exist yet, it might be persisted asynchronously
-      // The important thing is that the feature is implemented
-      console.log(
-        "Note: failed_logins not yet persisted on linked user's primary - async operation",
-      );
-    }
+    expect(primaryActivity?.failed_logins?.length).toBeGreaterThan(0);
+
+    // And nothing was recorded against the linked identity itself
+    const linkedActivity = await env.data.userActivity.get(
+      "tenantId",
+      `${USERNAME_PASSWORD_PROVIDER}|linked`,
+    );
+    expect(linkedActivity?.failed_logins ?? []).toEqual([]);
   });
 });

--- a/packages/authhero/test/authentication-flows/password.spec.ts
+++ b/packages/authhero/test/authentication-flows/password.spec.ts
@@ -4,6 +4,7 @@ import { testClient } from "hono/testing";
 import bcryptjs from "bcryptjs";
 import { USERNAME_PASSWORD_PROVIDER } from "../../src/constants";
 import { Strategy } from "@authhero/adapter-interfaces";
+import { recordPasswordReset } from "../../src/authentication-flows/password";
 
 describe("password authentication - failed login tracking", () => {
   it("should reject a login after three failed attempts and record in user_activity", async () => {
@@ -302,5 +303,59 @@ describe("password authentication - failed login tracking", () => {
       `${USERNAME_PASSWORD_PROVIDER}|linked`,
     );
     expect(linkedActivity?.failed_logins ?? []).toEqual([]);
+  });
+
+  it("should record a password reset on the linked user's primary account", async () => {
+    const { env } = await getTestServer();
+
+    await env.data.users.create("tenantId", {
+      email: "reset-primary@example.com",
+      email_verified: true,
+      name: "Reset Primary",
+      nickname: "Reset Primary",
+      connection: "email",
+      provider: "email",
+      is_social: false,
+      user_id: "email|resetPrimary",
+    });
+
+    const linkedUser = await env.data.users.create("tenantId", {
+      email: "reset-primary@example.com",
+      email_verified: true,
+      name: "Reset Linked",
+      nickname: "Reset Linked",
+      connection: Strategy.USERNAME_PASSWORD,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      is_social: false,
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|resetLinked`,
+      linked_to: "email|resetPrimary",
+    });
+
+    // A stale lockout on the primary account, as left behind by failed
+    // password attempts on the linked identity.
+    await env.data.userActivity.upsert("tenantId", "email|resetPrimary", {
+      failed_logins: [new Date().toISOString()],
+    });
+
+    // The reset-password screen passes the password identity, not the primary.
+    await recordPasswordReset(env.data, "tenantId", linkedUser);
+
+    // Both the lockout clear and the reset timestamp land on the primary.
+    const primaryActivity = await env.data.userActivity.get(
+      "tenantId",
+      "email|resetPrimary",
+    );
+    expect(primaryActivity?.failed_logins ?? []).toEqual([]);
+    expect(primaryActivity?.last_password_reset).toBeDefined();
+    expect(
+      Number.isNaN(Date.parse(primaryActivity!.last_password_reset!)),
+    ).toBe(false);
+
+    // Nothing is stamped on the linked identity's own row.
+    const linkedActivity = await env.data.userActivity.get(
+      "tenantId",
+      `${USERNAME_PASSWORD_PROVIDER}|resetLinked`,
+    );
+    expect(linkedActivity?.last_password_reset).toBeFalsy();
   });
 });

--- a/packages/authhero/test/routes/universal-login/passwords.spec.ts
+++ b/packages/authhero/test/routes/universal-login/passwords.spec.ts
@@ -583,9 +583,9 @@ describe("passwords", () => {
 
     // Simulate a lockout: 3 recent failed-login timestamps (>= the 3 limit
     // enforced in passwordGrant within the 5-minute window).
-    const now = Date.now();
-    await env.data.users.update("tenantId", userId, {
-      app_metadata: { failed_logins: [now, now, now] },
+    const nowIso = new Date().toISOString();
+    await env.data.userActivity.upsert("tenantId", userId, {
+      failed_logins: [nowIso, nowIso, nowIso],
     });
 
     // Start the password reset flow
@@ -641,9 +641,14 @@ describe("passwords", () => {
 
     expect(resetPasswordResponse.status).toBe(200);
 
-    // The failed-login counter should be cleared by the reset.
-    const userAfterReset = await env.data.users.get("tenantId", userId);
-    expect(userAfterReset?.app_metadata?.failed_logins).toEqual([]);
+    // The failed-login counter should be cleared by the reset, and the reset
+    // itself stamped on the activity row.
+    const activityAfterReset = await env.data.userActivity.get(
+      "tenantId",
+      userId,
+    );
+    expect(activityAfterReset?.failed_logins ?? []).toEqual([]);
+    expect(activityAfterReset?.last_password_reset).toBeDefined();
 
     // And the user should be able to log in immediately with the new password
     // rather than being blocked by the stale lockout.
@@ -706,9 +711,9 @@ describe("passwords", () => {
 
     // Simulate a lockout: 3 recent failed-login timestamps (>= the 3 limit
     // enforced in passwordGrant within the 5-minute window).
-    const now = Date.now();
-    await env.data.users.update("tenantId", userId, {
-      app_metadata: { failed_logins: [now, now, now] },
+    const nowIso = new Date().toISOString();
+    await env.data.userActivity.upsert("tenantId", userId, {
+      failed_logins: [nowIso, nowIso, nowIso],
     });
 
     // Start the password reset flow
@@ -760,9 +765,14 @@ describe("passwords", () => {
 
     expect(resetPasswordResponse.status).toBe(302);
 
-    // The failed-login counter should be cleared by the reset.
-    const userAfterReset = await env.data.users.get("tenantId", userId);
-    expect(userAfterReset?.app_metadata?.failed_logins).toEqual([]);
+    // The failed-login counter should be cleared by the reset, and the reset
+    // itself stamped on the activity row.
+    const activityAfterReset = await env.data.userActivity.get(
+      "tenantId",
+      userId,
+    );
+    expect(activityAfterReset?.failed_logins ?? []).toEqual([]);
+    expect(activityAfterReset?.last_password_reset).toBeDefined();
 
     // And the user should be able to log in immediately with the new password
     // rather than being blocked by the stale lockout.


### PR DESCRIPTION
## Summary

Completes the second (behavioral) phase of #1003: failed-password lockout strikes move out of `users.app_metadata.failed_logins` into `user_activity.failed_logins`, so a failed attempt no longer rewrites the users row.

- Strikes are stored as ISO 8601 strings (was numeric epochs) and pruned to the 5-minute window on every write.
- The strike write is now **awaited** before the 403 goes out (was fire-and-forget), so a terminated worker can't drop it and let an attacker dodge the lockout.
- Third-party adapters without a `userActivity` implementation keep the legacy `app_metadata` behavior, mirroring the fallback pattern from #1020.
- **Transition:** old `app_metadata` strikes are not read anymore — they expire after 5 minutes, so no backfill is needed. A successful login or password reset deletes the leftover `app_metadata.failed_logins` key so old rows converge.
- Both reset-password flows (classic + screens) now share a `recordPasswordReset` helper that clears the lockout and stamps `user_activity.last_password_reset` — the first writer of that column.

## Testing

- Rewrote the failed-login tests to assert against `user_activity` (ISO timestamps, primary-account attribution, window pruning via a real wrong-password request) and added a legacy-cleanup test.
- Lockout-reset tests now seed `user_activity` and assert the `last_password_reset` stamp.
- Full `authhero` suite: 1707 passed, 1 skipped.

Closes the remaining work tracked on #1003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed-login tracking now uses a dedicated activity record with ISO 8601 timestamps and a 5-minute lockout window.
  * Password resets now also record the time of the reset.

* **Bug Fixes**
  * Failed attempts are saved before the lockout response is returned, making lockouts more reliable.
  * Successful logins and password resets now clear leftover failed-login state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->