### PR TITLE
fix(kysely): tolerate legacy users.login_count column on pre-o080 schemas

### DIFF
--- a/.changeset/legacy-login-count-shim.md
+++ b/.changeset/legacy-login-count-shim.md
@@ -1,0 +1,5 @@
+---
+"@authhero/kysely-adapter": patch
+---
+
+Keep user creation working on databases that have not yet run the o080 drop migration. On those schemas users.login_count still exists as NOT NULL without a default, so the post-#1003 insert (which omits it) fails on MySQL strict mode with errno 1364. create() now detects the legacy column from the failed insert, retries with login_count supplied, and caches the schema state per Kysely instance — flipping back automatically once the column is dropped, so the o080 migration can run later without a coordinated deploy.

--- a/packages/kysely/src/db.ts
+++ b/packages/kysely/src/db.ts
@@ -115,6 +115,11 @@ const sqlPasswordSchema = z.object({
 export const sqlUserSchema = userSchema
   .omit({ last_login: true, last_ip: true, login_count: true })
   .extend({
+    // Transition shim: databases that haven't run the o080 drop migration yet
+    // still carry users.login_count as NOT NULL without a default, and
+    // users/create.ts supplies it there. Remove together with that shim once
+    // every environment has dropped the column.
+    login_count: z.number().optional(),
     email_verified: z.number(),
     phone_verified: z.number().optional().nullable(),
     is_social: z.number(),

--- a/packages/kysely/src/users/create.ts
+++ b/packages/kysely/src/users/create.ts
@@ -4,6 +4,40 @@ import { nanoid } from "nanoid";
 import { Database } from "../db";
 import { User, UserInsert, CreateOptions } from "@authhero/adapter-interfaces";
 
+// Transition shim for the user_activity split (issue #1003): databases that
+// have not yet run the o080 drop migration still have users.login_count as
+// NOT NULL without a default, so the insert must supply it or MySQL strict
+// mode rejects it (errno 1364). The schema state is learned from the first
+// failed insert and cached per Kysely instance; it flips back automatically
+// once the column is dropped. Remove together with the optional login_count
+// on sqlUserSchema when every environment has run o080.
+const legacyLoginCountColumn = new WeakMap<Kysely<Database>, boolean>();
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// MySQL: "Field 'login_count' doesn't have a default value"
+// SQLite/D1: "NOT NULL constraint failed: users.login_count"
+function isMissingLoginCountValueError(err: unknown): boolean {
+  const message = errorMessage(err);
+  return (
+    message.includes("login_count") &&
+    (message.includes("doesn't have a default value") ||
+      message.includes("NOT NULL constraint failed"))
+  );
+}
+
+// MySQL: "Unknown column 'login_count' in 'field list'"
+// SQLite/D1: "table users has no column named login_count"
+function isUnknownLoginCountColumnError(err: unknown): boolean {
+  const message = errorMessage(err);
+  return (
+    message.includes("login_count") &&
+    (message.includes("Unknown column") || message.includes("no column named"))
+  );
+}
+
 export function create(db: Kysely<Database>) {
   return async (
     tenantId: string,
@@ -39,9 +73,16 @@ export function create(db: Kysely<Database>) {
       address: user.address ? JSON.stringify(user.address) : null,
     };
 
-    try {
+    const runInsert = async (includeLegacyLoginCount: boolean) => {
       const execute = async (trx: Kysely<Database>) => {
-        await trx.insertInto("users").values(sqlUser).execute();
+        await trx
+          .insertInto("users")
+          .values(
+            includeLegacyLoginCount
+              ? { ...sqlUser, login_count: login_count ?? 0 }
+              : sqlUser,
+          )
+          .execute();
 
         // Callers that record a login at creation time (e.g. lazy Auth0
         // migration, social sign-up) pass activity fields — persist them in
@@ -83,6 +124,25 @@ export function create(db: Kysely<Database>) {
         await execute(db);
       } else {
         await db.transaction().execute(execute);
+      }
+    };
+
+    try {
+      const includeLegacy = legacyLoginCountColumn.get(db) ?? false;
+      try {
+        await runInsert(includeLegacy);
+      } catch (err) {
+        // Schema drift relative to the o080 migration — flip the cached mode
+        // and retry once (in a fresh transaction unless the caller passed one).
+        if (!includeLegacy && isMissingLoginCountValueError(err)) {
+          legacyLoginCountColumn.set(db, true);
+          await runInsert(true);
+        } else if (includeLegacy && isUnknownLoginCountColumnError(err)) {
+          legacyLoginCountColumn.set(db, false);
+          await runInsert(false);
+        } else {
+          throw err;
+        }
       }
     } catch (err: any) {
       if (

--- a/packages/kysely/test/users/legacy-login-count.spec.ts
+++ b/packages/kysely/test/users/legacy-login-count.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import SQLite from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
+import { Migrator } from "kysely/migration";
+import { Strategy } from "@authhero/adapter-interfaces";
+
+import { Database } from "../../src/db";
+import createAdapters from "../../src";
+import ReferenceMigrationProvider from "../../migrate/ReferenceMigrationProvider";
+import migrations from "../../migrate/migrations";
+
+// Reproduces the production schema state where the o080 drop migration has
+// not run yet: users.login_count still exists as NOT NULL without a default
+// (its shape since the init migration), so an insert that omits it fails.
+// users/create.ts must detect this and supply the column.
+async function getPreO080Server() {
+  const sqlite = new SQLite(":memory:");
+  const db = new Kysely<Database>({
+    dialect: new SqliteDialect({ database: sqlite }),
+  });
+  const migrator = new Migrator({
+    db,
+    provider: new ReferenceMigrationProvider(migrations),
+  });
+  const { error } = await migrator.migrateTo(
+    "o079_user_activity_and_user_column_cleanup",
+  );
+  if (error) throw error;
+
+  return { data: createAdapters(db), db };
+}
+
+describe("users create on a pre-o080 schema", () => {
+  it("supplies login_count while the legacy NOT NULL column still exists", async () => {
+    const { data, db } = await getPreO080Server();
+
+    await data.tenants.create({
+      id: "tenantId",
+      friendly_name: "Test Tenant",
+      audience: "https://example.com",
+      sender_email: "login@example.com",
+      sender_name: "SenderName",
+    });
+
+    const user = await data.users.create("tenantId", {
+      user_id: "email|legacy1",
+      email: "legacy1@example.com",
+      email_verified: true,
+      is_social: false,
+      connection: Strategy.USERNAME_PASSWORD,
+      provider: "authhero",
+    });
+    expect(user.login_count).toBe(0);
+
+    const row = await db
+      .selectFrom("users")
+      .where("user_id", "=", "email|legacy1")
+      .select("login_count")
+      .executeTakeFirstOrThrow();
+    expect(row.login_count).toBe(0);
+
+    // A second create runs in the cached legacy mode and still routes the
+    // activity counters to user_activity while keeping the legacy column fed.
+    const migrated = await data.users.create("tenantId", {
+      user_id: "email|legacy2",
+      email: "legacy2@example.com",
+      email_verified: true,
+      is_social: false,
+      connection: Strategy.USERNAME_PASSWORD,
+      provider: "authhero",
+      login_count: 7,
+      last_login: "2026-07-01T00:00:00.000Z",
+      last_ip: "127.0.0.1",
+    });
+    expect(migrated.login_count).toBe(7);
+
+    const legacyRow = await db
+      .selectFrom("users")
+      .where("user_id", "=", "email|legacy2")
+      .select("login_count")
+      .executeTakeFirstOrThrow();
+    expect(legacyRow.login_count).toBe(7);
+
+    const activity = await db
+      .selectFrom("user_activity")
+      .where("user_id", "=", "email|legacy2")
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(activity.login_count).toBe(7);
+    expect(activity.last_ip).toBe("127.0.0.1");
+
+    const fetched = await data.users.get("tenantId", "email|legacy2");
+    expect(fetched?.login_count).toBe(7);
+  });
+});


### PR DESCRIPTION
## Problem

Prod PlanetScale is running the post-#1003 code (activity counters split into `user_activity`) while still one migration behind — o080 (`drop_user_activity_columns_from_users`) has not been applied. There `users.login_count` is still `NOT NULL` without a default (its shape since the init migration), so every user INSERT fails under MySQL strict mode:

```
vttablet: Field 'login_count' doesn't have a default value (errno 1364)
```

Running o080 right now isn't desirable since it's destructive (drops the legacy columns), so this fixes it code-side.

## Fix

`users/create.ts` learns the schema state from the first failed insert and caches it per Kysely instance:

- Insert fails with "doesn't have a default value" / "NOT NULL constraint failed" for `login_count` → retry once with `login_count` supplied (caller value or 0, so e.g. lazy Auth0 imports keep their real count and the legacy column stays consistent for the backfill).
- Symmetrically, once o080 drops the column, an "Unknown column" / "no column named" error flips the mode back.

So the fix can deploy immediately, and o080 can run later without a coordinated deploy or worker restart.

`sqlUserSchema` gets `login_count` back as optional so the legacy insert type-checks without casts.

## Test

New spec migrates an in-memory DB to exactly prod's state (`migrateTo("o079...")`) and verifies: creation succeeds, the legacy column is written, caller-supplied counters land in both `users` and `user_activity`, and reads coalesce correctly.

## Note

This is a transition shim, not permanent defence — both sites are commented for removal once every environment (prod PlanetScale + D1 wfp tenants) has run o080. Follow-up issue to be created as a reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user creation compatibility with older database schemas, including cases where a required count field still exists during migration.
  * Added automatic retry behavior so account creation succeeds across mixed or partially migrated setups.
  * Ensured user data reads continue to return the expected count value in legacy environments.

* **Tests**
  * Added coverage for creating users against pre-migration database states to verify consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->