### PR TITLE
feat: record tenant operations with an inline executor and management API (#1026 phase 1b)

### DIFF
--- a/.changeset/tenant-operations-recording.md
+++ b/.changeset/tenant-operations-recording.md
@@ -1,0 +1,11 @@
+---
+"@authhero/multi-tenancy": minor
+"authhero": minor
+"@authhero/cloudflare-adapter": patch
+---
+
+Record tenant lifecycle operations and expose them via the management API (issue #1026, phase 1).
+
+- `@authhero/multi-tenancy` gains an operations module: `runRecordedTenantOperation` wraps `databaseIsolation.onProvision` so every provision writes a `tenant_operations` row with step events (no behavior change — recording is skipped when the adapters are absent and is warn-only on write failure), plus `createInlineExecutor` / `enqueueTenantOperation` implementing the row-first executor contract the Cloudflare Workflows engine plugs into next. `initMultiTenant` wires a default inline executor for `upgrade` operations when `tenantUpgrade` is configured.
+- `authhero` mounts `GET /api/v2/operations/{id}`, `GET/POST /api/v2/tenants/{id}/operations` (new scopes `read:tenant_operations`, `create:tenant_operations`) when the control-plane operations adapters are present, with a new `tenantOperationExecutor` config binding.
+- `@authhero/cloudflare-adapter`'s WFP provisioning hook accepts an optional step reporter and surfaces `provision-resources` / `seed-defaults` boundaries; reporting can never fail a provision.

--- a/packages/authhero/src/middlewares/apply-config.ts
+++ b/packages/authhero/src/middlewares/apply-config.ts
@@ -48,6 +48,10 @@ export function applyConfigMiddleware(
       ctx.env.tenantUpgrade = config.tenantUpgrade;
     }
 
+    if (config.tenantOperationExecutor) {
+      ctx.env.tenantOperationExecutor = config.tenantOperationExecutor;
+    }
+
     if (config.outbox) {
       ctx.env.outbox = config.outbox;
     }

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -62,6 +62,7 @@ import { guardianRoutes } from "./guardian";
 import { authenticationMethodsRoutes } from "./authentication-methods";
 import { ticketsRoutes } from "./tickets";
 import { proxyRoutesRoutes } from "./proxy-routes";
+import { operationRoutes, tenantOperationsRoutes } from "./tenant-operations";
 import { tenantExportImportRoutes } from "./tenant-export-import";
 import { DataAdapters } from "@authhero/adapter-interfaces";
 import { outboxMiddleware } from "../../middlewares/outbox";
@@ -594,6 +595,17 @@ export default function create(config: AuthHeroConfig) {
   // adapter is optional on DataAdapters; without it the routes return 501.
   if (!extensionPaths.has("/proxy-routes") && managementAdapter.proxyRoutes) {
     managementApp.route("/proxy-routes", proxyRoutesRoutes);
+  }
+
+  // Durable tenant lifecycle operations (issue #1026). Mounted only when
+  // the control-plane operations adapters are wired — tenant workers and
+  // non-control-plane deployments never expose these routes.
+  if (
+    managementAdapter.tenantOperations &&
+    managementAdapter.tenantOperationEvents
+  ) {
+    managementApp.route("/operations", operationRoutes);
+    managementApp.route("/tenants/:id/operations", tenantOperationsRoutes);
   }
 
   // Mount any additional route extensions from config

--- a/packages/authhero/src/routes/management-api/tenant-operations.ts
+++ b/packages/authhero/src/routes/management-api/tenant-operations.ts
@@ -1,0 +1,220 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { HTTPException } from "hono/http-exception";
+import {
+  LogTypes,
+  tenantOperationEventSchema,
+  tenantOperationKindSchema,
+  tenantOperationSchema,
+  tenantOperationStatusSchema,
+} from "@authhero/adapter-interfaces";
+import { Bindings, Variables } from "../../types";
+import { defineRoute } from "../../utils/define-route";
+import { logMessage } from "../../helpers/logging";
+import { isControlPlaneTenant } from "./tenants";
+
+// Durable tenant lifecycle operations (issue #1026). These are
+// control-plane records: the routes are only mounted when the management
+// adapter carries the tenantOperations/tenantOperationEvents adapters,
+// which only control-plane deployments wire up.
+
+const listQuerySchema = z.object({
+  page: z.coerce.number().int().min(0).default(0),
+  per_page: z.coerce.number().int().min(1).max(100).default(50),
+  kind: tenantOperationKindSchema.optional(),
+  status: tenantOperationStatusSchema.optional(),
+});
+
+// GET /operations/{id} — one operation plus its full event timeline.
+const getOperation = defineRoute({
+  route: createRoute({
+    tags: ["tenant-operations"],
+    method: "get",
+    path: "/{id}",
+    request: {
+      params: z.object({ id: z.string() }),
+      headers: z.object({ "tenant-id": z.string().optional() }),
+    },
+    security: [{ Bearer: ["read:tenant_operations"] }],
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: tenantOperationSchema.extend({
+              events: z.array(tenantOperationEventSchema),
+            }),
+          },
+        },
+        description: "The operation with its step events",
+      },
+    },
+  }),
+  handler: async (ctx) => {
+    const { tenantOperations, tenantOperationEvents } = ctx.env.data;
+    if (!tenantOperations || !tenantOperationEvents) {
+      throw new HTTPException(501, {
+        message: "Tenant operations are not configured for this deployment",
+      });
+    }
+
+    const { id } = ctx.req.valid("param");
+    const operation = await tenantOperations.get(id);
+    if (!operation) {
+      throw new HTTPException(404, { message: "Operation not found" });
+    }
+
+    const { events } = await tenantOperationEvents.listByOperation(id);
+    return ctx.json({ ...operation, events });
+  },
+});
+
+export const operationRoutes = new OpenAPIHono<{
+  Bindings: Bindings;
+  Variables: Variables;
+}>().openapiRoutes([getOperation] as const);
+
+// GET /tenants/:id/operations — paginated history for one tenant. The
+// target tenant id comes from the mount path (like
+// /users/:user_id/authentication-methods).
+const listTenantOperations = defineRoute({
+  route: createRoute({
+    tags: ["tenant-operations"],
+    method: "get",
+    path: "/",
+    request: {
+      query: listQuerySchema,
+      headers: z.object({ "tenant-id": z.string().optional() }),
+    },
+    security: [{ Bearer: ["read:tenant_operations"] }],
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: z.object({
+              operations: z.array(tenantOperationSchema),
+              start: z.number(),
+              limit: z.number(),
+              length: z.number(),
+            }),
+          },
+        },
+        description: "Operations for the tenant, newest first",
+      },
+    },
+  }),
+  handler: async (ctx) => {
+    const { tenantOperations } = ctx.env.data;
+    if (!tenantOperations) {
+      throw new HTTPException(501, {
+        message: "Tenant operations are not configured for this deployment",
+      });
+    }
+
+    const tenantId = ctx.req.param("id");
+    if (!tenantId) {
+      throw new HTTPException(400, { message: "Missing tenant id" });
+    }
+    const { page, per_page, kind, status } = ctx.req.valid("query");
+
+    const result = await tenantOperations.list({
+      tenant_id: tenantId,
+      page,
+      per_page,
+      kind,
+      status,
+    });
+
+    return ctx.json(result);
+  },
+});
+
+// POST /tenants/:id/operations — enqueue an operation for a tenant.
+// Control-plane only, mirroring POST /tenants/{id}/redeploy. Phase 1
+// supports { kind: "upgrade" } via the configured executor; provision and
+// deprovision stay lifecycle-hook driven, seed and backup arrive with the
+// durable executor phases.
+const createTenantOperation = defineRoute({
+  route: createRoute({
+    tags: ["tenant-operations"],
+    method: "post",
+    path: "/",
+    request: {
+      headers: z.object({ "tenant-id": z.string().optional() }),
+      body: {
+        content: {
+          "application/json": {
+            schema: z.object({ kind: tenantOperationKindSchema }),
+          },
+        },
+      },
+    },
+    security: [{ Bearer: ["create:tenant_operations"] }],
+    responses: {
+      201: {
+        content: {
+          "application/json": { schema: tenantOperationSchema },
+        },
+        description:
+          "The enqueued operation. Poll GET /operations/{id} for progress; the inline engine returns it already terminal.",
+      },
+    },
+  }),
+  handler: async (ctx) => {
+    if (!isControlPlaneTenant(ctx, ctx.var.tenant_id)) {
+      throw new HTTPException(403, {
+        message:
+          "Tenant operations can only be triggered from the control plane",
+      });
+    }
+
+    const { kind } = ctx.req.valid("json");
+    const tenantId = ctx.req.param("id");
+    if (!tenantId) {
+      throw new HTTPException(400, { message: "Missing tenant id" });
+    }
+
+    const tenant = await ctx.env.data.tenants.get(tenantId);
+    if (!tenant) {
+      throw new HTTPException(404, { message: "Tenant not found" });
+    }
+
+    if (kind === "provision" || kind === "deprovision") {
+      throw new HTTPException(400, {
+        message: `Operations of kind "${kind}" are managed by the tenant lifecycle (create/delete) and cannot be enqueued directly`,
+      });
+    }
+
+    if (kind === "seed" || kind === "backup") {
+      throw new HTTPException(501, {
+        message: `Operations of kind "${kind}" are not supported yet`,
+      });
+    }
+
+    const executor = ctx.env.tenantOperationExecutor;
+    if (!executor) {
+      throw new HTTPException(501, {
+        message:
+          "Tenant operations are not configured for this deployment (no executor)",
+      });
+    }
+
+    const operation = await executor.enqueue({
+      kind,
+      tenant_id: tenantId,
+      initiated_by: ctx.var.user?.sub,
+    });
+
+    await logMessage(ctx, tenantId, {
+      type: LogTypes.SUCCESS_API_OPERATION,
+      description: `Enqueue tenant operation (${kind})`,
+      targetType: "tenant",
+      targetId: tenantId,
+    });
+
+    return ctx.json(operation, { status: 201 });
+  },
+});
+
+export const tenantOperationsRoutes = new OpenAPIHono<{
+  Bindings: Bindings;
+  Variables: Variables;
+}>().openapiRoutes([listTenantOperations, createTenantOperation] as const);

--- a/packages/authhero/src/routes/management-api/tenant-operations.ts
+++ b/packages/authhero/src/routes/management-api/tenant-operations.ts
@@ -58,7 +58,14 @@ const getOperation = defineRoute({
 
     const { id } = ctx.req.valid("param");
     const operation = await tenantOperations.get(id);
-    if (!operation) {
+    // Only the control plane may read arbitrary operations; other callers
+    // are limited to their own tenant's. Respond 404 (not 403) so foreign
+    // operation ids don't leak their existence.
+    if (
+      !operation ||
+      (!isControlPlaneTenant(ctx, ctx.var.tenant_id) &&
+        operation.tenant_id !== ctx.var.tenant_id)
+    ) {
       throw new HTTPException(404, { message: "Operation not found" });
     }
 
@@ -112,6 +119,17 @@ const listTenantOperations = defineRoute({
     const tenantId = ctx.req.param("id");
     if (!tenantId) {
       throw new HTTPException(400, { message: "Missing tenant id" });
+    }
+    // Same scoping as GET /operations/{id}: only the control plane may read
+    // other tenants' operation history.
+    if (
+      !isControlPlaneTenant(ctx, ctx.var.tenant_id) &&
+      tenantId !== ctx.var.tenant_id
+    ) {
+      throw new HTTPException(403, {
+        message:
+          "Operations for other tenants can only be read from the control plane",
+      });
     }
     const { page, per_page, kind, status } = ctx.req.valid("query");
 

--- a/packages/authhero/src/routes/management-api/tenants.ts
+++ b/packages/authhero/src/routes/management-api/tenants.ts
@@ -262,7 +262,7 @@ export const tenantRoutes = new OpenAPIHono<{
 // multi-tenant deployments `multiTenancyConfig.controlPlaneTenantId` names the
 // designated tenant; when no config is set we treat the deployment as
 // single-tenant, which is effectively a control plane.
-function isControlPlaneTenant(
+export function isControlPlaneTenant(
   ctx: {
     env: { data: { multiTenancyConfig?: { controlPlaneTenantId?: string } } };
   },

--- a/packages/authhero/src/seed.ts
+++ b/packages/authhero/src/seed.ts
@@ -563,6 +563,12 @@ export const MANAGEMENT_API_SCOPES = [
   { description: "Create Tenants", value: "create:tenants" },
   { description: "Update Tenants", value: "update:tenants" },
   { description: "Delete Tenants", value: "delete:tenants" },
+  // Tenant lifecycle operations (issue #1026)
+  { description: "Read Tenant Operations", value: "read:tenant_operations" },
+  {
+    description: "Create Tenant Operations",
+    value: "create:tenant_operations",
+  },
 ];
 
 export interface SeedOptions {

--- a/packages/authhero/src/types/AuthHeroConfig.ts
+++ b/packages/authhero/src/types/AuthHeroConfig.ts
@@ -10,6 +10,8 @@ import {
   Role,
   RoleInsert,
   Tenant,
+  TenantOperation,
+  TenantOperationKind,
 } from "@authhero/adapter-interfaces";
 import type { RolePermissionHooks, Hooks } from "./Hooks";
 import type { SamlSigner } from "@authhero/saml/core";
@@ -123,6 +125,22 @@ export interface ManagementApiExtension {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   router: OpenAPIHono<any, any, any>;
+}
+
+/**
+ * Enqueues a durable tenant lifecycle operation (issue #1026): creates
+ * the `tenant_operations` row and starts execution on the configured
+ * engine. The inline engine resolves with a terminal row; durable engines
+ * resolve as soon as the run is enqueued — clients poll
+ * `GET /api/v2/operations/{id}`.
+ */
+export interface TenantOperationExecutorBinding {
+  engine: string;
+  enqueue(params: {
+    kind: TenantOperationKind;
+    tenant_id: string | null;
+    initiated_by?: string;
+  }): Promise<TenantOperation>;
 }
 
 /**
@@ -429,6 +447,17 @@ export interface AuthHeroConfig {
    * ```
    */
   tenantUpgrade?: (tenantId: string) => Promise<void>;
+
+  /**
+   * Optional executor for durable tenant lifecycle operations (issue
+   * #1026). When set together with the `tenantOperations` /
+   * `tenantOperationEvents` adapters, `POST /api/v2/tenants/{id}/operations`
+   * enqueues operations through it. Kept structural so authhero core
+   * depends on neither `@authhero/multi-tenancy` nor any engine —
+   * `@authhero/multi-tenancy`'s `enqueueTenantOperation` + executors
+   * satisfy this shape.
+   */
+  tenantOperationExecutor?: TenantOperationExecutorBinding;
 
   /**
    * Optional powered-by logo to display at the bottom left of the login widget.

--- a/packages/authhero/src/types/Bindings.ts
+++ b/packages/authhero/src/types/Bindings.ts
@@ -5,6 +5,7 @@ import {
   EntityHooksConfig,
   OutboxConfig,
   SigningKeyModeOption,
+  TenantOperationExecutorBinding,
   UserLinkingModeOption,
   UsernamePasswordProviderResolver,
   WebhookInvoker,
@@ -72,6 +73,11 @@ export type Bindings = {
   // bundle + migrations. Set via init({ tenantUpgrade: hook.onUpgrade }).
   // Drives POST /api/v2/tenants/{id}/redeploy.
   tenantUpgrade?: (tenantId: string) => Promise<void>;
+
+  // Optional executor for durable tenant lifecycle operations (issue #1026).
+  // Set via init({ tenantOperationExecutor }). Drives
+  // POST /api/v2/tenants/{id}/operations.
+  tenantOperationExecutor?: TenantOperationExecutorBinding;
 
   // Optional transactional outbox configuration
   // Set via init({ outbox: { enabled: true } })

--- a/packages/authhero/test/helpers/test-server.ts
+++ b/packages/authhero/test/helpers/test-server.ts
@@ -73,6 +73,9 @@ type getEnvParams = {
   // Optional handler driving POST /tenants/{id}/redeploy (the
   // `config.tenantUpgrade` integration point).
   tenantUpgrade?: (tenantId: string) => Promise<void>;
+  // Optional executor driving POST /tenants/{id}/operations (the
+  // `config.tenantOperationExecutor` integration point, issue #1026).
+  tenantOperationExecutor?: import("../../src/types").TenantOperationExecutorBinding;
   // Optional static CORS allow-list passed through to `init`.
   allowedOrigins?: string[];
 };
@@ -283,6 +286,9 @@ export async function getTestServer(
     ...(args.codeExecutor ? { codeExecutor: args.codeExecutor } : {}),
     ...(args.tenantDispatch ? { tenantDispatch: args.tenantDispatch } : {}),
     ...(args.tenantUpgrade ? { tenantUpgrade: args.tenantUpgrade } : {}),
+    ...(args.tenantOperationExecutor
+      ? { tenantOperationExecutor: args.tenantOperationExecutor }
+      : {}),
     ...(args.allowedOrigins ? { allowedOrigins: args.allowedOrigins } : {}),
   });
   return {

--- a/packages/authhero/test/helpers/token.ts
+++ b/packages/authhero/test/helpers/token.ts
@@ -135,6 +135,8 @@ const ADMIN_PERMISSIONS = [
   "read:sessions",
   "read:signing_keys",
   "read:stats",
+  "read:tenant_operations",
+  "create:tenant_operations",
   "read:tenants",
   "read:users",
   "update:actions",

--- a/packages/authhero/test/routes/management-api/tenant-operations.spec.ts
+++ b/packages/authhero/test/routes/management-api/tenant-operations.spec.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from "vitest";
+import { createToken, getAdminToken } from "../../helpers/token";
+import { getTestServer } from "../../helpers/test-server";
+import type { DataAdapters } from "@authhero/adapter-interfaces";
+import type { TenantOperationExecutorBinding } from "../../../src/types";
+
+// Driven through the full `app` (management API at /api/v2) so the parent
+// onError resolves 5xx responses, mirroring tenant-redeploy.spec.ts.
+
+// Stub executor backed by the test server's own adapters: creates the row,
+// records one event, and finalizes — modelling the inline engine's
+// "terminal before resolve" contract without importing multi-tenancy.
+function createStubExecutor(getData: () => DataAdapters | undefined) {
+  const executor: TenantOperationExecutorBinding = {
+    engine: "inline",
+    async enqueue(params) {
+      const data = getData();
+      if (!data?.tenantOperations || !data.tenantOperationEvents) {
+        throw new Error("stub executor: operations adapters missing");
+      }
+      const created = await data.tenantOperations.create({
+        tenant_id: params.tenant_id,
+        kind: params.kind,
+        engine: "inline",
+        initiated_by: params.initiated_by,
+      });
+      await data.tenantOperationEvents.create({
+        operation_id: created.id,
+        step: params.kind,
+        outcome: "succeeded",
+      });
+      await data.tenantOperations.update(created.id, {
+        status: "succeeded",
+        finished_at: new Date().toISOString(),
+      });
+      const finished = await data.tenantOperations.get(created.id);
+      if (!finished) throw new Error("stub executor: operation vanished");
+      return finished;
+    },
+  };
+  return executor;
+}
+
+describe("management-api tenant operations", () => {
+  it("lists an empty history for a fresh tenant", async () => {
+    const { app, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/operations",
+      {
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      operations: [],
+      start: 0,
+      limit: 50,
+      length: 0,
+    });
+  });
+
+  it("enqueues an upgrade and exposes it via GET /operations/{id}", async () => {
+    let dataRef: DataAdapters | undefined;
+    const { app, env } = await getTestServer({
+      tenantOperationExecutor: createStubExecutor(() => dataRef),
+    });
+    dataRef = env.data;
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/operations",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ kind: "upgrade" }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(201);
+    const operation = await response.json();
+    expect(operation).toMatchObject({
+      tenant_id: "tenantId",
+      kind: "upgrade",
+      status: "succeeded",
+      engine: "inline",
+    });
+
+    const detailResponse = await app.request(
+      `/api/v2/operations/${operation.id}`,
+      {
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+    expect(detailResponse.status).toBe(200);
+    const detail = await detailResponse.json();
+    expect(detail.id).toBe(operation.id);
+    expect(detail.events).toHaveLength(1);
+    expect(detail.events[0]).toMatchObject({
+      step: "upgrade",
+      outcome: "succeeded",
+    });
+
+    const listResponse = await app.request(
+      "/api/v2/tenants/tenantId/operations",
+      {
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+    const list = await listResponse.json();
+    expect(list.operations).toHaveLength(1);
+    expect(list.operations[0].id).toBe(operation.id);
+  });
+
+  it("rejects lifecycle-managed kinds with 400", async () => {
+    let dataRef: DataAdapters | undefined;
+    const { app, env } = await getTestServer({
+      tenantOperationExecutor: createStubExecutor(() => dataRef),
+    });
+    dataRef = env.data;
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/operations",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ kind: "provision" }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 501 for not-yet-supported kinds", async () => {
+    let dataRef: DataAdapters | undefined;
+    const { app, env } = await getTestServer({
+      tenantOperationExecutor: createStubExecutor(() => dataRef),
+    });
+    dataRef = env.data;
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/operations",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ kind: "backup" }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(501);
+  });
+
+  it("returns 501 when no executor is configured", async () => {
+    const { app, env } = await getTestServer();
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/operations",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ kind: "upgrade" }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(501);
+  });
+
+  it("returns 403 when the caller is not the control plane", async () => {
+    let dataRef: DataAdapters | undefined;
+    const { app, env } = await getTestServer({
+      tenantOperationExecutor: createStubExecutor(() => dataRef),
+    });
+    dataRef = env.data;
+
+    env.data.multiTenancyConfig = {
+      controlPlaneTenantId: "control_plane",
+    };
+
+    const token = await getAdminToken();
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/operations",
+      {
+        method: "POST",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ kind: "upgrade" }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 404 for an unknown operation id", async () => {
+    const { app, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    const response = await app.request(
+      "/api/v2/operations/op_does_not_exist",
+      {
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects tokens without the tenant_operations scopes", async () => {
+    const { app, env } = await getTestServer();
+    const token = await createToken({ permissions: ["read:users"] });
+
+    const response = await app.request(
+      "/api/v2/tenants/tenantId/operations",
+      {
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/packages/authhero/test/routes/management-api/tenant-operations.spec.ts
+++ b/packages/authhero/test/routes/management-api/tenant-operations.spec.ts
@@ -67,11 +67,11 @@ describe("management-api tenant operations", () => {
   });
 
   it("enqueues an upgrade and exposes it via GET /operations/{id}", async () => {
-    let dataRef: DataAdapters | undefined;
+    const dataRef: { current?: DataAdapters } = {};
     const { app, env } = await getTestServer({
-      tenantOperationExecutor: createStubExecutor(() => dataRef),
+      tenantOperationExecutor: createStubExecutor(() => dataRef.current),
     });
-    dataRef = env.data;
+    dataRef.current = env.data;
 
     const token = await getAdminToken();
     const response = await app.request(
@@ -132,11 +132,11 @@ describe("management-api tenant operations", () => {
   });
 
   it("rejects lifecycle-managed kinds with 400", async () => {
-    let dataRef: DataAdapters | undefined;
+    const dataRef: { current?: DataAdapters } = {};
     const { app, env } = await getTestServer({
-      tenantOperationExecutor: createStubExecutor(() => dataRef),
+      tenantOperationExecutor: createStubExecutor(() => dataRef.current),
     });
-    dataRef = env.data;
+    dataRef.current = env.data;
 
     const token = await getAdminToken();
     const response = await app.request(
@@ -157,11 +157,11 @@ describe("management-api tenant operations", () => {
   });
 
   it("returns 501 for not-yet-supported kinds", async () => {
-    let dataRef: DataAdapters | undefined;
+    const dataRef: { current?: DataAdapters } = {};
     const { app, env } = await getTestServer({
-      tenantOperationExecutor: createStubExecutor(() => dataRef),
+      tenantOperationExecutor: createStubExecutor(() => dataRef.current),
     });
-    dataRef = env.data;
+    dataRef.current = env.data;
 
     const token = await getAdminToken();
     const response = await app.request(
@@ -203,11 +203,11 @@ describe("management-api tenant operations", () => {
   });
 
   it("returns 403 when the caller is not the control plane", async () => {
-    let dataRef: DataAdapters | undefined;
+    const dataRef: { current?: DataAdapters } = {};
     const { app, env } = await getTestServer({
-      tenantOperationExecutor: createStubExecutor(() => dataRef),
+      tenantOperationExecutor: createStubExecutor(() => dataRef.current),
     });
-    dataRef = env.data;
+    dataRef.current = env.data;
 
     env.data.multiTenancyConfig = {
       controlPlaneTenantId: "control_plane",
@@ -229,6 +229,60 @@ describe("management-api tenant operations", () => {
     );
 
     expect(response.status).toBe(403);
+  });
+
+  it("hides other tenants' operations from non-control-plane callers", async () => {
+    const { app, env } = await getTestServer();
+
+    // Designate a control plane BEFORE any request — the management app
+    // wraps the data adapter on first use, so a later mutation isn't seen
+    // (same constraint as the redeploy 403 test).
+    env.data.multiTenancyConfig = {
+      controlPlaneTenantId: "control_plane",
+    };
+
+    // Seed the operation directly: POST is control-plane-only, and the
+    // acting tenants in this test deliberately aren't the control plane.
+    await env.data.tenants.create({
+      id: "otherTenant",
+      friendly_name: "Other Tenant",
+    });
+    const operation = await env.data.tenantOperations!.create({
+      tenant_id: "tenantId",
+      kind: "upgrade",
+      engine: "inline",
+    });
+
+    const token = await getAdminToken();
+
+    // A foreign tenant gets a 404 for the operation and a 403 for the list.
+    const foreignGet = await app.request(
+      `/api/v2/operations/${operation.id}`,
+      {
+        headers: { "tenant-id": "otherTenant", authorization: `Bearer ${token}` },
+      },
+      env,
+    );
+    expect(foreignGet.status).toBe(404);
+
+    const foreignList = await app.request(
+      "/api/v2/tenants/tenantId/operations",
+      {
+        headers: { "tenant-id": "otherTenant", authorization: `Bearer ${token}` },
+      },
+      env,
+    );
+    expect(foreignList.status).toBe(403);
+
+    // The owning tenant can still read its own history.
+    const ownGet = await app.request(
+      `/api/v2/operations/${operation.id}`,
+      {
+        headers: { "tenant-id": "tenantId", authorization: `Bearer ${token}` },
+      },
+      env,
+    );
+    expect(ownGet.status).toBe(200);
   });
 
   it("returns 404 for an unknown operation id", async () => {

--- a/packages/cloudflare/src/wfp-provisioner/tenant-hook.ts
+++ b/packages/cloudflare/src/wfp-provisioner/tenant-hook.ts
@@ -80,8 +80,24 @@ export interface WfpTenantProvisioningHookOptions {
   syncDefaults?: (tenantId: string) => Promise<unknown>;
 }
 
+/**
+ * Structural mirror of `@authhero/multi-tenancy`'s `StepReporter` — kept
+ * local so this module carries no multi-tenancy dependency. When the
+ * control plane records provisions as tenant operations (issue #1026),
+ * the hook receives this callback and surfaces coarse step boundaries
+ * (`provision-resources`, `seed-defaults`) in the operation history.
+ */
+export type WfpProvisioningStepReporter = (
+  step: string,
+  outcome: "started" | "succeeded" | "failed",
+  detail?: Record<string, unknown>,
+) => Promise<void>;
+
 export interface WfpTenantProvisioningHook {
-  onProvision(tenantId: string): Promise<void>;
+  onProvision(
+    tenantId: string,
+    report?: WfpProvisioningStepReporter,
+  ): Promise<void>;
   onDeprovision(tenantId: string): Promise<void>;
   /**
    * Re-run provisioning for an already-existing WFP tenant to pull it onto the
@@ -95,12 +111,13 @@ export interface WfpTenantProvisioningHook {
    * Throws if the tenant doesn't exist or isn't WFP-provisioned — callers
    * (e.g. a management-API redeploy endpoint) surface that as a 4xx.
    */
-  onUpgrade(tenantId: string): Promise<void>;
+  onUpgrade(
+    tenantId: string,
+    report?: WfpProvisioningStepReporter,
+  ): Promise<void>;
 }
 
-function defaultShouldProvision(tenant: {
-  deployment_type?: string;
-}): boolean {
+function defaultShouldProvision(tenant: { deployment_type?: string }): boolean {
   return tenant.deployment_type === "wfp";
 }
 
@@ -161,13 +178,38 @@ export function createWfpTenantProvisioningHook(
    * Failure at any step marks the tenant `failed` (persisting resource ids when
    * we have them) and re-throws.
    */
-  async function provisionAndPersist(tenantId: string): Promise<void> {
+  async function provisionAndPersist(
+    tenantId: string,
+    report?: WfpProvisioningStepReporter,
+  ): Promise<void> {
+    // Reporting is observability only — a throwing reporter must never
+    // fail (or retry) an otherwise healthy provision.
+    const reportStep: WfpProvisioningStepReporter = async (
+      step,
+      outcome,
+      detail,
+    ) => {
+      if (!report) return;
+      try {
+        await report(step, outcome, detail);
+      } catch (reportErr) {
+        logger?.warn(
+          `Failed to report provisioning step "${step}" for tenant ${tenantId}:`,
+          reportErr,
+        );
+      }
+    };
+
+    await reportStep("provision-resources", "started");
     let result;
     try {
       result = await provisioner.onProvision(tenantId);
     } catch (err) {
       // No resources (or only partial) — nothing to persist beyond the
       // failure marker.
+      await reportStep("provision-resources", "failed", {
+        message: err instanceof Error ? err.message : String(err),
+      });
       await markFailed(tenantId, err);
       throw err;
     }
@@ -181,6 +223,7 @@ export function createWfpTenantProvisioningHook(
       worker_version: result.workerVersion,
       database_version: result.databaseVersion,
     };
+    await reportStep("provision-resources", "succeeded", { ...resourceIds });
 
     try {
       // Seed BEFORE marking ready so we never report "ready" over an empty
@@ -188,12 +231,22 @@ export function createWfpTenantProvisioningHook(
       // `continueOnError`, so a resolved result can still carry per-entity
       // errors — treat those as a provisioning failure too.
       if (syncDefaults) {
-        const seedResult = await syncDefaults(tenantId);
-        const seedErrors = collectSyncDefaultsErrors(seedResult);
-        if (seedErrors.length > 0) {
-          throw new Error(
-            `sync-defaults seed reported ${seedErrors.length} error(s): ${seedErrors.join("; ")}`,
-          );
+        await reportStep("seed-defaults", "started");
+        try {
+          const seedResult = await syncDefaults(tenantId);
+          const seedErrors = collectSyncDefaultsErrors(seedResult);
+          if (seedErrors.length > 0) {
+            throw new Error(
+              `sync-defaults seed reported ${seedErrors.length} error(s): ${seedErrors.join("; ")}`,
+            );
+          }
+          await reportStep("seed-defaults", "succeeded");
+        } catch (seedErr) {
+          await reportStep("seed-defaults", "failed", {
+            message:
+              seedErr instanceof Error ? seedErr.message : String(seedErr),
+          });
+          throw seedErr;
         }
       }
 
@@ -223,15 +276,21 @@ export function createWfpTenantProvisioningHook(
   }
 
   return {
-    async onProvision(tenantId: string): Promise<void> {
+    async onProvision(
+      tenantId: string,
+      report?: WfpProvisioningStepReporter,
+    ): Promise<void> {
       const tenant = await tenants.get(tenantId);
       if (!tenant) return; // No tenant row — probably mid-rollback. Nothing to do.
       if (!shouldProvision(tenant)) return; // Shared deployment, skip.
 
-      await provisionAndPersist(tenantId);
+      await provisionAndPersist(tenantId, report);
     },
 
-    async onUpgrade(tenantId: string): Promise<void> {
+    async onUpgrade(
+      tenantId: string,
+      report?: WfpProvisioningStepReporter,
+    ): Promise<void> {
       const tenant = await tenants.get(tenantId);
       if (!tenant) {
         throw new Error(`Cannot upgrade tenant "${tenantId}": not found.`);
@@ -262,7 +321,7 @@ export function createWfpTenantProvisioningHook(
         );
       }
 
-      await provisionAndPersist(tenantId);
+      await provisionAndPersist(tenantId, report);
     },
 
     async onDeprovision(tenantId: string): Promise<void> {

--- a/packages/cloudflare/src/wfp-provisioner/tenant-hook.ts
+++ b/packages/cloudflare/src/wfp-provisioner/tenant-hook.ts
@@ -146,6 +146,15 @@ function collectSyncDefaultsErrors(result: unknown): string[] {
   return errors;
 }
 
+// Cap persisted error text (tenant rows and reported step details) so a
+// verbose upstream failure can't bloat control-plane records.
+const MAX_ERROR_LENGTH = 2048;
+
+function errorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.slice(0, MAX_ERROR_LENGTH);
+}
+
 export function createWfpTenantProvisioningHook(
   options: WfpTenantProvisioningHookOptions,
 ): WfpTenantProvisioningHook {
@@ -154,11 +163,10 @@ export function createWfpTenantProvisioningHook(
   const logger = options.logger;
 
   async function markFailed(tenantId: string, error: unknown): Promise<void> {
-    const message = error instanceof Error ? error.message : String(error);
     try {
       await tenants.update(tenantId, {
         provisioning_state: "failed",
-        provisioning_error: message.slice(0, 2048),
+        provisioning_error: errorMessage(error),
         provisioning_state_changed_at: new Date().toISOString(),
       });
     } catch (writeErr) {
@@ -208,7 +216,7 @@ export function createWfpTenantProvisioningHook(
       // No resources (or only partial) — nothing to persist beyond the
       // failure marker.
       await reportStep("provision-resources", "failed", {
-        message: err instanceof Error ? err.message : String(err),
+        message: errorMessage(err),
       });
       await markFailed(tenantId, err);
       throw err;
@@ -243,8 +251,7 @@ export function createWfpTenantProvisioningHook(
           await reportStep("seed-defaults", "succeeded");
         } catch (seedErr) {
           await reportStep("seed-defaults", "failed", {
-            message:
-              seedErr instanceof Error ? seedErr.message : String(seedErr),
+            message: errorMessage(seedErr),
           });
           throw seedErr;
         }
@@ -257,12 +264,11 @@ export function createWfpTenantProvisioningHook(
         provisioning_state_changed_at: new Date().toISOString(),
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
       try {
         await tenants.update(tenantId, {
           ...resourceIds,
           provisioning_state: "failed",
-          provisioning_error: message.slice(0, 2048),
+          provisioning_error: errorMessage(err),
           provisioning_state_changed_at: new Date().toISOString(),
         });
       } catch (writeErr) {

--- a/packages/cloudflare/test/wfp-provisioner.spec.ts
+++ b/packages/cloudflare/test/wfp-provisioner.spec.ts
@@ -15,10 +15,7 @@ import {
   createCloudflareWfpD1Provisioner,
   createWfpTenantProvisioningHook,
 } from "../src";
-import type {
-  CloudflareWfpD1Provisioner,
-  ProvisionResult,
-} from "../src";
+import type { CloudflareWfpD1Provisioner, ProvisionResult } from "../src";
 import type { Tenant, TenantsDataAdapter } from "@authhero/adapter-interfaces";
 
 const ACCOUNT_ID = "acc_test";
@@ -71,17 +68,20 @@ async function captureBody(req: Request): Promise<unknown> {
 describe("CloudflareApiClient", () => {
   it("createD1Database POSTs the name and returns the uuid", async () => {
     server.use(
-      http.post(path(`/accounts/${ACCOUNT_ID}/d1/database`), async ({ request }) => {
-        captured.push({
-          method: "POST",
-          path: "/d1/database",
-          body: await captureBody(request),
-        });
-        return HttpResponse.json({
-          result: { uuid: "db_uuid_1", name: "tenant-kvartal" },
-          success: true,
-        });
-      }),
+      http.post(
+        path(`/accounts/${ACCOUNT_ID}/d1/database`),
+        async ({ request }) => {
+          captured.push({
+            method: "POST",
+            path: "/d1/database",
+            body: await captureBody(request),
+          });
+          return HttpResponse.json({
+            result: { uuid: "db_uuid_1", name: "tenant-kvartal" },
+            success: true,
+          });
+        },
+      ),
     );
     const client = new CloudflareApiClient({
       accountId: ACCOUNT_ID,
@@ -227,7 +227,10 @@ describe("CloudflareApiClient", () => {
     server.use(
       http.post(path(`/accounts/${ACCOUNT_ID}/d1/database`), () =>
         HttpResponse.json(
-          { errors: [{ code: 7501, message: "Name already taken" }], success: false },
+          {
+            errors: [{ code: 7501, message: "Name already taken" }],
+            success: false,
+          },
           { status: 400 },
         ),
       ),
@@ -258,17 +261,20 @@ describe("createCloudflareWfpD1Provisioner", () => {
       http.get(path(`/accounts/${ACCOUNT_ID}/d1/database`), () =>
         HttpResponse.json({ result: [], success: true }),
       ),
-      http.post(path(`/accounts/${ACCOUNT_ID}/d1/database`), async ({ request }) => {
-        captured.push({
-          method: "POST",
-          path: "/d1/database",
-          body: await captureBody(request),
-        });
-        return HttpResponse.json({
-          result: { uuid: "db_kvartal", name: "tenant-kvartal" },
-          success: true,
-        });
-      }),
+      http.post(
+        path(`/accounts/${ACCOUNT_ID}/d1/database`),
+        async ({ request }) => {
+          captured.push({
+            method: "POST",
+            path: "/d1/database",
+            body: await captureBody(request),
+          });
+          return HttpResponse.json({
+            result: { uuid: "db_kvartal", name: "tenant-kvartal" },
+            success: true,
+          });
+        },
+      ),
       http.post(
         path(`/accounts/${ACCOUNT_ID}/d1/database/db_kvartal/query`),
         async ({ request }) => {
@@ -319,7 +325,8 @@ describe("createCloudflareWfpD1Provisioner", () => {
       apiToken: "token",
       dispatchNamespace: NAMESPACE,
       controlPlaneBaseUrl: "https://auth.example.com",
-      tenantWorkerScript: "export default { fetch() { return new Response('hi'); } };",
+      tenantWorkerScript:
+        "export default { fetch() { return new Response('hi'); } };",
       migrations: [
         { name: "0000_init.sql", sql: "CREATE TABLE users (id TEXT);" },
         { name: "0001_add_keys.sql", sql: "CREATE TABLE keys (kid TEXT);" },
@@ -357,7 +364,9 @@ describe("createCloudflareWfpD1Provisioner", () => {
     const metadata = JSON.parse(
       (upload!.body as Record<string, string>)["metadata"],
     );
-    const dbBinding = metadata.bindings.find((b: { name: string }) => b.name === "AUTH_DB");
+    const dbBinding = metadata.bindings.find(
+      (b: { name: string }) => b.name === "AUTH_DB",
+    );
     const cpBinding = metadata.bindings.find(
       (b: { name: string }) => b.name === "CONTROL_PLANE_BASE_URL",
     );
@@ -389,7 +398,11 @@ describe("createCloudflareWfpD1Provisioner", () => {
       migrations: [{ name: "0.sql", sql: "SELECT 1;" }],
       secrets: async () => ({ X: "y" }),
       extraBindings: [
-        { type: "service", name: "JWKS_SERVICE", service: "control-plane-auth" },
+        {
+          type: "service",
+          name: "JWKS_SERVICE",
+          service: "control-plane-auth",
+        },
         { type: "plain_text", name: "REGION", text: "eu" },
       ],
     });
@@ -409,7 +422,9 @@ describe("createCloudflareWfpD1Provisioner", () => {
       "REGION",
     ]);
     expect(
-      metadata.bindings.find((b: { name: string }) => b.name === "JWKS_SERVICE"),
+      metadata.bindings.find(
+        (b: { name: string }) => b.name === "JWKS_SERVICE",
+      ),
     ).toEqual({
       type: "service",
       name: "JWKS_SERVICE",
@@ -440,7 +455,10 @@ describe("createCloudflareWfpD1Provisioner", () => {
             path: "/d1/exec",
             body: await captureBody(request),
           });
-          return HttpResponse.json({ result: [{ success: true }], success: true });
+          return HttpResponse.json({
+            result: [{ success: true }],
+            success: true,
+          });
         },
       ),
       http.put(
@@ -448,7 +466,11 @@ describe("createCloudflareWfpD1Provisioner", () => {
           `/accounts/${ACCOUNT_ID}/workers/dispatch/namespaces/${NAMESPACE}/scripts/kvartal`,
         ),
         async () => {
-          captured.push({ method: "PUT", path: "/scripts/kvartal", body: null });
+          captured.push({
+            method: "PUT",
+            path: "/scripts/kvartal",
+            body: null,
+          });
           return HttpResponse.json({ result: {}, success: true });
         },
       ),
@@ -494,7 +516,11 @@ describe("createCloudflareWfpD1Provisioner", () => {
           `/accounts/${ACCOUNT_ID}/workers/dispatch/namespaces/${NAMESPACE}/scripts/kvartal`,
         ),
         () => {
-          captured.push({ method: "DELETE", path: "/scripts/kvartal", body: null });
+          captured.push({
+            method: "DELETE",
+            path: "/scripts/kvartal",
+            body: null,
+          });
           return HttpResponse.json({ result: null, success: true });
         },
       ),
@@ -507,7 +533,11 @@ describe("createCloudflareWfpD1Provisioner", () => {
       http.delete(
         path(`/accounts/${ACCOUNT_ID}/d1/database/db_kvartal`),
         () => {
-          captured.push({ method: "DELETE", path: "/d1/database/db_kvartal", body: null });
+          captured.push({
+            method: "DELETE",
+            path: "/d1/database/db_kvartal",
+            body: null,
+          });
           return HttpResponse.json({ result: null, success: true });
         },
       ),
@@ -578,14 +608,17 @@ describe("createCloudflareWfpD1Provisioner", () => {
           success: true,
         }),
       ),
-      http.delete(path(`/accounts/${ACCOUNT_ID}/d1/database/db_kvartal`), () => {
-        captured.push({
-          method: "DELETE",
-          path: "/d1/database/db_kvartal",
-          body: null,
-        });
-        return HttpResponse.json({ result: null, success: true });
-      }),
+      http.delete(
+        path(`/accounts/${ACCOUNT_ID}/d1/database/db_kvartal`),
+        () => {
+          captured.push({
+            method: "DELETE",
+            path: "/d1/database/db_kvartal",
+            body: null,
+          });
+          return HttpResponse.json({ result: null, success: true });
+        },
+      ),
     );
     const provisioner = createCloudflareWfpD1Provisioner({
       accountId: ACCOUNT_ID,
@@ -625,16 +658,19 @@ describe("createCloudflareWfpD1Provisioner", () => {
           });
         },
       ),
-      http.post(
-        path(`/accounts/${ACCOUNT_ID}/d1/database/db_x/query`),
-        () => HttpResponse.json({ result: [{ success: true }], success: true }),
+      http.post(path(`/accounts/${ACCOUNT_ID}/d1/database/db_x/query`), () =>
+        HttpResponse.json({ result: [{ success: true }], success: true }),
       ),
       http.put(
         path(
           `/accounts/${ACCOUNT_ID}/workers/dispatch/namespaces/${NAMESPACE}/scripts/tenant-kvartal-auth`,
         ),
         () => {
-          captured.push({ method: "PUT", path: "/scripts/tenant-kvartal-auth", body: null });
+          captured.push({
+            method: "PUT",
+            path: "/scripts/tenant-kvartal-auth",
+            body: null,
+          });
           return HttpResponse.json({ result: {}, success: true });
         },
       ),
@@ -660,7 +696,9 @@ describe("createCloudflareWfpD1Provisioner", () => {
     expect((captured[0].body as { name: string }).name).toBe(
       "authhero-tenant-kvartal",
     );
-    expect(captured.find((c) => c.path === "/scripts/tenant-kvartal-auth")).toBeDefined();
+    expect(
+      captured.find((c) => c.path === "/scripts/tenant-kvartal-auth"),
+    ).toBeDefined();
   });
 
   it("onProvision returns the resource ids the caller needs to persist", async () => {
@@ -832,7 +870,9 @@ describe("createWfpTenantProvisioningHook", () => {
     const syncDefaults = vi.fn(async (id: string) => {
       // At seed time the resources exist but the tenant isn't ready yet.
       order.push(`sync:${id}`);
-      expect(tenants.store.get("kvartal")?.provisioning_state).not.toBe("ready");
+      expect(tenants.store.get("kvartal")?.provisioning_state).not.toBe(
+        "ready",
+      );
     });
     const hook = createWfpTenantProvisioningHook({
       provisioner,
@@ -973,7 +1013,9 @@ describe("createWfpTenantProvisioningHook", () => {
       tenants,
       logger: { warn },
     });
-    await expect(hook.onProvision("kvartal")).rejects.toThrow(/upstream failed/);
+    await expect(hook.onProvision("kvartal")).rejects.toThrow(
+      /upstream failed/,
+    );
     expect(warn).toHaveBeenCalledOnce();
     expect(warn.mock.calls[0][0]).toMatch(/Failed to write provisioning_state/);
   });
@@ -1084,5 +1126,112 @@ describe("createWfpTenantProvisioningHook", () => {
       /not a WFP-provisioned tenant/,
     );
     expect(provisioner.onProvisionCalls).toEqual([]);
+  });
+});
+
+// ─── provisioning step reporter (issue #1026) ───────────────────────────
+
+describe("createWfpTenantProvisioningHook step reporter", () => {
+  function reporterFakes(withSeed: boolean) {
+    const provisioner: CloudflareWfpD1Provisioner & {
+      nextProvisionError?: Error;
+    } = {
+      nextProvisionError: undefined,
+      async onProvision(): Promise<ProvisionResult> {
+        if (provisioner.nextProvisionError)
+          throw provisioner.nextProvisionError;
+        return {
+          d1DatabaseId: "db_x",
+          scriptName: "kvartal",
+          d1Name: "tenant-kvartal",
+        };
+      },
+      async onDeprovision(): Promise<void> {},
+    };
+    const store = new Map<string, Partial<Tenant>>([
+      ["kvartal", { id: "kvartal", deployment_type: "wfp" }],
+    ]);
+    const tenants: TenantsDataAdapter = {
+      async create(): Promise<Tenant> {
+        throw new Error("not used");
+      },
+      async get(id: string): Promise<Tenant | null> {
+        return (store.get(id) as Tenant | undefined) ?? null;
+      },
+      async list() {
+        return { tenants: Array.from(store.values()) as Tenant[] };
+      },
+      async update(id: string, patch: Partial<Tenant>): Promise<void> {
+        const cur = store.get(id);
+        if (cur) store.set(id, { ...cur, ...patch });
+      },
+      async remove(id: string): Promise<boolean> {
+        return store.delete(id);
+      },
+    };
+    const syncDefaults = withSeed ? async () => ({}) : undefined;
+    return { provisioner, tenants, store, syncDefaults };
+  }
+
+  it("reports provision-resources and seed-defaults boundaries", async () => {
+    const { provisioner, tenants, syncDefaults } = reporterFakes(true);
+    const hook = createWfpTenantProvisioningHook({
+      provisioner,
+      tenants,
+      syncDefaults,
+    });
+
+    const reported: string[] = [];
+    await hook.onProvision("kvartal", async (step, outcome, detail) => {
+      reported.push(`${step}:${outcome}`);
+      if (step === "provision-resources" && outcome === "succeeded") {
+        expect(detail).toMatchObject({ d1_database_id: "db_x" });
+      }
+    });
+
+    expect(reported).toEqual([
+      "provision-resources:started",
+      "provision-resources:succeeded",
+      "seed-defaults:started",
+      "seed-defaults:succeeded",
+    ]);
+  });
+
+  it("reports a failed provision step and still marks the tenant failed", async () => {
+    const { provisioner, tenants, store } = reporterFakes(false);
+    provisioner.nextProvisionError = new Error("cf exploded");
+    const hook = createWfpTenantProvisioningHook({ provisioner, tenants });
+
+    const reported: string[] = [];
+    await expect(
+      hook.onProvision("kvartal", async (step, outcome) => {
+        reported.push(`${step}:${outcome}`);
+      }),
+    ).rejects.toThrow("cf exploded");
+
+    expect(reported).toEqual([
+      "provision-resources:started",
+      "provision-resources:failed",
+    ]);
+    expect(store.get("kvartal")).toMatchObject({
+      provisioning_state: "failed",
+    });
+  });
+
+  it("never lets a throwing reporter fail the provision", async () => {
+    const { provisioner, tenants, store, syncDefaults } = reporterFakes(true);
+    const hook = createWfpTenantProvisioningHook({
+      provisioner,
+      tenants,
+      syncDefaults,
+    });
+
+    await hook.onProvision("kvartal", async () => {
+      throw new Error("reporter down");
+    });
+
+    expect(store.get("kvartal")).toMatchObject({
+      provisioning_state: "ready",
+    });
   });
 });

--- a/packages/cloudflare/test/wfp-provisioner.spec.ts
+++ b/packages/cloudflare/test/wfp-provisioner.spec.ts
@@ -1218,6 +1218,61 @@ describe("createWfpTenantProvisioningHook step reporter", () => {
     });
   });
 
+  it("reports the same step boundaries during an upgrade", async () => {
+    const { provisioner, tenants, store, syncDefaults } = reporterFakes(true);
+    const hook = createWfpTenantProvisioningHook({
+      provisioner,
+      tenants,
+      syncDefaults,
+    });
+
+    const reported: string[] = [];
+    await hook.onUpgrade("kvartal", async (step, outcome) => {
+      reported.push(`${step}:${outcome}`);
+    });
+
+    expect(reported).toEqual([
+      "provision-resources:started",
+      "provision-resources:succeeded",
+      "seed-defaults:started",
+      "seed-defaults:succeeded",
+    ]);
+    expect(store.get("kvartal")).toMatchObject({
+      provisioning_state: "ready",
+    });
+  });
+
+  it("reports seed-defaults as failed when the seed collects errors", async () => {
+    const { provisioner, tenants, store } = reporterFakes(false);
+    const hook = createWfpTenantProvisioningHook({
+      provisioner,
+      tenants,
+      // Resolves cleanly but carries per-entity errors (continueOnError).
+      syncDefaults: async () => ({
+        connections: { errors: ["insert failed"] },
+      }),
+    });
+
+    const reported: string[] = [];
+    await expect(
+      hook.onProvision("kvartal", async (step, outcome) => {
+        reported.push(`${step}:${outcome}`);
+      }),
+    ).rejects.toThrow(/sync-defaults seed reported 1 error/);
+
+    expect(reported).toEqual([
+      "provision-resources:started",
+      "provision-resources:succeeded",
+      "seed-defaults:started",
+      "seed-defaults:failed",
+    ]);
+    expect(store.get("kvartal")).toMatchObject({
+      provisioning_state: "failed",
+      // Resource ids survive the failure so a re-provision can find them.
+      d1_database_id: "db_x",
+    });
+  });
+
   it("never lets a throwing reporter fail the provision", async () => {
     const { provisioner, tenants, store, syncDefaults } = reporterFakes(true);
     const hook = createWfpTenantProvisioningHook({

--- a/packages/create-authhero/test/generated-code.test.ts
+++ b/packages/create-authhero/test/generated-code.test.ts
@@ -139,11 +139,13 @@ async function scanDts(
   result: PackageExports,
   visited: Set<string>,
 ): Promise<void> {
-  const resolved = fs.existsSync(filePath)
-    ? filePath
-    : [`${filePath}.d.ts`, path.join(filePath, "index.d.ts")].find((p) =>
-        fs.existsSync(p),
-      );
+  // A bare specifier like "./operations" may exist as a directory; only a
+  // regular file can be read, so fall through to .d.ts / index.d.ts variants.
+  const resolved = [
+    filePath,
+    `${filePath}.d.ts`,
+    path.join(filePath, "index.d.ts"),
+  ].find((p) => fs.existsSync(p) && fs.statSync(p).isFile());
   if (!resolved || visited.has(resolved)) return;
   visited.add(resolved);
 

--- a/packages/multi-tenancy/src/hooks/provisioning.ts
+++ b/packages/multi-tenancy/src/hooks/provisioning.ts
@@ -18,6 +18,7 @@ import {
   TenantEntityHooks,
   TenantHookContext,
 } from "../types";
+import { runRecordedTenantOperation } from "../operations";
 
 /**
  * Creates hooks for tenant provisioning and deprovisioning.
@@ -58,9 +59,21 @@ export function createProvisioningHooks(
         await createOrganizationForTenant(ctx, tenant, accessControl);
       }
 
-      // 2. Provision database if isolation is enabled
+      // 2. Provision database if isolation is enabled. When the control
+      // plane carries the tenant-operations adapters (issue #1026), the
+      // provision run is recorded as an operation with step events;
+      // otherwise it runs exactly as before.
       if (databaseIsolation?.onProvision) {
-        await databaseIsolation.onProvision(tenant.id);
+        const onProvision = databaseIsolation.onProvision;
+        await runRecordedTenantOperation(
+          ctx.adapters,
+          {
+            kind: "provision",
+            tenant_id: tenant.id,
+            initiated_by: ctx.ctx?.var.user?.sub,
+          },
+          (report) => onProvision(tenant.id, report),
+        );
       }
     },
 

--- a/packages/multi-tenancy/src/index.ts
+++ b/packages/multi-tenancy/src/index.ts
@@ -49,6 +49,12 @@ export type {
   DefaultsPayloadEntities,
 } from "./rollout";
 
+// Durable tenant lifecycle operations (issue #1026) — record provisions as
+// operations with step events, run operations inline, and (phase 2) via
+// Cloudflare Workflows. The control-plane DB is the source of truth; the
+// executor engine is swappable.
+export * from "./operations";
+
 // Public API - functions and types consumers actually need
 export { createSyncHooks } from "./hooks/sync";
 export type { EntitySyncConfig, SyncHooksResult } from "./hooks/sync";

--- a/packages/multi-tenancy/src/init.ts
+++ b/packages/multi-tenancy/src/init.ts
@@ -8,6 +8,7 @@ import {
 } from "authhero";
 import { createSyncHooks, EntitySyncConfig } from "./hooks/sync";
 import { createProvisioningHooks } from "./hooks";
+import { createInlineExecutor, enqueueTenantOperation } from "./operations";
 import { createTenantsOpenAPIRouter } from "./routes";
 import {
   createProtectSyncedMiddleware,
@@ -253,6 +254,48 @@ export function initMultiTenant(config: MultiTenantConfig): MultiTenantResult {
     };
   }
 
+  // Wire a default inline executor for tenant operations (issue #1026)
+  // when the control plane carries the operations adapters and an upgrade
+  // handler is configured. Downstream deployments can pass their own
+  // `tenantOperationExecutor` (e.g. Cloudflare Workflows) to override.
+  let tenantOperationExecutor = restConfig.tenantOperationExecutor;
+  if (
+    !tenantOperationExecutor &&
+    rawDataAdapter.tenantOperations &&
+    rawDataAdapter.tenantOperationEvents &&
+    restConfig.tenantUpgrade
+  ) {
+    const stores = {
+      tenantOperations: rawDataAdapter.tenantOperations,
+      tenantOperationEvents: rawDataAdapter.tenantOperationEvents,
+    };
+    const tenantUpgrade = restConfig.tenantUpgrade;
+    const inlineExecutor = createInlineExecutor({
+      stores,
+      definitions: {
+        upgrade: (operation) => [
+          {
+            name: "upgrade",
+            async run() {
+              if (!operation.tenant_id) {
+                throw new Error("upgrade operations require a tenant_id");
+              }
+              await tenantUpgrade(operation.tenant_id);
+            },
+          },
+        ],
+      },
+    });
+    tenantOperationExecutor = {
+      engine: inlineExecutor.engine,
+      enqueue: (params) =>
+        enqueueTenantOperation(stores, inlineExecutor, {
+          ...params,
+          tenant_id: params.tenant_id,
+        }),
+    };
+  }
+
   // Determine sync settings
   const syncEnabled = sync !== false;
   const syncConfig = syncEnabled
@@ -358,6 +401,7 @@ export function initMultiTenant(config: MultiTenantConfig): MultiTenantResult {
     dataAdapter,
     managementDataAdapter,
     ...restConfig,
+    tenantOperationExecutor,
     entityHooks,
     managementApiExtensions: [
       ...managementApiExtensions,

--- a/packages/multi-tenancy/src/operations/enqueue.ts
+++ b/packages/multi-tenancy/src/operations/enqueue.ts
@@ -8,6 +8,31 @@ import { buildEngineInstanceId } from "./instance-id";
 import { createOperationRecorder, isTerminalStatus } from "./recorder";
 
 /**
+ * Persist a new operation row and stamp its deterministic engine instance
+ * id. Shared by the executor enqueue path and the inline recording wrapper
+ * (`runRecordedTenantOperation`) so the row-first setup can't drift.
+ */
+export async function createOperationRow(
+  stores: TenantOperationStores,
+  params: EnqueueTenantOperationParams,
+  engine: TenantOperationExecutor["engine"],
+): Promise<TenantOperation> {
+  const created = await stores.tenantOperations.create({
+    tenant_id: params.tenant_id,
+    rollout_id: params.rollout_id,
+    kind: params.kind,
+    engine,
+    initiated_by: params.initiated_by,
+    target_worker_version: params.target_worker_version,
+    target_database_version: params.target_database_version,
+  });
+
+  const engine_instance_id = buildEngineInstanceId(created);
+  await stores.tenantOperations.update(created.id, { engine_instance_id });
+  return { ...created, engine_instance_id };
+}
+
+/**
  * Row-first enqueue: persist the operation as `pending`, write the
  * deterministic engine instance id, then hand it to the executor. If
  * `start` throws, the row is marked failed (unless the executor already
@@ -21,19 +46,7 @@ export async function enqueueTenantOperation(
 ): Promise<TenantOperation> {
   const recorder = createOperationRecorder(stores);
 
-  const created = await stores.tenantOperations.create({
-    tenant_id: params.tenant_id,
-    rollout_id: params.rollout_id,
-    kind: params.kind,
-    engine: executor.engine,
-    initiated_by: params.initiated_by,
-    target_worker_version: params.target_worker_version,
-    target_database_version: params.target_database_version,
-  });
-
-  const engine_instance_id = buildEngineInstanceId(created);
-  await stores.tenantOperations.update(created.id, { engine_instance_id });
-  const operation: TenantOperation = { ...created, engine_instance_id };
+  const operation = await createOperationRow(stores, params, executor.engine);
 
   try {
     await executor.start(operation);

--- a/packages/multi-tenancy/src/operations/enqueue.ts
+++ b/packages/multi-tenancy/src/operations/enqueue.ts
@@ -1,0 +1,49 @@
+import { TenantOperation } from "authhero";
+import {
+  EnqueueTenantOperationParams,
+  TenantOperationExecutor,
+  TenantOperationStores,
+} from "./types";
+import { buildEngineInstanceId } from "./instance-id";
+import { createOperationRecorder, isTerminalStatus } from "./recorder";
+
+/**
+ * Row-first enqueue: persist the operation as `pending`, write the
+ * deterministic engine instance id, then hand it to the executor. If
+ * `start` throws, the row is marked failed (unless the executor already
+ * finalized it) and the error is rethrown so callers keep their existing
+ * failure semantics.
+ */
+export async function enqueueTenantOperation(
+  stores: TenantOperationStores,
+  executor: TenantOperationExecutor,
+  params: EnqueueTenantOperationParams,
+): Promise<TenantOperation> {
+  const recorder = createOperationRecorder(stores);
+
+  const created = await stores.tenantOperations.create({
+    tenant_id: params.tenant_id,
+    rollout_id: params.rollout_id,
+    kind: params.kind,
+    engine: executor.engine,
+    initiated_by: params.initiated_by,
+    target_worker_version: params.target_worker_version,
+    target_database_version: params.target_database_version,
+  });
+
+  const engine_instance_id = buildEngineInstanceId(created);
+  await stores.tenantOperations.update(created.id, { engine_instance_id });
+  const operation: TenantOperation = { ...created, engine_instance_id };
+
+  try {
+    await executor.start(operation);
+  } catch (error) {
+    const current = await stores.tenantOperations.get(operation.id);
+    if (current && !isTerminalStatus(current.status)) {
+      await recorder.markFailed(operation.id, error);
+    }
+    throw error;
+  }
+
+  return (await stores.tenantOperations.get(operation.id)) ?? operation;
+}

--- a/packages/multi-tenancy/src/operations/index.ts
+++ b/packages/multi-tenancy/src/operations/index.ts
@@ -1,0 +1,24 @@
+export type {
+  StepConfig,
+  StepRunner,
+  StepReporter,
+  TenantOperationStores,
+  TenantOperationExecutor,
+  EnqueueTenantOperationParams,
+} from "./types";
+export { buildEngineInstanceId } from "./instance-id";
+export {
+  createOperationRecorder,
+  errorToMessage,
+  isTerminalStatus,
+} from "./recorder";
+export type { OperationRecorder } from "./recorder";
+export { createInlineExecutor, inlineStepRunner } from "./inline-executor";
+export type {
+  InlineExecutorConfig,
+  TenantOperationDefinitions,
+  TenantOperationStep,
+  TenantOperationStepContext,
+} from "./inline-executor";
+export { enqueueTenantOperation } from "./enqueue";
+export { runRecordedTenantOperation } from "./record-provision";

--- a/packages/multi-tenancy/src/operations/inline-executor.ts
+++ b/packages/multi-tenancy/src/operations/inline-executor.ts
@@ -4,7 +4,7 @@ import {
   TenantOperationExecutor,
   TenantOperationStores,
 } from "./types";
-import { createOperationRecorder } from "./recorder";
+import { createOperationRecorder, errorToMessage } from "./recorder";
 
 export interface TenantOperationStepContext {
   operation: TenantOperation;
@@ -108,7 +108,7 @@ export function createInlineExecutor(
           await recorder.appendEvent(operation.id, {
             step: step.name,
             outcome: "failed",
-            detail: { message: String(error) },
+            detail: { message: errorToMessage(error) },
           });
           await recorder.markFailed(operation.id, error);
           throw error;

--- a/packages/multi-tenancy/src/operations/inline-executor.ts
+++ b/packages/multi-tenancy/src/operations/inline-executor.ts
@@ -1,0 +1,121 @@
+import { TenantOperation, TenantOperationKind } from "authhero";
+import {
+  StepRunner,
+  TenantOperationExecutor,
+  TenantOperationStores,
+} from "./types";
+import { createOperationRecorder } from "./recorder";
+
+export interface TenantOperationStepContext {
+  operation: TenantOperation;
+  step: StepRunner;
+}
+
+/**
+ * A named, idempotent unit of work. The resolved value (when a plain
+ * object) is stored as the succeeded-event detail.
+ */
+export interface TenantOperationStep {
+  name: string;
+  run(ctx: TenantOperationStepContext): Promise<Record<string, unknown> | void>;
+}
+
+/**
+ * Maps an operation kind to its ordered steps. Factories receive the
+ * operation row so steps can read the target tenant / versions — but they
+ * must resolve all heavy dependencies from their own closure, never from
+ * serialized state.
+ */
+export type TenantOperationDefinitions = Partial<
+  Record<
+    TenantOperationKind,
+    (operation: TenantOperation) => TenantOperationStep[]
+  >
+>;
+
+/**
+ * Trivial StepRunner: no retries, no durability — runs the function
+ * immediately. Used by the inline executor so operation definitions are
+ * written against the same `StepRunner` seam the Workflows engine
+ * satisfies in phase 2.
+ */
+export const inlineStepRunner: StepRunner = {
+  async do<T>(
+    _name: string,
+    configOrFn: unknown,
+    maybeFn?: () => Promise<T>,
+  ): Promise<T> {
+    const fn =
+      typeof configOrFn === "function"
+        ? (configOrFn as () => Promise<T>)
+        : maybeFn;
+    if (!fn) {
+      throw new Error("StepRunner.do called without a function");
+    }
+    return fn();
+  },
+};
+
+export interface InlineExecutorConfig {
+  stores: TenantOperationStores;
+  definitions: TenantOperationDefinitions;
+}
+
+/**
+ * Runs operations synchronously in the calling process, writing the same
+ * operation/event rows the durable executor writes. Used by tests and
+ * deployments without Cloudflare Workflows; `enqueueTenantOperation`
+ * resolves only after the run reaches a terminal status.
+ */
+export function createInlineExecutor(
+  config: InlineExecutorConfig,
+): TenantOperationExecutor {
+  const recorder = createOperationRecorder(config.stores);
+
+  return {
+    engine: "inline",
+
+    async start(operation: TenantOperation): Promise<void> {
+      const definition = config.definitions[operation.kind];
+      if (!definition) {
+        const error = new Error(
+          `No inline operation definition for kind "${operation.kind}"`,
+        );
+        await recorder.markFailed(operation.id, error);
+        throw error;
+      }
+
+      const steps = definition(operation);
+      await recorder.markRunning(operation.id, steps[0]?.name);
+
+      for (const step of steps) {
+        await recorder.setCurrentStep(operation.id, step.name);
+        await recorder.appendEvent(operation.id, {
+          step: step.name,
+          outcome: "started",
+        });
+        try {
+          const detail = await step.run({
+            operation,
+            step: inlineStepRunner,
+          });
+          await recorder.appendEvent(operation.id, {
+            step: step.name,
+            outcome: "succeeded",
+            detail: detail ?? undefined,
+          });
+        } catch (error) {
+          await recorder.appendEvent(operation.id, {
+            step: step.name,
+            outcome: "failed",
+            detail: { message: String(error) },
+          });
+          await recorder.markFailed(operation.id, error);
+          throw error;
+        }
+      }
+
+      await recorder.markSucceeded(operation.id);
+    },
+  };
+}

--- a/packages/multi-tenancy/src/operations/instance-id.ts
+++ b/packages/multi-tenancy/src/operations/instance-id.ts
@@ -1,0 +1,31 @@
+/**
+ * Deterministic engine instance id for a tenant operation:
+ * `op-{kind}-{tenantSegment}-{operationId}`.
+ *
+ * Uses dashes (Cloudflare Workflows instance ids only allow
+ * `[a-zA-Z0-9_-]`) and stays ≤ 64 characters by truncating the tenant
+ * segment — never the operation id, which alone guarantees uniqueness.
+ * Deterministic so an engine handle can be re-derived from the operation
+ * row (e.g. by the reconciler) without any lookup.
+ */
+const MAX_INSTANCE_ID_LENGTH = 64;
+
+function sanitizeSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+export function buildEngineInstanceId(operation: {
+  kind: string;
+  tenant_id: string | null;
+  id: string;
+}): string {
+  const kind = sanitizeSegment(operation.kind);
+  const operationId = sanitizeSegment(operation.id);
+  const fixedLength = "op-".length + kind.length + 2 + operationId.length;
+  const tenantBudget = Math.max(0, MAX_INSTANCE_ID_LENGTH - fixedLength);
+  const tenant = sanitizeSegment(operation.tenant_id ?? "fleet").slice(
+    0,
+    tenantBudget,
+  );
+  return `op-${kind}-${tenant}-${operationId}`.slice(0, MAX_INSTANCE_ID_LENGTH);
+}

--- a/packages/multi-tenancy/src/operations/record-provision.ts
+++ b/packages/multi-tenancy/src/operations/record-provision.ts
@@ -4,7 +4,7 @@ import {
   StepReporter,
   TenantOperationStores,
 } from "./types";
-import { buildEngineInstanceId } from "./instance-id";
+import { createOperationRow } from "./enqueue";
 import { createOperationRecorder, errorToMessage } from "./recorder";
 
 function getStores(adapters: DataAdapters): TenantOperationStores | undefined {
@@ -56,19 +56,8 @@ export async function runRecordedTenantOperation(
 
   let operationId: string | undefined;
   await safe(async () => {
-    const created = await stores.tenantOperations.create({
-      tenant_id: params.tenant_id,
-      rollout_id: params.rollout_id,
-      kind: params.kind,
-      engine: "inline",
-      initiated_by: params.initiated_by,
-      target_worker_version: params.target_worker_version,
-      target_database_version: params.target_database_version,
-    });
+    const created = await createOperationRow(stores, params, "inline");
     operationId = created.id;
-    await stores.tenantOperations.update(created.id, {
-      engine_instance_id: buildEngineInstanceId(created),
-    });
     await recorder.markRunning(created.id);
   });
 

--- a/packages/multi-tenancy/src/operations/record-provision.ts
+++ b/packages/multi-tenancy/src/operations/record-provision.ts
@@ -1,0 +1,118 @@
+import { DataAdapters } from "authhero";
+import {
+  EnqueueTenantOperationParams,
+  StepReporter,
+  TenantOperationStores,
+} from "./types";
+import { buildEngineInstanceId } from "./instance-id";
+import { createOperationRecorder, errorToMessage } from "./recorder";
+
+function getStores(adapters: DataAdapters): TenantOperationStores | undefined {
+  if (adapters.tenantOperations && adapters.tenantOperationEvents) {
+    return {
+      tenantOperations: adapters.tenantOperations,
+      tenantOperationEvents: adapters.tenantOperationEvents,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Wraps an existing inline lifecycle flow (today: the provisioning hook)
+ * so it is recorded as a tenant operation with step events — with NO
+ * behavior change:
+ *
+ * - When the operations adapters are absent, `fn` runs exactly as before.
+ * - Recording writes are best-effort (warn-only): a broken control-plane
+ *   log must never block or fail a provision. This mirrors the existing
+ *   markFailed philosophy in the WFP tenant hook.
+ * - `fn`'s error is always rethrown, preserving the caller's rollback
+ *   semantics.
+ *
+ * `fn` receives a StepReporter it may call at step boundaries; if it never
+ * does (e.g. a custom onProvision that ignores the parameter), a single
+ * coarse step named after the operation kind is recorded instead.
+ */
+export async function runRecordedTenantOperation(
+  adapters: DataAdapters,
+  params: EnqueueTenantOperationParams,
+  fn: (report: StepReporter | undefined) => Promise<void>,
+): Promise<void> {
+  const stores = getStores(adapters);
+  if (!stores) {
+    await fn(undefined);
+    return;
+  }
+
+  const recorder = createOperationRecorder(stores);
+
+  const safe = async (write: () => Promise<void>) => {
+    try {
+      await write();
+    } catch (error) {
+      console.warn("Failed to record tenant operation progress:", error);
+    }
+  };
+
+  let operationId: string | undefined;
+  await safe(async () => {
+    const created = await stores.tenantOperations.create({
+      tenant_id: params.tenant_id,
+      rollout_id: params.rollout_id,
+      kind: params.kind,
+      engine: "inline",
+      initiated_by: params.initiated_by,
+      target_worker_version: params.target_worker_version,
+      target_database_version: params.target_database_version,
+    });
+    operationId = created.id;
+    await stores.tenantOperations.update(created.id, {
+      engine_instance_id: buildEngineInstanceId(created),
+    });
+    await recorder.markRunning(created.id);
+  });
+
+  // The log row could not even be created — run the work unrecorded.
+  if (!operationId) {
+    await fn(undefined);
+    return;
+  }
+  const id = operationId;
+
+  let reported = false;
+  const report: StepReporter = async (step, outcome, detail) => {
+    reported = true;
+    await safe(async () => {
+      if (outcome === "started") {
+        await recorder.setCurrentStep(id, step);
+      }
+      await recorder.appendEvent(id, { step, outcome, detail });
+    });
+  };
+
+  try {
+    await fn(report);
+  } catch (error) {
+    await safe(async () => {
+      if (!reported) {
+        await recorder.appendEvent(id, {
+          step: params.kind,
+          outcome: "failed",
+          detail: { message: errorToMessage(error) },
+        });
+      }
+      await recorder.markFailed(id, error);
+    });
+    throw error;
+  }
+
+  await safe(async () => {
+    if (!reported) {
+      await recorder.appendEvent(id, {
+        step: params.kind,
+        outcome: "succeeded",
+      });
+    }
+    await recorder.markSucceeded(id);
+  });
+}

--- a/packages/multi-tenancy/src/operations/recorder.ts
+++ b/packages/multi-tenancy/src/operations/recorder.ts
@@ -1,0 +1,86 @@
+import { TenantOperation } from "authhero";
+import { TenantOperationStores } from "./types";
+
+const MAX_ERROR_LENGTH = 2048;
+
+export function errorToMessage(error: unknown): string {
+  const message =
+    error instanceof Error ? error.message : String(error ?? "unknown error");
+  return message.slice(0, MAX_ERROR_LENGTH);
+}
+
+/**
+ * Write-back helpers for the operation log, callable with just stores and
+ * an operation id. All writes are idempotent (safe under workflow-step
+ * replay): status transitions rewrite the same values, and duplicate
+ * events are harmless in an append-only step history.
+ *
+ * These helpers throw on write failure — in the executor path the log IS
+ * the deliverable. Callers that must never let recording break the actual
+ * work (the provisioning recording wrapper) catch and warn instead.
+ */
+export function createOperationRecorder(stores: TenantOperationStores) {
+  const { tenantOperations, tenantOperationEvents } = stores;
+
+  return {
+    async markRunning(operationId: string, currentStep?: string) {
+      await tenantOperations.update(operationId, {
+        status: "running",
+        ...(currentStep !== undefined ? { current_step: currentStep } : {}),
+      });
+    },
+
+    async setCurrentStep(operationId: string, step: string) {
+      await tenantOperations.update(operationId, { current_step: step });
+    },
+
+    async appendEvent(
+      operationId: string,
+      event: {
+        step: string;
+        outcome:
+          | "started"
+          | "succeeded"
+          | "failed"
+          | "retried"
+          | "skipped"
+          | "reconciled";
+        detail?: Record<string, unknown>;
+        attempt?: number;
+      },
+    ) {
+      await tenantOperationEvents.create({
+        operation_id: operationId,
+        step: event.step,
+        outcome: event.outcome,
+        detail: event.detail,
+        attempt: event.attempt ?? 1,
+      });
+    },
+
+    async markSucceeded(operationId: string) {
+      await tenantOperations.update(operationId, {
+        status: "succeeded",
+        error: null,
+        finished_at: new Date().toISOString(),
+      });
+    },
+
+    async markFailed(operationId: string, error: unknown) {
+      await tenantOperations.update(operationId, {
+        status: "failed",
+        error: errorToMessage(error),
+        finished_at: new Date().toISOString(),
+      });
+    },
+  };
+}
+
+export type OperationRecorder = ReturnType<typeof createOperationRecorder>;
+
+/** True when the operation can no longer transition (reconciler guard). */
+export function isTerminalStatus(status: TenantOperation["status"]): boolean {
+  return (
+    status === "succeeded" || status === "failed" || status === "cancelled"
+  );
+}

--- a/packages/multi-tenancy/src/operations/types.ts
+++ b/packages/multi-tenancy/src/operations/types.ts
@@ -1,0 +1,73 @@
+import {
+  TenantOperation,
+  TenantOperationEventsAdapter,
+  TenantOperationKind,
+  TenantOperationsAdapter,
+} from "authhero";
+
+/**
+ * Structural subset of Cloudflare Workflows' `WorkflowStepConfig`, kept
+ * platform-agnostic so operation orchestration can run against any engine.
+ */
+export interface StepConfig {
+  retries?: {
+    limit: number;
+    delay: string | number;
+    backoff?: "constant" | "linear" | "exponential";
+  };
+  timeout?: string | number;
+}
+
+/**
+ * Structural subset of Cloudflare Workflows' `WorkflowStep`. The inline
+ * executor runs steps through a trivial implementation; the Workflows
+ * executor passes the engine's own `step` object, which satisfies this
+ * type structurally.
+ */
+export interface StepRunner {
+  do<T>(name: string, fn: () => Promise<T>): Promise<T>;
+  do<T>(name: string, config: StepConfig, fn: () => Promise<T>): Promise<T>;
+}
+
+/** The control-plane stores every operation write goes through. */
+export interface TenantOperationStores {
+  tenantOperations: TenantOperationsAdapter;
+  tenantOperationEvents: TenantOperationEventsAdapter;
+}
+
+export interface EnqueueTenantOperationParams {
+  kind: TenantOperationKind;
+  /** Target tenant; null for fleet-level operations. */
+  tenant_id: string | null;
+  rollout_id?: string;
+  initiated_by?: string;
+  target_worker_version?: string;
+  target_database_version?: string;
+}
+
+/**
+ * Executes an already-persisted operation row. Row-first contract: the
+ * caller (`enqueueTenantOperation`) creates the row and writes the
+ * deterministic `engine_instance_id` before calling `start`, so a crashed
+ * enqueue can never leave an untracked engine instance.
+ *
+ * - Inline executor: `start` runs the steps to a terminal status before
+ *   resolving.
+ * - Cloudflare Workflows executor (phase 2): `start` returns as soon as
+ *   the instance is created; the workflow owns all further writes.
+ */
+export interface TenantOperationExecutor {
+  readonly engine: "inline" | "cloudflare-workflows";
+  start(operation: TenantOperation): Promise<void>;
+}
+
+/**
+ * Step-boundary callback threaded through provisioning hooks so the
+ * existing inline provision flow can report coarse step outcomes without
+ * depending on this package (implementations accept it structurally).
+ */
+export type StepReporter = (
+  step: string,
+  outcome: "started" | "succeeded" | "failed",
+  detail?: Record<string, unknown>,
+) => Promise<void>;

--- a/packages/multi-tenancy/src/types.ts
+++ b/packages/multi-tenancy/src/types.ts
@@ -1,5 +1,6 @@
 import { CreateTenantParams, DataAdapters, Tenant } from "authhero";
 import { Context } from "hono";
+import type { StepReporter } from "./operations/types";
 
 /**
  * Bindings type from authhero core - simplified version for this package
@@ -124,6 +125,11 @@ export interface DatabaseIsolationConfig {
    *
    * @param tenantId - The ID of the newly created tenant
    *
+   * When the control plane carries the tenant-operations adapters, the
+   * hook receives an optional `StepReporter` — call it at step boundaries
+   * to surface per-step events in the operation history (issue #1026).
+   * Implementations may ignore it; a single coarse step is recorded then.
+   *
    * @example
    * ```typescript
    * onProvision: async (tenantId) => {
@@ -133,7 +139,7 @@ export interface DatabaseIsolationConfig {
    * }
    * ```
    */
-  onProvision?: (tenantId: string) => Promise<void>;
+  onProvision?: (tenantId: string, report?: StepReporter) => Promise<void>;
 
   /**
    * Called when a tenant is being deleted to cleanup its database.

--- a/packages/multi-tenancy/test/operations.test.ts
+++ b/packages/multi-tenancy/test/operations.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import createAdapters from "@authhero/kysely-adapter";
+import { createMigratedDb } from "./helpers/migrated-db";
+import {
+  buildEngineInstanceId,
+  createInlineExecutor,
+  enqueueTenantOperation,
+  runRecordedTenantOperation,
+  TenantOperationStores,
+} from "../src/operations";
+import { createProvisioningHooks } from "../src/hooks";
+
+describe("buildEngineInstanceId", () => {
+  it("builds a deterministic dash-separated id", () => {
+    const id = buildEngineInstanceId({
+      kind: "provision",
+      tenant_id: "tenant-a",
+      id: "op_abc123",
+    });
+    expect(id).toBe("op-provision-tenant-a-op_abc123");
+  });
+
+  it("sanitizes characters outside [a-zA-Z0-9_-]", () => {
+    const id = buildEngineInstanceId({
+      kind: "provision",
+      tenant_id: "tenant:with spaces/slashes",
+      id: "op_abc",
+    });
+    expect(id).toMatch(/^[a-zA-Z0-9_-]+$/);
+  });
+
+  it("uses a fleet segment for null tenant ids", () => {
+    const id = buildEngineInstanceId({
+      kind: "backup",
+      tenant_id: null,
+      id: "op_abc",
+    });
+    expect(id).toBe("op-backup-fleet-op_abc");
+  });
+
+  it("truncates the tenant segment, never the operation id", () => {
+    const id = buildEngineInstanceId({
+      kind: "provision",
+      tenant_id: "x".repeat(200),
+      id: "op_abcdefghij123456789",
+    });
+    expect(id.length).toBeLessThanOrEqual(64);
+    expect(id.endsWith("-op_abcdefghij123456789")).toBe(true);
+  });
+});
+
+describe("inline executor + enqueue", () => {
+  let stores: TenantOperationStores;
+
+  beforeEach(async () => {
+    const db = await createMigratedDb();
+    const adapters = createAdapters(db);
+    stores = {
+      tenantOperations: adapters.tenantOperations!,
+      tenantOperationEvents: adapters.tenantOperationEvents!,
+    };
+  });
+
+  it("runs steps to succeeded, recording an event trail", async () => {
+    const calls: string[] = [];
+    const executor = createInlineExecutor({
+      stores,
+      definitions: {
+        upgrade: () => [
+          {
+            name: "snapshot",
+            async run() {
+              calls.push("snapshot");
+              return { bookmark: "bm-1" };
+            },
+          },
+          {
+            name: "apply",
+            async run() {
+              calls.push("apply");
+            },
+          },
+        ],
+      },
+    });
+
+    const operation = await enqueueTenantOperation(stores, executor, {
+      kind: "upgrade",
+      tenant_id: "tenant-a",
+      initiated_by: "auth0|admin",
+    });
+
+    expect(calls).toEqual(["snapshot", "apply"]);
+    expect(operation.status).toBe("succeeded");
+    expect(operation.engine).toBe("inline");
+    expect(operation.engine_instance_id).toContain("op-upgrade-tenant-a-");
+    expect(operation.finished_at).toBeTruthy();
+
+    const { events } = await stores.tenantOperationEvents.listByOperation(
+      operation.id,
+    );
+    expect(events.map((e) => `${e.step}:${e.outcome}`)).toEqual([
+      "snapshot:started",
+      "snapshot:succeeded",
+      "apply:started",
+      "apply:succeeded",
+    ]);
+    expect(events[1]!.detail).toEqual({ bookmark: "bm-1" });
+  });
+
+  it("marks the operation failed and rethrows when a step throws", async () => {
+    const executor = createInlineExecutor({
+      stores,
+      definitions: {
+        upgrade: () => [
+          {
+            name: "explode",
+            async run() {
+              throw new Error("boom");
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(
+      enqueueTenantOperation(stores, executor, {
+        kind: "upgrade",
+        tenant_id: "tenant-a",
+      }),
+    ).rejects.toThrow("boom");
+
+    const { operations } = await stores.tenantOperations.list({
+      tenant_id: "tenant-a",
+    });
+    expect(operations).toHaveLength(1);
+    expect(operations[0]!.status).toBe("failed");
+    expect(operations[0]!.error).toBe("boom");
+    expect(operations[0]!.finished_at).toBeTruthy();
+
+    const { events } = await stores.tenantOperationEvents.listByOperation(
+      operations[0]!.id,
+    );
+    expect(events.map((e) => `${e.step}:${e.outcome}`)).toEqual([
+      "explode:started",
+      "explode:failed",
+    ]);
+  });
+
+  it("fails cleanly for an unknown kind", async () => {
+    const executor = createInlineExecutor({ stores, definitions: {} });
+
+    await expect(
+      enqueueTenantOperation(stores, executor, {
+        kind: "seed",
+        tenant_id: "tenant-a",
+      }),
+    ).rejects.toThrow(/no inline operation definition/i);
+
+    const { operations } = await stores.tenantOperations.list({
+      tenant_id: "tenant-a",
+    });
+    expect(operations[0]!.status).toBe("failed");
+  });
+});
+
+describe("runRecordedTenantOperation", () => {
+  it("records reported steps and finalizes succeeded", async () => {
+    const db = await createMigratedDb();
+    const adapters = createAdapters(db);
+
+    await runRecordedTenantOperation(
+      adapters,
+      { kind: "provision", tenant_id: "tenant-a", initiated_by: "auth0|admin" },
+      async (report) => {
+        expect(report).toBeDefined();
+        await report!("provision-resources", "started");
+        await report!("provision-resources", "succeeded", {
+          d1_database_id: "d1-1",
+        });
+        await report!("seed-defaults", "started");
+        await report!("seed-defaults", "succeeded");
+      },
+    );
+
+    const { operations } = await adapters.tenantOperations!.list({
+      tenant_id: "tenant-a",
+    });
+    expect(operations).toHaveLength(1);
+    const op = operations[0]!;
+    expect(op.status).toBe("succeeded");
+    expect(op.kind).toBe("provision");
+    expect(op.initiated_by).toBe("auth0|admin");
+    expect(op.engine).toBe("inline");
+    expect(op.current_step).toBe("seed-defaults");
+
+    const { events } = await adapters.tenantOperationEvents!.listByOperation(
+      op.id,
+    );
+    expect(events.map((e) => `${e.step}:${e.outcome}`)).toEqual([
+      "provision-resources:started",
+      "provision-resources:succeeded",
+      "seed-defaults:started",
+      "seed-defaults:succeeded",
+    ]);
+    expect(events[1]!.detail).toEqual({ d1_database_id: "d1-1" });
+  });
+
+  it("records a single coarse step when the reporter is never called", async () => {
+    const db = await createMigratedDb();
+    const adapters = createAdapters(db);
+
+    await runRecordedTenantOperation(
+      adapters,
+      { kind: "provision", tenant_id: "tenant-b" },
+      async () => {
+        /* legacy onProvision that ignores the reporter */
+      },
+    );
+
+    const { operations } = await adapters.tenantOperations!.list({
+      tenant_id: "tenant-b",
+    });
+    expect(operations[0]!.status).toBe("succeeded");
+
+    const { events } = await adapters.tenantOperationEvents!.listByOperation(
+      operations[0]!.id,
+    );
+    expect(events.map((e) => `${e.step}:${e.outcome}`)).toEqual([
+      "provision:succeeded",
+    ]);
+  });
+
+  it("marks failed and rethrows when the work throws", async () => {
+    const db = await createMigratedDb();
+    const adapters = createAdapters(db);
+
+    await expect(
+      runRecordedTenantOperation(
+        adapters,
+        { kind: "provision", tenant_id: "tenant-c" },
+        async () => {
+          throw new Error("provision blew up");
+        },
+      ),
+    ).rejects.toThrow("provision blew up");
+
+    const { operations } = await adapters.tenantOperations!.list({
+      tenant_id: "tenant-c",
+    });
+    expect(operations[0]!.status).toBe("failed");
+    expect(operations[0]!.error).toBe("provision blew up");
+  });
+
+  it("runs the work unrecorded when the adapters are absent", async () => {
+    const db = await createMigratedDb();
+    const adapters = createAdapters(db);
+    const withoutOperations = {
+      ...adapters,
+      tenantOperations: undefined,
+      tenantOperationEvents: undefined,
+    };
+
+    let ran = false;
+    let receivedReporter: unknown = "sentinel";
+    await runRecordedTenantOperation(
+      withoutOperations,
+      { kind: "provision", tenant_id: "tenant-d" },
+      async (report) => {
+        ran = true;
+        receivedReporter = report;
+      },
+    );
+
+    expect(ran).toBe(true);
+    expect(receivedReporter).toBeUndefined();
+    // No rows were written anywhere
+    const { operations } = await adapters.tenantOperations!.list({});
+    expect(operations).toHaveLength(0);
+  });
+});
+
+describe("provisioning hook recording", () => {
+  it("records a provision operation from afterCreate", async () => {
+    const db = await createMigratedDb();
+    const adapters = createAdapters(db);
+
+    const provisioned: string[] = [];
+    const hooks = createProvisioningHooks({
+      databaseIsolation: {
+        getAdapters: async () => adapters,
+        onProvision: async (tenantId, report) => {
+          provisioned.push(tenantId);
+          await report?.("provision-resources", "started");
+          await report?.("provision-resources", "succeeded");
+        },
+      },
+    });
+
+    const tenant = await adapters.tenants.create({
+      id: "wfp-tenant",
+      friendly_name: "WFP Tenant",
+    });
+    await hooks.afterCreate!({ adapters }, tenant);
+
+    expect(provisioned).toEqual(["wfp-tenant"]);
+
+    const { operations } = await adapters.tenantOperations!.list({
+      tenant_id: "wfp-tenant",
+    });
+    expect(operations).toHaveLength(1);
+    expect(operations[0]!.kind).toBe("provision");
+    expect(operations[0]!.status).toBe("succeeded");
+  });
+
+  it("marks the operation failed and propagates a provision error", async () => {
+    const db = await createMigratedDb();
+    const adapters = createAdapters(db);
+
+    const hooks = createProvisioningHooks({
+      databaseIsolation: {
+        getAdapters: async () => adapters,
+        onProvision: async () => {
+          throw new Error("no capacity");
+        },
+      },
+    });
+
+    const tenant = await adapters.tenants.create({
+      id: "wfp-tenant-2",
+      friendly_name: "WFP Tenant 2",
+    });
+
+    await expect(hooks.afterCreate!({ adapters }, tenant)).rejects.toThrow(
+      "no capacity",
+    );
+
+    const { operations } = await adapters.tenantOperations!.list({
+      tenant_id: "wfp-tenant-2",
+    });
+    expect(operations[0]!.status).toBe("failed");
+    expect(operations[0]!.error).toBe("no capacity");
+  });
+});


### PR DESCRIPTION
Part 2/5 of the issue #1026 stack. Stacked on #1037.

## What

Every tenant provision is now recorded as an operation with step events — with no behavior change when the operations adapters are absent.

- **`@authhero/multi-tenancy`** gains `src/operations/`:
  - `runRecordedTenantOperation` wraps `databaseIsolation.onProvision` in `createProvisioningHooks.afterCreate`. Recording writes are warn-only (a broken log can never block a provision) and the original error is always rethrown, preserving rollback semantics.
  - The row-first executor contract: `enqueueTenantOperation` persists the row + deterministic `op-{kind}-{tenant}-{opid}` instance id (≤64 chars, `[a-zA-Z0-9_-]`) before `executor.start(operation)` — a crashed enqueue can never leave an untracked engine instance. `createInlineExecutor` runs steps synchronously through the same `StepRunner` seam Cloudflare's `WorkflowStep` satisfies structurally (part 4/5).
  - `initMultiTenant` wires a default inline executor for `upgrade` operations when `tenantUpgrade` is configured.
- **`authhero`**: mounts `GET /api/v2/operations/{id}`, `GET/POST /api/v2/tenants/{id}/operations` when the operations adapters are present (jobs-style: POST returns 201, clients poll). New scopes `read:tenant_operations` / `create:tenant_operations`. New `tenantOperationExecutor` config binding (structural — core imports neither multi-tenancy nor any engine).
- **`@authhero/cloudflare-adapter`**: the WFP hook accepts an optional step reporter and surfaces `provision-resources` / `seed-defaults` boundaries; a throwing reporter can never fail a provision.

POST semantics in this phase: `upgrade` → enqueued via the executor; `provision`/`deprovision` → 400 (lifecycle-managed); `seed`/`backup` → 501 (later phases).

## Follow-up commit

A second commit tenant-scopes the read endpoints (non-control-plane callers get 404 for foreign operations — no existence leak — and 403 for foreign history lists), shares the row-first setup between the enqueue path and the recording wrapper via `createOperationRow`, caps persisted error text consistently, and adds upgrade/seed-error coverage for the WFP step reporter.

## Tests

New multi-tenancy operations suite (13) covering executor success/failure trails, instance-id format, coarse-step fallback, and behavior parity without adapters; new route spec (8) covering list/get/POST guards (403 non-control-plane, 501 no executor, scope rejection); reporter tests in the cloudflare suite. Full suites: multi-tenancy 123, cloudflare 87, authhero 1722 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant operations management endpoints for listing, viewing, and creating tenant operations with new access permissions.
  * Tenant provisioning and upgrade flows now track progress in clearer steps, including success/failure reporting.
  * Added support for recording tenant lifecycle activity during provisioning and upgrades.

* **Bug Fixes**
  * Improved reliability when operation tracking or reporting is unavailable, so provisioning continues without being blocked.
  * Fixed operation handling so failed steps are recorded consistently and operation history stays accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
