### PR TITLE
ci(conformance): report the required check on retargeted stacked PRs

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,6 +13,13 @@ on:
   pull_request:
     branches:
       - main
+    # "edited" (non-default) covers stacked PRs: when a parent PR merges and
+    # GitHub auto-retargets the child to main, no opened/synchronize event
+    # fires — without it the required conformance check is never reported and
+    # the PR is stuck on "Expected". Title/body edits also fire it, but those
+    # runs skip in seconds (non-release PRs) or dedupe via the per-SHA
+    # concurrency group below.
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
     inputs:
       grep:


### PR DESCRIPTION
## Summary

When a stacked PR's parent merges, GitHub auto-retargets the child PR to `main`. That retarget fires the `pull_request` **edited** event, which isn't in the default trigger types (`opened`, `synchronize`, `reopened`) — so the conformance workflow never runs on the retargeted PR, the required `conformance` check sits at "Expected" forever, and the PR is blocked even though the job would have been skipped anyway.

This happened on #1039 today: last push landed while its base was still the parent branch, the auto-retarget to `main` after #1044 merged fired only `edited`, and the PR stayed blocked until a close/reopen re-fired the trigger.

## Change

Add `types: [opened, synchronize, reopened, edited]` to the `pull_request` trigger so retargeted PRs get the (skipped) check reported.

Extra runs from title/body edits are harmless:
- On non-release PRs the job skips in ~1s (`if` guard).
- On the release PR, redundant runs for the same commit dedupe through the per-SHA concurrency group, and already-passed code skips via the precheck marker.

No changeset — CI-only change, no versioned package touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PR validation now re-runs when a pull request is edited, helping ensure status checks stay up to date after metadata changes.
  * Improved reliability of conformance reporting for pull requests with updated details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->