### PR TITLE
ci: run OIDC conformance suite on the changesets release PR

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,9 +1,18 @@
 name: OIDC Conformance
 
-# Manually triggered. Builds the OpenID Foundation conformance suite (cached
-# Maven artifact), generates a fresh auth-server, and runs the conformance
-# runner. ~10–20 min on cold cache, ~5–8 min when the suite JAR cache hits.
+# Runs on manual dispatch, and automatically on the changesets release PR
+# (changeset-release/main) where it is a required check — packages must pass
+# the conformance suite before a version-bump PR can merge. The pull_request
+# trigger fires on every PR so the required check is always reported, but the
+# job itself is skipped (= satisfied) unless the head is the release branch.
+#
+# Builds the OpenID Foundation conformance suite (cached Maven artifact),
+# generates a fresh auth-server, and runs the conformance runner.
+# ~10–20 min on cold cache, ~5–8 min when the suite JAR cache hits.
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       grep:
@@ -16,8 +25,15 @@ on:
         type: boolean
         default: true
 
+# The release workflow force-pushes changeset-release/main on every main
+# merge; cancel a superseded conformance run instead of queueing behind it.
+concurrency:
+  group: conformance-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   conformance:
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -129,10 +145,12 @@ jobs:
 
       # SKIP_SETUP=1 because the steps above already started the suite and
       # seeded the DB; ALLOW_WARNING is configurable from the workflow input.
+      # On pull_request runs there are no inputs — allow warnings (the
+      # dispatch default) and run the full plan.
       - name: Run conformance runner
         env:
           SKIP_SETUP: "1"
-          ALLOW_WARNING: ${{ inputs.allow_warning && '1' || '' }}
+          ALLOW_WARNING: ${{ (github.event_name == 'pull_request' || inputs.allow_warning) && '1' || '' }}
           GREP: ${{ inputs.grep }}
         run: |
           if [ -n "$GREP" ]; then


### PR DESCRIPTION
## Summary

The OIDC conformance workflow was manual-only (`workflow_dispatch`), so nothing verified the suite still passes before a `chore: version packages` PR merged and published new versions.

- Add a `pull_request` trigger to `conformance.yml`. The full plan runs when the PR head is `changeset-release/main`; on every other PR the job is **skipped**, which still reports (and satisfies) the check without spending ~20 min of CI per PR.
- Add a concurrency group so a force-push of the release branch (which `release.yml` does on every main merge) cancels the superseded conformance run instead of queueing.
- Default `ALLOW_WARNING=1` on `pull_request` runs, matching the `workflow_dispatch` input default (inputs are empty on PR events, which would otherwise silently turn warnings into failures).

The `main` ruleset has been updated (via API) to make the `conformance` job a **required status check**, so the release PR cannot merge until the suite passes.

## Note for other open PRs

Until a PR's merge ref contains this workflow change, the required `conformance` check never reports and the PR shows as blocked. Merging this PR first, then updating the branch (or pushing any commit) resolves it — the check will report "skipped" and pass.

No changeset: workflow-only change, no versioned packages touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated conformance checks to run on pull requests targeting the main branch.
  * Added smarter run handling so newer checks cancel older queued runs.
  * Improved when the conformance job runs, keeping required status checks available while avoiding unnecessary work.
  * Made warning handling consistent across manual and pull request-triggered runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->