### PR TITLE
Gate upstream password fallback on missing local password (#992)

### DIFF
--- a/.changeset/password-fallback-local-gate.md
+++ b/.changeset/password-fallback-local-gate.md
@@ -1,0 +1,7 @@
+---
+"authhero": patch
+---
+
+Don't delegate to the upstream password source when the user has a current local password (#992)
+
+The lazy-migration fallback for `import_mode` connections now only fires when the user has no current local password. Once a password exists locally, a mismatch is a real failed login — matching Auth0, which never re-consults the legacy source after import. Previously a migrated user who changed their password in authhero could still log in with the old upstream password, and every wrong-password typo triggered an upstream call.

--- a/packages/authhero/src/authentication-flows/password.ts
+++ b/packages/authhero/src/authentication-flows/password.ts
@@ -367,10 +367,14 @@ export async function passwordGrant(
     password &&
     (await bcryptjs.compare(authParams.password, password.password));
 
-  if (!valid) {
-    // Try upstream lazy migration before recording a failed-login strike.
-    // The user already exists locally; we just don't have a matching
-    // password hash. Use the user's own connection record to read the
+  if (!valid && !password) {
+    // Try upstream lazy migration before recording a failed-login strike —
+    // but only when the user has no current local password (e.g. an
+    // admin/import-created shell user). Once a password exists locally, a
+    // mismatch is a real failed login: Auth0 never re-delegates to the
+    // legacy source after import, so neither do we — otherwise a user who
+    // changed their password here could still log in with the old upstream
+    // one. Use the user's own connection record to read the
     // import_mode flag — only that connection's name is acceptable as the
     // upstream realm.
     const userDbConnection = await findConnectionByName(

--- a/packages/authhero/test/authentication-flows/auth0-migration.spec.ts
+++ b/packages/authhero/test/authentication-flows/auth0-migration.spec.ts
@@ -649,6 +649,57 @@ describe("auth0 migration: password fallback", () => {
     expect(passwordRow).toBeDefined();
   });
 
+  // Issue #992: once a user has a current local password, a mismatch is a
+  // real failed login — Auth0 never re-delegates to the legacy source after
+  // import. Otherwise a user who changed their password here could still log
+  // in with the old upstream one, and every typo would fire an upstream call.
+  it("does NOT call upstream on a wrong password when the user has a current local password", async () => {
+    // If the gate regressed, this upstream 200 would turn the wrong local
+    // password into a successful login.
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(200, {
+        access_token: "upstream-at",
+        token_type: "Bearer",
+        expires_in: 86400,
+      }),
+    );
+
+    const { oauthApp, env } = await makeMigrationServer();
+
+    const existingUserId = `${USERNAME_PASSWORD_PROVIDER}|has-local-pwd`;
+    await env.data.users.create(TENANT_ID, {
+      user_id: existingUserId,
+      email: "has-local-pwd@example.com",
+      email_verified: true,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      connection: Strategy.USERNAME_PASSWORD,
+      is_social: false,
+    });
+    await env.data.passwords.create(TENANT_ID, {
+      user_id: existingUserId,
+      password: await bcryptjs.hash("CurrentLocalPwd!", 10),
+      algorithm: "bcrypt",
+    });
+
+    const oauthClient = testClient(oauthApp, env);
+    const response = await oauthClient.co.authenticate.$post({
+      json: {
+        client_id: CLIENT_ID,
+        credential_type: "http://auth0.com/oauth/grant-type/password-realm",
+        realm: REALM,
+        username: "has-local-pwd@example.com",
+        password: "OldUpstreamPwd!",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // The mismatch counts as a real failed-login strike.
+    const activity = await env.data.userActivity.get(TENANT_ID, existingUserId);
+    expect(activity?.failed_logins?.length).toBe(1);
+  });
+
   // Local password row already exists and matches: the local check succeeds
   // and we must NOT call upstream — the bcrypt path is the source of truth
   // once migration has happened.


### PR DESCRIPTION
Once a user has a current local password, a mismatch is a real failed login and upstream is never consulted — matching Auth0, which never re-delegates to the legacy source after import. Previously a migrated user who changed their password locally could still log in with the old upstream password, and every typo fired an upstream call before the failed-login strike was recorded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Password sign-in now correctly rejects invalid local passwords without retrying legacy authentication sources.
  * Failed login attempts are recorded immediately when a local password exists and does not match.
  * Users with an existing local password will no longer be silently authenticated through older fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->