### PR TITLE
feat(create-authhero): switch local template to the drizzle adapter

### DIFF
--- a/.changeset/local-template-drizzle.md
+++ b/.changeset/local-template-drizzle.md
@@ -1,0 +1,5 @@
+---
+"create-authhero": minor
+---
+
+Switch the local (SQLite) template from the kysely adapter to @authhero/drizzle, aligning it with the Cloudflare/D1 templates. The scaffolded project now uses drizzle-orm/better-sqlite3 with the pre-generated migrations shipped in @authhero/drizzle. Existing scaffolded projects keep working; to adopt drizzle in an existing local project, delete db.sqlite and re-run migrate + seed (the kysely and drizzle migration histories are not compatible).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,12 +43,15 @@ This is a **pnpm monorepo** implementing a multi-tenant authentication/IAM syste
 
 - **`packages/authhero`** — Core Hono.js HTTP application. Contains all auth routes, login UI (React + TailwindCSS), authentication flows (authorization code, refresh token, device flow, etc.), and state machines. Built with Vite; outputs CJS + ESM bundles. i18n handled at build time via Paraglide.
 - **`packages/adapter-interfaces`** — TypeScript interfaces defining the adapter contract (CRUD for tenants, users, clients, connections, etc.). All database adapters must implement these.
-- **`packages/kysely`** — Primary database adapter using Kysely ORM. Supports SQLite (local dev), PlanetScale (MySQL), and other SQL databases. ~39 entity modules each handling one domain entity.
-- **`packages/drizzle`** — Experimental Drizzle ORM adapter (not production-ready).
+- **`packages/kysely`** — Kysely ORM adapter for PlanetScale (MySQL) and other SQL databases. Kept while PlanetScale runs in production; new deployments should use drizzle. ~39 entity modules each handling one domain entity.
+- **`packages/drizzle`** — Primary database adapter (Drizzle ORM, SQLite/D1). Used by all create-authhero templates; ships pre-generated migrations in `drizzle/`.
 - **`packages/cloudflare`** — Cloudflare-specific adapter for custom domain support.
 - **`packages/saml`** — SAML 2.0 authentication strategy.
 - **`packages/multi-tenancy`** — Multi-tenancy utilities shared across packages.
 - **`packages/proxy`** — Hono-based multi-tenant reverse proxy library. Resolves the `Host` header to a tenant via `custom_domains`, then dispatches each request to one of multiple upstreams based on path-prefix routes with per-route middleware (CORS, headers, basic auth, cache).
+- **`packages/ui-widget`** — Stencil web component that renders server-driven auth screens following the Auth0 Forms schema (types live in `adapter-interfaces`).
+- **`packages/aws`** — DynamoDB adapter.
+- **`packages/create-authhero`** — CLI scaffolder for new AuthHero projects.
 
 ### Applications
 
@@ -56,6 +59,10 @@ This is a **pnpm monorepo** implementing a multi-tenant authentication/IAM syste
 - **`apps/admin`** — Admin UI built on `ra-core` (the headless half of react-admin) with shadcn/ui and Tailwind v4. Uses Auth0 SPA JS for its own authentication to the admin API.
 - **`apps/proxy-dev`** — Cloudflare Worker harness for developing/deploying `@authhero/proxy`.
 - **`apps/docs`** — VitePress documentation site.
+- **`apps/website`** — Public marketing site (Vite + React SSG, Cloudflare Pages).
+- **`apps/conformance-auth-server`** / **`apps/conformance-runner`** — Local AuthHero server plus Playwright runner for the OpenID Foundation conformance suite.
+
+Packages with non-obvious conventions have their own `CLAUDE.md` (currently `apps/admin` and `packages/ui-widget`).
 
 ### Key Architectural Patterns
 
@@ -64,12 +71,14 @@ This is a **pnpm monorepo** implementing a multi-tenant authentication/IAM syste
 **Multi-tenancy**: Every API request is scoped to a tenant. The tenant ID flows through URL paths, request headers, and database queries. All entity CRUD operations accept a `tenantId` parameter.
 
 **Authentication routes in `authhero`**:
+
 - `src/routes/auth-api/` — OAuth2/OIDC endpoints (authorize, token, userinfo, jwks, etc.)
 - `src/routes/management-api/` — Tenant management REST API (26+ resource modules)
 - `src/routes/universal-login/` — Server-rendered login/signup/MFA UI
 - `src/routes/saml/` — SAML SSO endpoints
 
 **Admin UI dual-router** (`apps/admin`):
+
 - Outer router (`src/index.tsx`): domain selection → `/`, tenant management → `/tenants/*`, per-tenant admin → `/:tenantId/*`, auth callback → `/auth-callback`
 - Inner router (`src/App.tsx`): react-admin Router with `basename="/:tenantId"` for all resource routes
 - Domain config (URL, clientId, API URL) stored in cookies via `src/utils/domainUtils.ts`

--- a/packages/create-authhero/llms.txt
+++ b/packages/create-authhero/llms.txt
@@ -129,23 +129,24 @@ export default function createApp(config: AuthHeroConfig) {
 
 ```typescript
 // src/index.ts
-import { Kysely } from "kysely";
-import { D1Dialect } from "kysely-d1";
-import createAdapters from "@authhero/kysely-adapter";
+import { drizzle } from "drizzle-orm/d1";
+import createAdapters from "@authhero/drizzle";
+import * as schema from "@authhero/drizzle/schema/sqlite";
 import createApp from "./app";
 
 export default {
   async fetch(request: Request, env: Env) {
-    const db = new Kysely({ dialect: new D1Dialect({ database: env.AUTH_DB }) });
-    const dataAdapter = createAdapters(db);
-    const app = createApp({
-      dataAdapter,
-      issuer: new URL(request.url).origin,
-    });
+    const db = drizzle(env.AUTH_DB, { schema });
+    const dataAdapter = createAdapters(db, { useTransactions: false });
+    const app = createApp({ dataAdapter });
     return app.fetch(request, env);
   },
 };
 ```
+
+The local template uses the same adapter on better-sqlite3
+(`drizzle-orm/better-sqlite3`), with migrations shipped inside the
+`@authhero/drizzle` package.
 
 ## Seed Data
 
@@ -166,7 +167,7 @@ The CLI generates seed data including:
 ## Related Packages
 
 - `authhero` - Core authentication library
-- `@authhero/kysely-adapter` - Database adapter
+- `@authhero/drizzle` - Database adapter (SQLite/D1)
 - `@authhero/multi-tenancy` - Multi-tenant support
 
 ## License

--- a/packages/create-authhero/src/index.ts
+++ b/packages/create-authhero/src/index.ts
@@ -83,7 +83,7 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
           decrypt: "node --env-file=.env scripts/decrypt-field.mjs",
         },
         dependencies: {
-          "@authhero/kysely-adapter": v,
+          "@authhero/drizzle": v,
           ...(adminUi && { "@authhero/admin": v }),
           "@authhero/widget": v,
           "@hono/swagger-ui": "^0.6.0",
@@ -91,8 +91,8 @@ const setupConfigs: Record<SetupType, SetupConfig> = {
           "@hono/node-server": "latest",
           authhero: v,
           "better-sqlite3": "latest",
+          "drizzle-orm": "^0.44.0",
           hono: "^4.12.0",
-          kysely: "latest",
           ...(multiTenant && { "@authhero/multi-tenancy": v }),
           ...(conformance && { bcryptjs: "latest" }),
         },
@@ -571,9 +571,10 @@ function generateLocalSeedFileContent(
     : "";
 
   // TypeScript seed file for local setup - uses the seed function from authhero
-  return `import { SqliteDialect, Kysely } from "kysely";
-import Database from "better-sqlite3";
-import createAdapters from "@authhero/kysely-adapter";
+  return `import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import createAdapters from "@authhero/drizzle";
+import * as schema from "@authhero/drizzle/schema/sqlite";
 import { seed, createEncryptedDataAdapter, loadEncryptionKey${conformance ? ", USERNAME_PASSWORD_PROVIDER" : ""} } from "authhero";
 
 interface ExtraClient {
@@ -623,11 +624,8 @@ async function main() {
     ? JSON.parse(userProfileJson)
     : {};
 
-  const dialect = new SqliteDialect({
-    database: new Database("db.sqlite"),
-  });
-
-  const db = new Kysely<any>({ dialect });
+  const sqlite = new Database("db.sqlite");
+  const db = drizzle(sqlite, { schema });
   let adapters = createAdapters(db);
 
   // Match the server: encrypt seeded secrets at rest when a key is configured.
@@ -674,7 +672,7 @@ async function main() {
     console.log(\`✅ Updated profile of user "\${seedResult.username}"\`);
   }
 ${conformanceClientCode}
-  await db.destroy();
+  sqlite.close();
 }
 
 main().catch((err) => {

--- a/packages/create-authhero/templates/local/src/index.ts
+++ b/packages/create-authhero/templates/local/src/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "@hono/node-server";
-import { SqliteDialect } from "kysely";
-import { Kysely } from "kysely";
 import Database from "better-sqlite3";
-import createAdapters from "@authhero/kysely-adapter";
+import { drizzle, BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import createAdapters from "@authhero/drizzle";
+import * as schema from "@authhero/drizzle/schema/sqlite";
 import { createEncryptedDataAdapter, loadEncryptionKey } from "authhero";
 import createApp from "./app";
 import fs from "fs";
@@ -85,12 +85,9 @@ function ensureCertificates() {
 }
 
 // Initialize SQLite database
-let db: Kysely<any>;
+let db: BetterSQLite3Database<typeof schema>;
 try {
-  const dialect = new SqliteDialect({
-    database: new Database("db.sqlite"),
-  });
-  db = new Kysely<any>({ dialect });
+  db = drizzle(new Database("db.sqlite"), { schema });
 } catch (error) {
   console.error("❌ Failed to initialize database:");
   console.error(

--- a/packages/create-authhero/templates/local/src/migrate.ts
+++ b/packages/create-authhero/templates/local/src/migrate.ts
@@ -1,25 +1,26 @@
-import { SqliteDialect, Kysely } from "kysely";
 import Database from "better-sqlite3";
-import { migrateToLatest } from "@authhero/kysely-adapter";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 
-async function migrate() {
-  const dialect = new SqliteDialect({
-    database: new Database("db.sqlite"),
-  });
+// Migrations are pre-generated and shipped with the @authhero/drizzle package.
+// The schema is managed by AuthHero — do not generate your own migrations.
+const migrationsFolder = "node_modules/@authhero/drizzle/drizzle";
 
-  const db = new Kysely<any>({ dialect });
+function migrateDb() {
+  const sqlite = new Database("db.sqlite");
+  const db = drizzle(sqlite);
 
   console.log("Running migrations...");
 
   try {
-    await migrateToLatest(db, true);
+    migrate(db, { migrationsFolder });
     console.log("✅ All migrations completed successfully");
   } catch (error) {
     console.error("Migration failed:", error);
     process.exit(1);
   } finally {
-    await db.destroy();
+    sqlite.close();
   }
 }
 
-migrate();
+migrateDb();

--- a/packages/create-authhero/templates/proxy/README.md
+++ b/packages/create-authhero/templates/proxy/README.md
@@ -29,34 +29,35 @@ export const proxyConfig: StaticProxyAdapterOptions = {
 
 The proxy reads its routes through a `ProxyDataAdapter`. Three implementations are common:
 
-| Adapter | Best for | Notes |
-| --- | --- | --- |
-| **Static** (default) | Local dev, small fixed deployments | Routes baked into the worker bundle; re-deploy to change them. |
-| **Database** | Same-process or co-located deployments | Reads directly from the proxy_routes table that authhero writes to. |
+| Adapter                   | Best for                                           | Notes                                                                      |
+| ------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Static** (default)      | Local dev, small fixed deployments                 | Routes baked into the worker bundle; re-deploy to change them.             |
+| **Database**              | Same-process or co-located deployments             | Reads directly from the proxy_routes table that authhero writes to.        |
 | **HTTP / management API** | Geographically distributed proxies, hosted Workers | Calls `/api/v2/proxy-routes` on your authhero server with a service token. |
 
 The authhero server exposes the management API (`/api/v2/proxy-routes`) and creates the underlying table automatically once the standard adapter migrations have run — see the `local` template's [src/index.ts](../local/src/index.ts).
 
-### Database-backed (Kysely)
+### Database-backed (Drizzle)
 
-Add the adapter and your Kysely driver, then swap the data line:
+Add the adapter and drizzle-orm, then swap the data line:
 
 ```bash
-npm install @authhero/kysely-adapter kysely
+npm install @authhero/drizzle drizzle-orm
 ```
 
 ```ts
-import { Kysely } from "kysely";
+import { drizzle } from "drizzle-orm/d1";
 import { createProxyApp } from "@authhero/proxy";
-import { createProxyDataAdapter } from "@authhero/kysely-adapter";
+import { createProxyDataAdapter } from "@authhero/drizzle";
+import * as schema from "@authhero/drizzle/schema/sqlite";
 
-const db = new Kysely({ dialect: /* your dialect */ });
+const db = drizzle(env.AUTH_DB, { schema });
 const app = createProxyApp({
   data: createProxyDataAdapter(db),
 });
 ```
 
-Cloudflare Workers can't open SQLite files, so on Workers this path means D1, Hyperdrive, or a remote MySQL/Postgres. For a local Node process, `better-sqlite3` pointing at the same `db.sqlite` your authhero server uses works out of the box.
+On Cloudflare Workers this reads from the same D1 database your authhero worker uses. For a local Node process, use `drizzle-orm/better-sqlite3` pointing at the same `db.sqlite` your authhero server uses. (If your routes live in MySQL/Postgres, `@authhero/kysely-adapter` exposes the same `createProxyDataAdapter` for Kysely dialects.)
 
 ### HTTP-backed (management API)
 
@@ -87,7 +88,7 @@ interface Env {
 
 function createHttpProxyAdapter(env: Env): ProxyDataAdapter {
   const headers = {
-    "authorization": `Bearer ${env.AUTHHERO_SERVICE_TOKEN}`,
+    authorization: `Bearer ${env.AUTHHERO_SERVICE_TOKEN}`,
     "tenant-id": env.AUTHHERO_TENANT_ID,
   };
 
@@ -101,16 +102,29 @@ function createHttpProxyAdapter(env: Env): ProxyDataAdapter {
     // The proxy data plane only needs resolveHost; the CRUD methods on
     // proxyRoutes stay unused (writes always go through authhero directly).
     proxyRoutes: {
-      list: () => { throw new Error("read-only proxy adapter"); },
-      get: () => { throw new Error("read-only proxy adapter"); },
-      create: () => { throw new Error("read-only proxy adapter"); },
-      update: () => { throw new Error("read-only proxy adapter"); },
-      remove: () => { throw new Error("read-only proxy adapter"); },
+      list: () => {
+        throw new Error("read-only proxy adapter");
+      },
+      get: () => {
+        throw new Error("read-only proxy adapter");
+      },
+      create: () => {
+        throw new Error("read-only proxy adapter");
+      },
+      update: () => {
+        throw new Error("read-only proxy adapter");
+      },
+      remove: () => {
+        throw new Error("read-only proxy adapter");
+      },
     },
     async resolveHost(host): Promise<ResolvedHost | null> {
-      const domains = await api<{ custom_domains: Array<{
-        custom_domain_id: string; domain: string;
-      }> }>("/api/v2/custom-domains");
+      const domains = await api<{
+        custom_domains: Array<{
+          custom_domain_id: string;
+          domain: string;
+        }>;
+      }>("/api/v2/custom-domains");
       const match = domains.custom_domains.find((d) => d.domain === host);
       if (!match) return null;
 

--- a/packages/create-authhero/test/scaffold.test.ts
+++ b/packages/create-authhero/test/scaffold.test.ts
@@ -98,11 +98,13 @@ describe("local template", () => {
     }
   });
 
-  it("depends on the kysely adapter with published versions by default", () => {
+  it("depends on the drizzle adapter with published versions by default", () => {
     const pkg = readJson(path.join(projects.local.projectPath, "package.json"));
-    expect(pkg.dependencies["@authhero/kysely-adapter"]).toBe("latest");
+    expect(pkg.dependencies["@authhero/drizzle"]).toBe("latest");
+    expect(pkg.dependencies["@authhero/kysely-adapter"]).toBeUndefined();
     expect(pkg.dependencies.authhero).toBe("latest");
     expect(pkg.dependencies["better-sqlite3"]).toBeTruthy();
+    expect(pkg.dependencies["drizzle-orm"]).toBeTruthy();
   });
 
   it("enables the admin UI by default in non-interactive mode", () => {


### PR DESCRIPTION
## Summary

Moves the last kysely-based template (`local`, SQLite) over to `@authhero/drizzle`, so every create-authhero scaffold now runs the same adapter, schema, and pre-generated migrations as the Cloudflare/D1 templates. First step of the gradual kysely→drizzle migration; `@authhero/kysely-adapter` remains the PlanetScale/MySQL production adapter.

- **`templates/local/src/index.ts`** — server entry builds the adapter with `drizzle-orm/better-sqlite3` + `@authhero/drizzle` (no casts; `BetterSQLite3Database<typeof schema>` is assignable to the adapter's `DrizzleDb`).
- **`templates/local/src/migrate.ts`** — uses drizzle's migrator against the migrations shipped in `node_modules/@authhero/drizzle/drizzle`, the same files wrangler applies on D1.
- **CLI generator** — local template deps swap `@authhero/kysely-adapter` + `kysely` for `@authhero/drizzle` + `drizzle-orm` (better-sqlite3 stays as the driver); the generated `seed.ts` sets up drizzle and closes the sqlite handle.
- **Docs** — refreshes stale kysely references: `llms.txt` (still showed a kysely-d1 cloudflare example), the proxy template README (database-backed adapter example now drizzle), and CLAUDE.md's adapter descriptions.

### Migration note

Existing scaffolded local projects keep working as-is. To adopt drizzle in an existing project, delete `db.sqlite` and re-run `migrate` + `seed` — the kysely (`kysely_migration`) and drizzle (`__drizzle_migrations`) histories are not compatible.

## Test plan

- [x] `pnpm --filter create-authhero test` — 84/84 passing, including the generated-code checks that validate every import in scaffolded files against real package exports
- [x] Type-checked the better-sqlite3 drizzle instance against `createAdapters` without casts
- [x] Ran the drizzle migrator against the shipped migrations on a fresh SQLite file: 45 tables created, second run is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local project scaffolding now uses Drizzle ORM for SQLite by default, aligning it with the Cloudflare/D1 setup.
  * Generated projects now include preconfigured Drizzle migrations and updated database startup/migration flow.

* **Documentation**
  * Updated setup guidance and examples to reflect the new Drizzle-based templates and adapter usage.
  * Expanded architecture notes and package/application listings for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->