### PR TITLE
fix(authhero): prefetch tenant export prefix so failures surface as 500s

### DIFF
--- a/.changeset/tender-pugs-attack.md
+++ b/.changeset/tender-pugs-attack.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Tenant export: prefetch the first 1000 lines / 1 MB before committing the streaming response, so adapter failures anywhere in that window — in practice the entirety of small and medium tenants — surface as a real 500 with a tenant log entry, instead of a 200 with a truncated 10-byte gzip. Also make the stream-side success/failure logs reliable: they are now written with `waitForCompletion` (a `waitUntil`-scheduled write can be dropped once the stream ends) and a failed log write can no longer mask the original error.

--- a/packages/authhero/src/routes/management-api/tenant-export-import.ts
+++ b/packages/authhero/src/routes/management-api/tenant-export-import.ts
@@ -273,50 +273,81 @@ const exportRoute = defineRoute({
     let rowCount = 0;
     let logged = false;
 
-    // Pull the first line *before* committing the response. The body streams,
-    // so returning the Response locks in status 200 + headers; if the very
-    // first adapter call throws after that, the only recourse is
+    // Prefetch a bounded prefix of the export *before* committing the
+    // response. The body streams, so returning the Response locks in status
+    // 200 + headers; any adapter failure after that can only surface as
     // `controller.error`, which truncates the gzip to its 10-byte header and
-    // hands the client a 200 with a corrupt file. Surfacing that first failure
-    // here lets us return a real 5xx (and log it) instead.
-    let firstResult: IteratorResult<ExportLine>;
+    // hands the client a 200 with a corrupt file. Buffering the first rows
+    // up-front means a failure anywhere in them — in practice the entirety of
+    // small and medium tenants — comes back as a real 5xx (and a log entry)
+    // instead. Only exports larger than this window can still truncate
+    // mid-stream, and those at least carry a partial body that shows where
+    // they stopped.
+    const PREFETCH_MAX_LINES = 1000;
+    const PREFETCH_MAX_BYTES = 1024 * 1024;
+    const prefetched: Uint8Array<ArrayBuffer>[] = [];
+    let prefetchedBytes = 0;
+    let exhausted = false;
     try {
-      firstResult = await iterator.next();
+      while (
+        prefetched.length < PREFETCH_MAX_LINES &&
+        prefetchedBytes < PREFETCH_MAX_BYTES
+      ) {
+        const { value, done } = await iterator.next();
+        if (done) {
+          exhausted = true;
+          break;
+        }
+        const chunk = encoder.encode(JSON.stringify(value) + "\n");
+        prefetched.push(chunk);
+        prefetchedBytes += chunk.byteLength;
+        rowCount += 1;
+      }
     } catch (err) {
       await logMessage(ctx, tenant_id, {
         type: LogTypes.FAILED_API_OPERATION,
-        description: `Tenant export failed (password_hashes=${includePasswordHashes}) by ${ctx.var.user?.sub ?? "unknown"}: ${err instanceof Error ? err.message : String(err)}`,
+        description: `Tenant export failed after ${rowCount} rows (password_hashes=${includePasswordHashes}) by ${ctx.var.user?.sub ?? "unknown"}: ${err instanceof Error ? err.message : String(err)}`,
         targetType: "tenant",
         targetId: tenant_id,
-      });
+      }).catch(() => {});
       throw new HTTPException(500, { message: "Tenant export failed" });
     }
-    // The first chunk is already fetched; emit it before resuming the iterator.
-    let pending: IteratorResult<ExportLine> | undefined = firstResult;
 
     const ndjson = new ReadableStream<Uint8Array<ArrayBuffer>>({
       async pull(controller) {
+        // Drain the prefetched prefix before resuming the iterator.
+        const buffered = prefetched.shift();
+        if (buffered) {
+          controller.enqueue(buffered);
+          return;
+        }
         try {
-          const { value, done } = pending ?? (await iterator.next());
-          pending = undefined;
-          if (done) {
+          const next = exhausted ? undefined : await iterator.next();
+          if (!next || next.done) {
             if (!logged) {
               logged = true;
+              // waitForCompletion: this runs inside the stream, after the
+              // middleware chain finished — a waitUntil-scheduled write can be
+              // dropped, so await the log write itself before closing.
               await logMessage(ctx, tenant_id, {
                 type: LogTypes.SUCCESS_API_OPERATION,
                 description: `Tenant export (${rowCount} rows, password_hashes=${includePasswordHashes}) by ${ctx.var.user?.sub ?? "unknown"}`,
                 targetType: "tenant",
                 targetId: tenant_id,
+                waitForCompletion: true,
               });
             }
             controller.close();
             return;
           }
           rowCount += 1;
-          controller.enqueue(encoder.encode(JSON.stringify(value) + "\n"));
+          controller.enqueue(encoder.encode(JSON.stringify(next.value) + "\n"));
         } catch (err) {
           // Mid-stream failure: status 200 is already on the wire, so the
           // client still gets a truncated body — but at least record why.
+          // waitForCompletion: awaited directly because a waitUntil-scheduled
+          // write can be dropped once the stream errors. Never let a failed
+          // log write mask the original error.
           if (!logged) {
             logged = true;
             await logMessage(ctx, tenant_id, {
@@ -324,7 +355,8 @@ const exportRoute = defineRoute({
               description: `Tenant export failed after ${rowCount} rows (password_hashes=${includePasswordHashes}) by ${ctx.var.user?.sub ?? "unknown"}: ${err instanceof Error ? err.message : String(err)}`,
               targetType: "tenant",
               targetId: tenant_id,
-            });
+              waitForCompletion: true,
+            }).catch(() => {});
           }
           controller.error(err);
         }

--- a/packages/authhero/src/routes/management-api/tenant-export-import.ts
+++ b/packages/authhero/src/routes/management-api/tenant-export-import.ts
@@ -328,14 +328,16 @@ const exportRoute = defineRoute({
               logged = true;
               // waitForCompletion: this runs inside the stream, after the
               // middleware chain finished — a waitUntil-scheduled write can be
-              // dropped, so await the log write itself before closing.
+              // dropped, so await the log write itself before closing. Swallow
+              // its errors: every row is already produced, and a failed audit
+              // write must not error the stream and corrupt a complete export.
               await logMessage(ctx, tenant_id, {
                 type: LogTypes.SUCCESS_API_OPERATION,
                 description: `Tenant export (${rowCount} rows, password_hashes=${includePasswordHashes}) by ${ctx.var.user?.sub ?? "unknown"}`,
                 targetType: "tenant",
                 targetId: tenant_id,
                 waitForCompletion: true,
-              });
+              }).catch(() => {});
             }
             controller.close();
             return;

--- a/packages/authhero/test/management-api/tenant-export-import.test.ts
+++ b/packages/authhero/test/management-api/tenant-export-import.test.ts
@@ -91,6 +91,78 @@ describe("GET /tenant-data/export", () => {
     expect(res.status).toBe(500);
   });
 
+  it("returns 500 (not a truncated 200) when the export fails partway through", async () => {
+    const { app, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    // Fails on a later entity, after the tenants row already succeeded.
+    // Rows within the prefetch window are pulled before the response commits,
+    // so this must be a real 500 rather than a 200 with a 10-byte gzip header.
+    env.data.clients.list = async () => {
+      throw new Error("boom");
+    };
+
+    const res = await app.request(
+      "/api/v2/tenant-data/export",
+      {
+        headers: { authorization: `Bearer ${token}`, "tenant-id": "tenantId" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(500);
+  });
+
+  it("streams complete exports larger than the prefetch window", async () => {
+    const { managementApp, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    // Serve more rows than the 1000-line prefetch window so the tail is
+    // produced by the live iterator after the response has committed.
+    const totalUsers = 1200;
+    env.data.users.list = async (_tenantId, params) => {
+      const page = params?.page ?? 0;
+      const perPage = params?.per_page ?? 50;
+      const start = page * perPage;
+      const users = Array.from(
+        { length: Math.max(0, Math.min(perPage, totalUsers - start)) },
+        (_, i) => ({
+          user_id: `auth2|bulk${start + i}`,
+          email: `bulk${start + i}@example.com`,
+          email_verified: true,
+          provider: "auth2",
+          connection: "Username-Password-Authentication",
+          is_social: false,
+          login_count: 0,
+          created_at: "2020-01-01T00:00:00.000Z",
+          updated_at: "2020-01-01T00:00:00.000Z",
+        }),
+      );
+      return { users, start, limit: perPage, length: users.length };
+    };
+    // Skip the per-user fan-out lookups so the test stays fast.
+    env.data.authenticationMethods.list = async () => [];
+    env.data.userRoles.list = async () => [];
+    env.data.userPermissions.list = async () => [];
+
+    const res = await managementApp.request(
+      "/tenant-data/export",
+      {
+        headers: { authorization: `Bearer ${token}`, "tenant-id": "tenantId" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    const text = await gunzip(await res.arrayBuffer());
+    const userLines = text
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line))
+      .filter((line) => line.entity === "users");
+    expect(userLines).toHaveLength(totalUsers);
+  });
+
   it("rejects include_password_hashes without the elevated scope", async () => {
     const { managementApp, env } = await getTestServer();
     const token = await getAdminToken();


### PR DESCRIPTION
## Problem

Tenant exports on dev were coming back as a 200 with a 10-byte gzip (just the header) and **no failed log entry**, even on `authhero@8.12.0` which already had the first-row guard.

Two root causes in the streaming export:

1. **The 200 commits before most adapter calls run.** Only the first line was pulled before returning the Response; any failure after that could only `controller.error()` the stream, truncating the gzip to its bare header while the client still saw a 200. (CompressionStream buffers tens of KB before flushing, so even a failure hundreds of rows in still produces a header-only file.)
2. **The mid-stream failure log was unreliable by construction.** It runs inside the stream's `pull()`, after the middleware chain finished: on outbox-enabled deployments the event is pushed to `ctx.var.outboxEventPromises` after the outbox middleware already flushed it, and on direct-log deployments the write is `waitUntil`-scheduled and can be dropped once the stream errors. Either way: no log.

## Fix

- **Prefetch up to 1000 lines / 1 MB of the export before committing the response.** In practice that covers entire small and medium tenants, so a failure anywhere in the window surfaces as a real 500 — and its log is written from inside the handler, where both the outbox and direct paths work. Exports larger than the window stream the tail live as before and can still truncate, but now carry a partial body showing where they stopped.
- **Make the remaining stream-side success/failure logs use `waitForCompletion`** so the write itself is awaited before the stream closes/errors, and wrap failure-log writes in `.catch()` so a failed log write can never mask the original error.

## Tests

- New: a failure on a later adapter call (`clients.list`, after the tenants row succeeded) returns 500 instead of a truncated 200 — the exact case that produced the 10-byte file.
- New: a 1200-row export (larger than the prefetch window) still streams completely and gunzips to all rows.
- All 13 export/import tests pass; package typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant export now fails with a proper error when an issue occurs early in the export, instead of returning a misleading successful response.
  * Large exports now stream the full dataset reliably, even when the initial response is delayed.
  * Export logging is more dependable, with success and failure events captured more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->