### PR TITLE
Reject response_mode=query for token-bearing response types

### DIFF
--- a/.changeset/tidy-planes-refuse.md
+++ b/.changeset/tidy-planes-refuse.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Reject `response_mode=query` for token-bearing response types at /authorize with `unsupported_response_mode` instead of silently coercing the response into the fragment — Auth0 parity per OAuth 2.0 Multiple Response Type Encoding Practices. Pure `code` responses with `response_mode=query` are unaffected.

--- a/packages/authhero/src/routes/auth-api/authorize.ts
+++ b/packages/authhero/src/routes/auth-api/authorize.ts
@@ -572,6 +572,33 @@ const getRoot = defineRoute({
       }
     }
 
+    // OAuth 2.0 Multiple Response Type Encoding Practices: `query` must not
+    // be used when the authorization response carries front-channel tokens.
+    // Auth0 rejects the combination with unsupported_response_mode; we used
+    // to silently coerce to fragment at redirect-build time. Every
+    // response_type except pure `code` carries a token. The error itself is
+    // token-free, so delivering it via the requested query channel is safe.
+    if (
+      response_mode === AuthorizationResponseMode.QUERY &&
+      response_type !== AuthorizationResponseType.CODE
+    ) {
+      const errorDescription = `Invalid response_mode "query" for response_type "${response_type}"`;
+      if (sanitizedRedirectUri) {
+        const errorParams: Record<string, string> = {
+          error: "unsupported_response_mode",
+          error_description: errorDescription,
+        };
+        if (state) errorParams.state = state;
+
+        const redirectUrl = new URL(sanitizedRedirectUri);
+        for (const [k, v] of Object.entries(errorParams)) {
+          redirectUrl.searchParams.set(k, v);
+        }
+        return ctx.redirect(redirectUrl.toString());
+      }
+      throw new HTTPException(400, { message: errorDescription });
+    }
+
     // Auth0 parity: reject /authorize when the audience doesn't match a
     // registered resource server, so the user sees the error before the
     // login UI rather than after entering credentials. An undefined

--- a/packages/authhero/test/routes/auth-api/authorize.spec.ts
+++ b/packages/authhero/test/routes/auth-api/authorize.spec.ts
@@ -361,6 +361,101 @@ describe("authorize", () => {
     expect(login.authParams.redirect_uri).toEqual("http://localhost:3000/auth");
   });
 
+  describe("response_mode validation", () => {
+    it("redirects with unsupported_response_mode when query is combined with response_type=token", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const oauthClient = testClient(oauthApp, env);
+
+      const response = await oauthClient.authorize.$get(
+        {
+          query: {
+            client_id: "clientId",
+            redirect_uri: "https://example.com/callback",
+            state: "state",
+            scope: "openid",
+            response_type: AuthorizationResponseType.TOKEN,
+            response_mode: AuthorizationResponseMode.QUERY,
+          },
+        },
+        {
+          headers: {
+            origin: "https://example.com",
+          },
+        },
+      );
+
+      expect(response.status).toEqual(302);
+      const location = new URL(response.headers.get("location")!);
+      expect(location.searchParams.get("error")).toEqual(
+        "unsupported_response_mode",
+      );
+      expect(location.searchParams.get("error_description")).toEqual(
+        'Invalid response_mode "query" for response_type "token"',
+      );
+      expect(location.searchParams.get("state")).toEqual("state");
+      // The error must not create a login session
+      expect(location.pathname).toEqual("/callback");
+    });
+
+    it("rejects query for hybrid response types carrying a token", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const oauthClient = testClient(oauthApp, env);
+
+      const response = await oauthClient.authorize.$get(
+        {
+          query: {
+            client_id: "clientId",
+            redirect_uri: "https://example.com/callback",
+            state: "state",
+            scope: "openid",
+            response_type: AuthorizationResponseType.CODE_ID_TOKEN,
+            response_mode: AuthorizationResponseMode.QUERY,
+          },
+        },
+        {
+          headers: {
+            origin: "https://example.com",
+          },
+        },
+      );
+
+      expect(response.status).toEqual(302);
+      const location = new URL(response.headers.get("location")!);
+      expect(location.searchParams.get("error")).toEqual(
+        "unsupported_response_mode",
+      );
+    });
+
+    it("still allows response_mode=query with response_type=code", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const oauthClient = testClient(oauthApp, env);
+
+      const response = await oauthClient.authorize.$get(
+        {
+          query: {
+            client_id: "clientId",
+            redirect_uri: "https://example.com/callback",
+            state: "state",
+            scope: "openid",
+            response_type: AuthorizationResponseType.CODE,
+            response_mode: AuthorizationResponseMode.QUERY,
+          },
+        },
+        {
+          headers: {
+            origin: "https://example.com",
+          },
+        },
+      );
+
+      expect(response.status).toEqual(302);
+      const redirectUri = new URL(
+        "http://localhost:3000" + response.headers.get("location"),
+      );
+      expect(redirectUri.pathname).toEqual("/u/login/identifier");
+    });
+  });
+
   describe("resource server validation", () => {
     it("redirects with access_denied when the audience doesn't match a resource server", async () => {
       const { oauthApp, env } = await getTestServer();


### PR DESCRIPTION
## Summary

Fixes #987.

When a client sends `response_mode=query` with a token-bearing `response_type` (anything other than pure `code`), authhero accepted the request and silently coerced the response into the URL fragment at redirect-build time. Auth0 rejects the combination up front with `unsupported_response_mode`, per OAuth 2.0 Multiple Response Type Encoding Practices — `query` encoding is forbidden when the response carries front-channel tokens.

## Changes

- `packages/authhero/src/routes/auth-api/authorize.ts` — after redirect-uri validation, reject `response_mode=query` + any `response_type` except `code`: redirect back with `error=unsupported_response_mode` (state echoed), or a local 400 when there is no registered `redirect_uri`. The error itself is token-free, so delivering it via the requested query channel is safe and matches the sibling error paths (missing `response_type`, unknown audience). The check sits after the callback-registration check, so error redirects only ever target registered callbacks.
- Tests: `response_type=token` + query redirects with `unsupported_response_mode`; hybrid `code id_token` + query is also rejected; `code` + query still proceeds to the login UI.
- Changeset (patch).

The downstream fragment coercion in `common.ts` is left in place as defense-in-depth for login sessions created before this validation existed.

## Testing

Full authhero suite: 207 files, 1714 tests passing — nothing relied on the silent coercion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests to the authorization endpoint now correctly reject unsupported `response_mode=query` combinations for token-bearing responses, returning an error instead of silently changing the response format.
  * Error responses preserve `state` when provided and are returned either via redirect or a standard 400 response as appropriate.
  * Pure authorization code requests with `response_mode=query` continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->