### PR TITLE
feat(admin,docs): tenant operations UI and docs coverage (#1026 phase 5)

### DIFF
--- a/.changeset/admin-tenant-operations-ui.md
+++ b/.changeset/admin-tenant-operations-ui.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": minor
+---
+
+Add a control-plane Operations page per tenant (issue #1026 phase 5): lifecycle operation history with expandable step-event timelines, live polling while an operation is in flight, and a Redeploy button that enqueues an upgrade operation. The data provider gains `listTenantOperations` / `getTenantOperation` / `createTenantOperation`, and the tenants list links to the new page. Full-page loads of `/tenants/:id/members` and `/tenants/:id/operations` now render the control-plane app correctly.

--- a/apps/admin/src/TenantsApp.tsx
+++ b/apps/admin/src/TenantsApp.tsx
@@ -8,6 +8,7 @@ import { getConfigValue, getBasePath } from "./utils/runtimeConfig";
 import { TenantsList } from "./resources/tenants/list";
 import { TenantsCreate } from "./resources/tenants/create";
 import { TenantMembers } from "./resources/tenants/members";
+import { TenantOperations } from "./resources/tenants/operations";
 import { Loader2 } from "lucide-react";
 
 interface TenantsAppProps {
@@ -109,6 +110,10 @@ export function TenantsApp({ initialDomain, onAuthComplete }: TenantsAppProps) {
       <Resource name="users" />
       <CustomRoutes>
         <Route path="/tenants/:tenantId/members" element={<TenantMembers />} />
+        <Route
+          path="/tenants/:tenantId/operations"
+          element={<TenantOperations />}
+        />
       </CustomRoutes>
     </Admin>
   );

--- a/apps/admin/src/auth0DataProvider.ts
+++ b/apps/admin/src/auth0DataProvider.ts
@@ -340,6 +340,60 @@ export interface AuthHeroDataProvider extends DataProvider {
     counts: Record<string, number>;
     errors: { entity: string; error: string }[];
   }>;
+  /**
+   * Durable tenant lifecycle operations (issue #1026). Control-plane
+   * routes — available only when the server carries the operations
+   * adapters (404 otherwise, 501 when no executor is configured).
+   */
+  listTenantOperations: (
+    tenantId: string,
+    params?: { page?: number; perPage?: number },
+  ) => Promise<{
+    operations: TenantOperationRecord[];
+    start: number;
+    limit: number;
+    length: number;
+  }>;
+  getTenantOperation: (
+    operationId: string,
+  ) => Promise<
+    TenantOperationRecord & { events: TenantOperationEventRecord[] }
+  >;
+  createTenantOperation: (
+    tenantId: string,
+    kind: "upgrade" | "seed" | "backup",
+  ) => Promise<TenantOperationRecord>;
+}
+
+// Wire shapes of the tenant-operations management API (issue #1026).
+export interface TenantOperationRecord {
+  id: string;
+  tenant_id: string | null;
+  kind: "provision" | "seed" | "upgrade" | "backup" | "deprovision";
+  status: "pending" | "running" | "succeeded" | "failed" | "cancelled";
+  current_step?: string | null;
+  engine: string;
+  error?: string | null;
+  initiated_by?: string | null;
+  created_at: string;
+  updated_at: string;
+  finished_at?: string | null;
+}
+
+export interface TenantOperationEventRecord {
+  id: string;
+  operation_id: string;
+  step: string;
+  outcome:
+    | "started"
+    | "succeeded"
+    | "failed"
+    | "retried"
+    | "skipped"
+    | "reconciled";
+  detail?: Record<string, unknown> | null;
+  attempt: number;
+  created_at: string;
 }
 
 /**
@@ -2508,6 +2562,38 @@ export default (
         method: "POST",
         headers: createHeaders(tenantId),
       });
+    },
+
+    listTenantOperations: async (targetTenantId, params) => {
+      const query = new URLSearchParams({
+        page: String((params?.page ?? 1) - 1),
+        per_page: String(params?.perPage ?? 25),
+      });
+      const res = await httpClient(
+        `${apiUrl}/api/v2/tenants/${encodeURIComponent(targetTenantId)}/operations?${query}`,
+        { headers: createHeaders(tenantId) },
+      );
+      return res.json;
+    },
+
+    getTenantOperation: async (operationId) => {
+      const res = await httpClient(
+        `${apiUrl}/api/v2/operations/${encodeURIComponent(operationId)}`,
+        { headers: createHeaders(tenantId) },
+      );
+      return res.json;
+    },
+
+    createTenantOperation: async (targetTenantId, kind) => {
+      const res = await httpClient(
+        `${apiUrl}/api/v2/tenants/${encodeURIComponent(targetTenantId)}/operations`,
+        {
+          method: "POST",
+          headers: createHeaders(tenantId),
+          body: JSON.stringify({ kind }),
+        },
+      );
+      return res.json;
     },
 
     revokeSigningKey: async (kid: string) => {

--- a/apps/admin/src/index.tsx
+++ b/apps/admin/src/index.tsx
@@ -32,7 +32,11 @@ function Root() {
   const isTenantsPath =
     relativePath === "/tenants" ||
     relativePath.startsWith("/tenants/create") ||
-    relativePath === "/tenants/";
+    relativePath === "/tenants/" ||
+    // Control-plane subpages registered as CustomRoutes inside TenantsApp —
+    // without these, a full page load of their URLs would fall through to
+    // the per-tenant app branch with tenantId="tenants".
+    /^\/tenants\/[^/]+\/(members|operations)(\/|$)/.test(relativePath);
 
   if (isAuthCallback) {
     return (

--- a/apps/admin/src/resources/tenants/list.tsx
+++ b/apps/admin/src/resources/tenants/list.tsx
@@ -1,7 +1,7 @@
 import { useId } from "react";
 import { Link } from "react-router-dom";
 import { useRecordContext } from "ra-core";
-import { Users } from "lucide-react";
+import { History, Users } from "lucide-react";
 import { BadgeField, DataTable, List, TextInput } from "@/components/admin";
 import { Button } from "@/components/ui/button";
 import { getBasePath } from "@/utils/runtimeConfig";
@@ -61,6 +61,26 @@ function MembersLinkCell() {
   );
 }
 
+function OperationsLinkCell() {
+  const record = useRecordContext<TenantRecord>();
+  if (!record) return null;
+  // Plain router path — react-router prefixes the basename itself, and the
+  // outer Root also renders TenantsApp for this URL on a full reload.
+  return (
+    <Button
+      asChild
+      variant="outline"
+      size="sm"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Link to={`/tenants/${String(record.id)}/operations`}>
+        <History className="h-4 w-4 mr-1" />
+        Operations
+      </Link>
+    </Button>
+  );
+}
+
 export function TenantsList() {
   const filters = [
     <TextInput key="q" source="q" placeholder="Search" label={false} />,
@@ -88,6 +108,9 @@ export function TenantsList() {
         <DataTable.Col source="support_url" label="Support URL" />
         <DataTable.Col label="">
           <MembersLinkCell />
+        </DataTable.Col>
+        <DataTable.Col label="">
+          <OperationsLinkCell />
         </DataTable.Col>
       </DataTable>
     </List>

--- a/apps/admin/src/resources/tenants/operations.tsx
+++ b/apps/admin/src/resources/tenants/operations.tsx
@@ -1,0 +1,386 @@
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useDataProvider, useNotify } from "ra-core";
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  RefreshCw,
+  Rocket,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type {
+  AuthHeroDataProvider,
+  TenantOperationRecord,
+  TenantOperationEventRecord,
+} from "@/auth0DataProvider";
+import { getBasePath } from "@/utils/runtimeConfig";
+
+const STATUS_VARIANT: Record<
+  TenantOperationRecord["status"],
+  "default" | "outline" | "secondary" | "destructive"
+> = {
+  pending: "secondary",
+  running: "secondary",
+  succeeded: "outline",
+  failed: "destructive",
+  cancelled: "secondary",
+};
+
+const OUTCOME_VARIANT: Record<
+  TenantOperationEventRecord["outcome"],
+  "default" | "outline" | "secondary" | "destructive"
+> = {
+  started: "secondary",
+  succeeded: "outline",
+  failed: "destructive",
+  retried: "secondary",
+  skipped: "secondary",
+  reconciled: "secondary",
+};
+
+const ACTIVE_STATUSES: TenantOperationRecord["status"][] = [
+  "pending",
+  "running",
+];
+const POLL_INTERVAL_MS = 4000;
+
+function formatTimestamp(value?: string | null): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function formatDuration(operation: TenantOperationRecord): string {
+  const start = new Date(operation.created_at).getTime();
+  const end = operation.finished_at
+    ? new Date(operation.finished_at).getTime()
+    : Date.now();
+  if (isNaN(start) || isNaN(end) || end < start) return "—";
+  const seconds = Math.round((end - start) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function EventsTimeline({ events }: { events: TenantOperationEventRecord[] }) {
+  if (events.length === 0) {
+    return (
+      <p className="py-2 text-sm text-muted-foreground">
+        No step events recorded for this operation.
+      </p>
+    );
+  }
+  return (
+    <ol className="flex flex-col gap-1 py-2">
+      {events.map((event) => (
+        <li key={event.id} className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground whitespace-nowrap">
+            {formatTimestamp(event.created_at)}
+          </span>
+          <span className="font-mono">{event.step}</span>
+          <Badge variant={OUTCOME_VARIANT[event.outcome] ?? "secondary"}>
+            {event.outcome}
+          </Badge>
+          {event.attempt > 1 ? (
+            <span className="text-muted-foreground">
+              attempt {event.attempt}
+            </span>
+          ) : null}
+          {event.detail ? (
+            <span
+              className="text-muted-foreground truncate max-w-md"
+              title={JSON.stringify(event.detail, null, 2)}
+            >
+              {JSON.stringify(event.detail)}
+            </span>
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ready" }
+  | { status: "unavailable" }
+  | { status: "error" };
+
+/**
+ * Control-plane view of a tenant's lifecycle operation history
+ * (issue #1026): every provision/upgrade run with its per-step event
+ * timeline, plus a redeploy control that enqueues an upgrade operation.
+ * Polls while an operation is in flight — the server marks it terminal.
+ */
+export function TenantOperations() {
+  const { tenantId } = useParams();
+  const dataProvider = useDataProvider<AuthHeroDataProvider>();
+  const notify = useNotify();
+
+  const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
+  const [operations, setOperations] = useState<TenantOperationRecord[]>([]);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [events, setEvents] = useState<
+    Record<string, TenantOperationEventRecord[]>
+  >({});
+  const [enqueuing, setEnqueuing] = useState(false);
+  const mounted = useRef(true);
+
+  const refresh = useCallback(async () => {
+    if (!tenantId) return;
+    try {
+      const result = await dataProvider.listTenantOperations(tenantId, {
+        page: 1,
+        perPage: 50,
+      });
+      if (!mounted.current) return;
+      setOperations(result.operations);
+      setLoadState({ status: "ready" });
+    } catch (error) {
+      if (!mounted.current) return;
+      const status =
+        error && typeof error === "object" && "status" in error
+          ? Number(error.status)
+          : undefined;
+      // 404 = the routes aren't mounted (no operations adapters on this
+      // deployment); anything else is a real failure.
+      setLoadState(
+        status === 404 ? { status: "unavailable" } : { status: "error" },
+      );
+    }
+  }, [dataProvider, tenantId]);
+
+  useEffect(() => {
+    mounted.current = true;
+    refresh();
+    return () => {
+      mounted.current = false;
+    };
+  }, [refresh]);
+
+  // Poll while anything is in flight so terminal states appear without a
+  // manual refresh.
+  const hasActive = operations.some((op) =>
+    ACTIVE_STATUSES.includes(op.status),
+  );
+  useEffect(() => {
+    if (!hasActive) return;
+    const interval = setInterval(refresh, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [hasActive, refresh]);
+
+  const loadEvents = useCallback(
+    async (operationId: string) => {
+      try {
+        const detail = await dataProvider.getTenantOperation(operationId);
+        if (!mounted.current) return;
+        setEvents((prev) => ({ ...prev, [operationId]: detail.events }));
+      } catch {
+        // Row stays expandable; timeline just shows the empty state.
+      }
+    },
+    [dataProvider],
+  );
+
+  const toggleExpanded = (operationId: string) => {
+    const next = expandedId === operationId ? null : operationId;
+    setExpandedId(next);
+    if (next) loadEvents(next);
+  };
+
+  // Keep the expanded timeline live while its operation runs.
+  useEffect(() => {
+    if (!expandedId) return;
+    const operation = operations.find((op) => op.id === expandedId);
+    if (!operation || !ACTIVE_STATUSES.includes(operation.status)) return;
+    const interval = setInterval(
+      () => loadEvents(expandedId),
+      POLL_INTERVAL_MS,
+    );
+    return () => clearInterval(interval);
+  }, [expandedId, operations, loadEvents]);
+
+  const enqueueUpgrade = async () => {
+    if (!tenantId) return;
+    setEnqueuing(true);
+    try {
+      await dataProvider.createTenantOperation(tenantId, "upgrade");
+      notify("Upgrade operation enqueued", { type: "info" });
+      await refresh();
+    } catch (error) {
+      const message =
+        error && typeof error === "object" && "message" in error
+          ? String(error.message)
+          : "Failed to enqueue the upgrade";
+      notify(message, { type: "error" });
+    } finally {
+      if (mounted.current) setEnqueuing(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div>
+        <Button asChild variant="ghost" size="sm">
+          <Link to={getBasePath()}>
+            <ArrowLeft className="h-4 w-4 mr-1" />
+            Back to tenants
+          </Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-4">
+          <div className="flex flex-col gap-1.5">
+            <CardTitle>Operations for {tenantId}</CardTitle>
+            <CardDescription>
+              Lifecycle operation history — every provision, seed, and upgrade
+              run with its step-by-step timeline. Retrying is safe: steps are
+              idempotent.
+            </CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={refresh}
+              disabled={loadState.status === "loading"}
+            >
+              <RefreshCw className="h-4 w-4 mr-1" />
+              Refresh
+            </Button>
+            <Button
+              size="sm"
+              onClick={enqueueUpgrade}
+              disabled={enqueuing || hasActive}
+              title={
+                hasActive
+                  ? "An operation is already in flight for this tenant"
+                  : undefined
+              }
+            >
+              {enqueuing ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+              ) : (
+                <Rocket className="h-4 w-4 mr-1" />
+              )}
+              Redeploy
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loadState.status === "loading" ? (
+            <div className="flex items-center gap-2 py-8 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Loading operations…</span>
+            </div>
+          ) : loadState.status === "unavailable" ? (
+            <p className="py-8 text-sm text-muted-foreground">
+              Tenant operations aren&apos;t enabled for this deployment. The
+              control plane needs the tenant-operations adapters configured.
+            </p>
+          ) : loadState.status === "error" ? (
+            <p className="py-8 text-sm text-destructive">
+              Could not load operations for this tenant. Check that you have the
+              read:tenant_operations permission and try again.
+            </p>
+          ) : operations.length === 0 ? (
+            <p className="py-8 text-sm text-muted-foreground">
+              No operations recorded for this tenant yet. Operations appear here
+              when the tenant is provisioned, seeded, or upgraded.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8" />
+                  <TableHead>Kind</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Current step</TableHead>
+                  <TableHead>Started</TableHead>
+                  <TableHead>Duration</TableHead>
+                  <TableHead>Initiated by</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {operations.map((operation) => (
+                  <Fragment key={operation.id}>
+                    <TableRow
+                      className="cursor-pointer"
+                      onClick={() => toggleExpanded(operation.id)}
+                    >
+                      <TableCell>
+                        {expandedId === operation.id ? (
+                          <ChevronDown className="h-4 w-4" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4" />
+                        )}
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {operation.kind}
+                      </TableCell>
+                      <TableCell>
+                        <span title={operation.error ?? undefined}>
+                          <Badge variant={STATUS_VARIANT[operation.status]}>
+                            {operation.status}
+                          </Badge>
+                        </span>
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {operation.current_step ?? "—"}
+                      </TableCell>
+                      <TableCell>
+                        {formatTimestamp(operation.created_at)}
+                      </TableCell>
+                      <TableCell>{formatDuration(operation)}</TableCell>
+                      <TableCell className="truncate max-w-40">
+                        {operation.initiated_by ?? "—"}
+                      </TableCell>
+                    </TableRow>
+                    {expandedId === operation.id ? (
+                      <TableRow>
+                        <TableCell />
+                        <TableCell colSpan={6}>
+                          {operation.error ? (
+                            <p className="py-1 text-sm text-destructive">
+                              {operation.error}
+                            </p>
+                          ) : null}
+                          {events[operation.id] ? (
+                            <EventsTimeline events={events[operation.id]!} />
+                          ) : (
+                            <div className="flex items-center gap-2 py-2 text-muted-foreground text-sm">
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                              <span>Loading events…</span>
+                            </div>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ) : null}
+                  </Fragment>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/admin/src/resources/tenants/operations.tsx
+++ b/apps/admin/src/resources/tenants/operations.tsx
@@ -31,7 +31,6 @@ import type {
   TenantOperationRecord,
   TenantOperationEventRecord,
 } from "@/auth0DataProvider";
-import { getBasePath } from "@/utils/runtimeConfig";
 
 const STATUS_VARIANT: Record<
   TenantOperationRecord["status"],
@@ -239,7 +238,7 @@ export function TenantOperations() {
     <div className="flex flex-col gap-4 p-4">
       <div>
         <Button asChild variant="ghost" size="sm">
-          <Link to={getBasePath()}>
+          <Link to="/tenants">
             <ArrowLeft className="h-4 w-4 mr-1" />
             Back to tenants
           </Link>
@@ -324,7 +323,16 @@ export function TenantOperations() {
                   <Fragment key={operation.id}>
                     <TableRow
                       className="cursor-pointer"
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={expandedId === operation.id}
                       onClick={() => toggleExpanded(operation.id)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          toggleExpanded(operation.id);
+                        }
+                      }}
                     >
                       <TableCell>
                         {expandedId === operation.id ? (

--- a/apps/docs/customization/multi-tenancy/api-reference.md
+++ b/apps/docs/customization/multi-tenancy/api-reference.md
@@ -14,7 +14,7 @@ Complete API reference for the `@authhero/multi-tenancy` package.
 The easiest way to set up multi-tenancy. Automatically configures sync hooks, tenants API, middleware, and runtime fallback.
 
 ```typescript
-function initMultiTenant(config: MultiTenantConfig): MultiTenantResult
+function initMultiTenant(config: MultiTenantConfig): MultiTenantResult;
 ```
 
 **Parameters:**
@@ -48,7 +48,10 @@ export default app;
 Configuration for `initMultiTenant()`.
 
 ```typescript
-interface MultiTenantConfig extends Omit<AuthHeroConfig, "entityHooks" | "managementApiExtensions"> {
+interface MultiTenantConfig extends Omit<
+  AuthHeroConfig,
+  "entityHooks" | "managementApiExtensions"
+> {
   // Control plane configuration (optional but recommended)
   controlPlane?: ControlPlaneConfig;
 
@@ -110,6 +113,7 @@ const { app } = initMultiTenant({
 ```
 
 When `controlPlane` is configured:
+
 - **Runtime Fallback**: Connection secrets, OAuth credentials, and client settings fallback to control plane without copying
 - **Access Control**: `/api/v2/tenants` endpoint filters based on user's organization memberships
 - **Organization Sync**: Organizations are automatically created on control plane when tenants are created
@@ -123,7 +127,9 @@ Per-tenant resolver for runtime inheritance. Mirrors the shape of
 wrapped adapter read with the tenant being read.
 
 ```typescript
-type ControlPlaneResolver = (params: { tenant_id: string }) =>
+type ControlPlaneResolver = (params: {
+  tenant_id: string;
+}) =>
   | { tenantId: string; clientId?: string }
   | undefined
   | Promise<{ tenantId: string; clientId?: string } | undefined>;
@@ -202,8 +208,14 @@ interface DatabaseIsolationConfig {
   // Get data adapters for a specific tenant
   getAdapters: (tenantId: string) => Promise<DataAdapters>;
 
-  // Called when a new tenant is provisioned
-  onProvision?: (tenantId: string) => Promise<void>;
+  // Called when a new tenant is provisioned. The optional StepReporter
+  // surfaces per-step events in the operation history when the control
+  // plane records tenant operations (see Tenant Operations).
+  onProvision?: (tenantId: string, report?: StepReporter) => Promise<void>;
+
+  // Set to false when the hook creates its own operation rows (e.g. the
+  // Cloudflare Workflows provisioning hook). Default: true.
+  recordProvisionOperations?: boolean;
 
   // Called when a tenant is deprovisioned/deleted
   onDeprovision?: (tenantId: string) => Promise<void>;
@@ -258,7 +270,7 @@ import { withRuntimeFallback } from "@authhero/multi-tenancy";
 
 const adapters = withRuntimeFallback(baseAdapters, {
   controlPlaneTenantId: "control_plane",
-  controlPlaneClientId: "control_plane_client"
+  controlPlaneClientId: "control_plane_client",
 });
 ```
 
@@ -543,7 +555,7 @@ import { createRuntimeFallbackAdapter } from "@authhero/multi-tenancy";
 
 const adapters = createRuntimeFallbackAdapter(baseAdapters, {
   controlPlaneTenantId: "control_plane",
-  controlPlaneClientId: "control_plane_client"
+  controlPlaneClientId: "control_plane_client",
 });
 ```
 
@@ -576,7 +588,7 @@ import { withRuntimeFallback } from "@authhero/multi-tenancy";
 
 const adapters = withRuntimeFallback(baseAdapters, {
   controlPlaneTenantId: "control_plane",
-  controlPlaneClientId: "control_plane_client"
+  controlPlaneClientId: "control_plane_client",
 });
 ```
 
@@ -778,6 +790,14 @@ Delete a tenant (main tenant only).
   success: boolean;
 }
 ```
+
+### Tenant operations
+
+Mounted only when the control plane carries the tenant-operations adapters (see [Tenant Operations](./tenant-operations.md)). Scopes: `read:tenant_operations`, `create:tenant_operations`.
+
+- `GET /tenants/:id/operations` — paginated lifecycle-operation history for a tenant (query: `page`, `per_page`, `kind`, `status`)
+- `GET /operations/:id` — one operation with its full step-event timeline
+- `POST /tenants/:id/operations` — enqueue `{ "kind": "upgrade" }` (control-plane only; returns `201` with the operation row — poll `GET /operations/:id`)
 
 ## Context Variables
 

--- a/apps/docs/customization/multi-tenancy/control-plane-defaults.md
+++ b/apps/docs/customization/multi-tenancy/control-plane-defaults.md
@@ -19,6 +19,10 @@ This page describes how a WFP tenant still gets its default connections,
 prompts, branding and **shared social-login secrets** (Google, Apple, …) — and
 how it can hold those secrets at rest without being able to decrypt them.
 
+::: tip Durable delivery
+Delivery of the projection is made durable by [Tenant Operations](./tenant-operations.md): on control planes using the Cloudflare Workflows executor, the seed runs as a retried workflow step _before_ the tenant is marked `ready`, followed by a verification step — a lost or failed seed can no longer produce a `ready` tenant with an empty database.
+:::
+
 ## The core idea: push a durable copy, don't pull on the hot path
 
 The naive fix is a request-time call from the tenant Worker to the control
@@ -32,12 +36,12 @@ database**, under the control plane tenant id. The tenant Worker then reads
 rows with **no read-path change** — the tenant database is, in effect, a
 miniature control-plane-colocated database.
 
-| | Pull (cache) | **Push (projection)** |
-| --- | --- | --- |
-| Read path | new remote source, blocks on miss | existing runtime fallback, unchanged |
-| Control plane outage | cold isolate fails | serves last-known-good from D1 |
-| Freshness | bounded by cache TTL | bounded by rollout cadence |
-| Where new code lives | request path | rollout (write) path only |
+|                      | Pull (cache)                      | **Push (projection)**                |
+| -------------------- | --------------------------------- | ------------------------------------ |
+| Read path            | new remote source, blocks on miss | existing runtime fallback, unchanged |
+| Control plane outage | cold isolate fails                | serves last-known-good from D1       |
+| Freshness            | bounded by cache TTL              | bounded by rollout cadence           |
+| Where new code lives | request path                      | rollout (write) path only            |
 
 ::: tip
 Defaults, schema migrations and tenant Worker code all change at **release
@@ -144,8 +148,8 @@ sequenceDiagram
 ::: warning Keep three concepts orthogonal
 **Host** = which tenant's auth surface (`acme.token.example.com` / custom
 domain). **`deployment_type`** = which Worker serves it (control plane vs WFP).
-**`controlplane.token.example.com`** = the control plane *as itself*. A
-control-plane-*colocated* tenant is still addressed at its own host — it is not
+**`controlplane.token.example.com`** = the control plane _as itself_. A
+control-plane-_colocated_ tenant is still addressed at its own host — it is not
 reachable as the control plane.
 :::
 
@@ -171,14 +175,14 @@ code** it uses in a shared database. Nothing on the read path is WFP-aware.
 
 What gets projected (the "defaults bundle"):
 
-| Entity | Filter | Consumed on read by |
-| --- | --- | --- |
-| Connections | all | runtime fallback, matched by `strategy` |
-| Resource servers | `is_system === true` | runtime fallback scope inheritance |
-| Hooks | `metadata.inheritable === true` | runtime fallback hook inheritance |
-| Email provider | singleton | runtime fallback email-provider fallback |
-| Branding | singleton | tenant resolving control-plane branding |
-| Prompt settings | singleton | tenant resolving control-plane prompts |
+| Entity           | Filter                          | Consumed on read by                      |
+| ---------------- | ------------------------------- | ---------------------------------------- |
+| Connections      | all                             | runtime fallback, matched by `strategy`  |
+| Resource servers | `is_system === true`            | runtime fallback scope inheritance       |
+| Hooks            | `metadata.inheritable === true` | runtime fallback hook inheritance        |
+| Email provider   | singleton                       | runtime fallback email-provider fallback |
+| Branding         | singleton                       | tenant resolving control-plane branding  |
+| Prompt settings  | singleton                       | tenant resolving control-plane prompts   |
 
 ## The rollout
 
@@ -290,12 +294,12 @@ The payload carries the control plane's `jwt_signing` keys so a tenant can
 without a request-time JWKS fetch. This is security-sensitive, so the invariants
 are owned centrally:
 
-| Invariant | Enforced |
-| --- | --- |
-| Public only — never the private key | `pkcs7` stripped on build **and** re-stripped on apply |
+| Invariant                           | Enforced                                                                 |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| Public only — never the private key | `pkcs7` stripped on build **and** re-stripped on apply                   |
 | Stored as shared, not tenant-scoped | written with **no `tenant_id`**, so `listControlPlaneKeys` resolves them |
-| Verify-only by construction | with no private material the sign path physically can't use them |
-| Rotation-safe | **create-if-missing by `kid`**; old public keys are harmless to leave |
+| Verify-only by construction         | with no private material the sign path physically can't use them         |
+| Rotation-safe                       | **create-if-missing by `kid`**; old public keys are harmless to leave    |
 
 The selection (`type:jwt_signing AND -_exists_:tenant_id`) is authhero's
 `listControlPlaneKeys`, reused so the public-key query has a single source of
@@ -305,7 +309,7 @@ truth. Opt out with `buildControlPlaneDefaultsPayload(..., { signingKeys: false 
 
 A shared Google connection means the tenant Worker needs the Google
 `client_secret` to complete the token exchange. But a tenant operator may be
-able to **pull a copy of their own D1** — and must not be able to read *our*
+able to **pull a copy of their own D1** — and must not be able to read _our_
 shared secret out of it.
 
 The solution is envelope-style **keyed encryption**: control-plane-owned secrets
@@ -410,7 +414,7 @@ those templates generate.
 ### 1. Control plane Worker
 
 The control plane owns every key and serves colocated tenants from the shared
-database. Its adapters are the *source* for projection.
+database. Its adapters are the _source_ for projection.
 
 ```typescript
 import createAdapters from "@authhero/kysely-adapter";
@@ -425,7 +429,9 @@ const CONTROL_PLANE_TENANT_ID = "control_plane";
 
 // Both keys live as Worker secret bindings — never in any database.
 const tenantKey = await loadEncryptionKey(env.ENCRYPTION_KEY);
-const controlPlaneKey = await loadEncryptionKey(env.CONTROL_PLANE_ENCRYPTION_KEY);
+const controlPlaneKey = await loadEncryptionKey(
+  env.CONTROL_PLANE_ENCRYPTION_KEY,
+);
 
 // The control plane reads/writes its own rows; a single key is enough here.
 const controlPlaneAdapters: DataAdapters = createEncryptedDataAdapter(
@@ -458,7 +464,9 @@ import { withRuntimeFallback } from "@authhero/multi-tenancy";
 const CONTROL_PLANE_TENANT_ID = "control_plane";
 
 const tenantKey = await loadEncryptionKey(env.ENCRYPTION_KEY);
-const controlPlaneKey = await loadEncryptionKey(env.CONTROL_PLANE_ENCRYPTION_KEY);
+const controlPlaneKey = await loadEncryptionKey(
+  env.CONTROL_PLANE_ENCRYPTION_KEY,
+);
 
 // Encrypt this tenant's own rows under the tenant key, but control-plane-tenant
 // rows under the "cp" key id (so the operator can hold but not read them).
@@ -543,13 +551,13 @@ Every piece is additive and reversible — except one. The only one-way door is
 reference today's issuer, so do not change `ISSUER` for existing tenants; give
 new issuer hosts only to new or deliberately migrated tenants.
 
-| Change | Breaking? | Note |
-| --- | --- | --- |
-| Project defaults into tenant D1 | No | New code on the WFP/provision path; colocated tenants untouched |
-| Runtime fallback (read path) | No | Not modified — the whole point of the push model |
-| Keyed encryption | No | `enc:v1:<payload>` still decrypts; key id is additive |
-| `controlplane.*` host | No, if additive | Add as an accepted host; keep the existing/apex path working |
-| Issuer / JWT `iss` host | **Irreversible** | Pin names before any token carries them |
+| Change                          | Breaking?        | Note                                                            |
+| ------------------------------- | ---------------- | --------------------------------------------------------------- |
+| Project defaults into tenant D1 | No               | New code on the WFP/provision path; colocated tenants untouched |
+| Runtime fallback (read path)    | No               | Not modified — the whole point of the push model                |
+| Keyed encryption                | No               | `enc:v1:<payload>` still decrypts; key id is additive           |
+| `controlplane.*` host           | No, if additive  | Add as an accepted host; keep the existing/apex path working    |
+| Issuer / JWT `iss` host         | **Irreversible** | Pin names before any token carries them                         |
 
 Suggested order, each step independently shippable:
 

--- a/apps/docs/customization/multi-tenancy/database-isolation.md
+++ b/apps/docs/customization/multi-tenancy/database-isolation.md
@@ -241,6 +241,11 @@ const multiTenancy = setupMultiTenancy({
 });
 ```
 
+When the control plane carries the tenant-operations adapters, the provision run is recorded as a durable operation with step events (see [Tenant Operations](./tenant-operations.md)). Two extra knobs on `databaseIsolation` control this:
+
+- `onProvision(tenantId, report?)` — the optional second argument is a `StepReporter`; call it at step boundaries (`await report?.("run-migrations", "succeeded")`) to surface per-step events in the operation history. Ignoring it records a single coarse step.
+- `recordProvisionOperations: false` — opt out of the automatic recording when the hook manages its own operation rows (the Cloudflare Workflows hook does this).
+
 ### With Deprovisioning
 
 Add cleanup when tenants are deleted:

--- a/apps/docs/customization/multi-tenancy/index.md
+++ b/apps/docs/customization/multi-tenancy/index.md
@@ -288,6 +288,7 @@ Set any option to `false` to disable that type of synchronization if you want ch
 - [Architecture](./architecture.md) - Organization-tenant model and token-based access
 - [Database Isolation](./database-isolation.md) - Per-tenant databases with D1, Turso, or custom
 - [Tenant Lifecycle](./tenant-lifecycle.md) - Creating, managing, and deleting tenants
+- [Tenant Operations](./tenant-operations.md) - Durable lifecycle operations with an append-only history and Cloudflare Workflows execution
 - [Subdomain Routing](./subdomain-routing.md) - Route requests based on subdomains
 - [API Reference](./api-reference.md) - Complete API documentation
 - [Migration Guide](./migration.md) - Moving from single to multi-tenant

--- a/apps/docs/customization/multi-tenancy/tenant-lifecycle.md
+++ b/apps/docs/customization/multi-tenancy/tenant-lifecycle.md
@@ -288,6 +288,10 @@ const multiTenancy = setupMultiTenancy({
 
 ## Provisioning
 
+::: tip Operation history
+When the control plane carries the tenant-operations adapters, every provision run is automatically recorded as a durable operation with per-step events — queryable via `GET /api/v2/tenants/{id}/operations` and shown in the admin UI. `onProvision` also receives an optional `StepReporter` to surface custom step boundaries. See [Tenant Operations](./tenant-operations.md).
+:::
+
 ### Database Provisioning
 
 Automatically provision databases for new tenants:


### PR DESCRIPTION
Part 5/5 of the issue #1026 stack. Stacked on #1040.

## Admin UI

The parts of phase 5 that phases 1+2 can power (rollout screens come with the phase-3 coordinator):

- **Operations page** at `/tenants/:id/operations` in the control-plane area: operation history (kind, status badge with error tooltip, current step, started, duration, initiated-by); expanding a row loads the per-step event timeline (step, outcome, attempts, detail JSON). Polls every 4s while an operation is `pending`/`running` — including the expanded timeline — so workflow runs update live.
- **Redeploy button** enqueues `{ kind: "upgrade" }`; disabled while an operation is in flight; 403/501 server errors surface as notifications; deployments without the operations adapters get a friendly "not enabled" state.
- **Data provider**: `listTenantOperations` / `getTenantOperation` / `createTenantOperation` on `AuthHeroDataProvider` (same pattern as `rotateSigningKeys`).
- **Tenants list**: Operations link next to Members.
- **Routing fix**: the outer router only rendered `TenantsApp` for `/tenants` and `/tenants/create`, so a full-page load of `/tenants/:id/members` fell into the per-tenant branch with `tenantId="tenants"`. It now also matches `/tenants/:id/(members|operations)` — fixing reloads for the existing Members page too. (Separate latent issue not touched here: the Members list link builds `${basePath}/${id}/members`, which doesn't match the registered `/tenants/:tenantId/members` route.)

## Docs

Cross-references so operations are discoverable from every relevant page, not just the new `tenant-operations.md`: the multi-tenancy index, tenant-lifecycle (history tip), database-isolation + api-reference (`onProvision(tenantId, report?)` signature and `recordProvisionOperations`), control-plane-defaults (durable seed delivery), and the api-reference management-routes list.

## Tests

Admin type-check clean, 25/25 tests pass, production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Tenant Operations page to view lifecycle history, step timelines, and operation status.
  * Added a Redeploy action for tenants and new links to the Operations view from tenant lists.
  * Extended multi-tenant documentation with Tenant Operations guidance and provisioning history details.

* **Bug Fixes**
  * Improved routing for tenant members and operations subpages so they load in the correct tenant control-plane area.
  * Added automatic refresh while operations are in progress to keep status current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->