### PR TITLE
feat: durable provision-as-workflow with verify and reconciler (#1026 phase 2b, re-land)

### DIFF
--- a/.changeset/tenant-operations-workflows.md
+++ b/.changeset/tenant-operations-workflows.md
@@ -1,0 +1,11 @@
+---
+"@authhero/cloudflare-adapter": minor
+"@authhero/multi-tenancy": patch
+---
+
+Add the `@authhero/cloudflare-adapter/workflows` subpath (issue #1026 phase 2): durable provision-as-workflow for WFP tenants on Cloudflare Workflows.
+
+- `runProvisionOperation` runs the provisioner steps (via the provider-agnostic `TenantProvisionerSteps` contract) as one durable engine step each — with the defaults seed as a retried step _before_ `ready` and a `verify` step that throws until the tenant D1 actually holds signing keys and its tenant row. "Ready over an empty D1" is no longer possible.
+- `createCloudflareWorkflowsExecutor` implements the row-first `TenantOperationExecutor` contract over a structural Workflows binding (no `cloudflare:workers` import in the library; the downstream worker owns the ~10-line `WorkflowEntrypoint` shell — see `entrypoint.example.ts`).
+- `reconcileTenantOperations` sweeps operations stuck in `pending`/`running` whose engine instance died before its terminal write, copying terminal engine states into the control-plane log (run from a `scheduled` handler, at least daily).
+- `createWfpWorkflowProvisioningHook` replaces inline provisioning with a durable enqueue on tenant create; upgrade/deprovision keep delegating to the inline hook. Wire with `databaseIsolation.recordProvisionOperations: false` (new `@authhero/multi-tenancy` flag) since the workflow owns the operation row.

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -568,6 +568,10 @@ gtag('config', 'G-DNZWG3PF2L');`,
                   link: "/customization/multi-tenancy/tenant-lifecycle",
                 },
                 {
+                  text: "Tenant Operations",
+                  link: "/customization/multi-tenancy/tenant-operations",
+                },
+                {
                   text: "Runtime Fallback",
                   link: "/customization/multi-tenancy/runtime-fallback",
                 },

--- a/apps/docs/customization/multi-tenancy/tenant-operations.md
+++ b/apps/docs/customization/multi-tenancy/tenant-operations.md
@@ -1,0 +1,105 @@
+---
+title: Tenant Operations
+description: Durable tenant lifecycle operations (provision, upgrade, backup) with an append-only history, an inline executor, and a Cloudflare Workflows engine.
+---
+
+# Tenant Operations
+
+Tenant lifecycle work — provisioning a WFP tenant's D1, seeding its defaults, upgrading its worker bundle — used to run as one-shot imperative sequences: no retries surviving a redeploy, no history of what was attempted, and a failed seed could leave a tenant marked `ready` over an empty database.
+
+Tenant operations (issue #1026) fix this with two pieces:
+
+1. **A control-plane log**: `tenant_operations` (one row per run: kind, status, engine, error, timestamps) and `tenant_operation_events` (append-only per-step history). The tenant row's `provisioning_state` / `worker_version` / `database_version` stay the _current-state snapshot_; operations are the log explaining how it got there.
+2. **Swappable executors**: an inline executor that runs steps synchronously, and a Cloudflare Workflows executor that runs the same steps durably with per-step retries. The control-plane database is always the source of truth — the engine is just the executor.
+
+## Data model
+
+The tables are **control-plane only** — they never exist in a WFP tenant's D1:
+
+- **kysely**: shipped in the normal migration chain (kysely only runs control planes).
+- **drizzle**: shipped as a separate `drizzle-control-plane/` migration set with its own journal. Apply it _in addition to_ the core set, with a distinct migrations table:
+
+```typescript
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+
+migrate(db, { migrationsFolder: "node_modules/@authhero/drizzle/drizzle" });
+migrate(db, {
+  migrationsFolder: "node_modules/@authhero/drizzle/drizzle-control-plane",
+  migrationsTable: "__drizzle_migrations_control_plane",
+});
+```
+
+Then opt the adapter factory in — the adapters' presence is also what mounts the management routes:
+
+```typescript
+const adapters = createAdapters(db, { controlPlane: true });
+```
+
+## Recording (no behavior change)
+
+When the control plane carries the operations adapters, `createProvisioningHooks` automatically wraps `databaseIsolation.onProvision` so every provision writes an operation row with step events (`provision-resources`, `seed-defaults` when using the WFP hook). Failures are recorded with the error and rethrown — rollback semantics are unchanged, and a deployment without the adapters behaves exactly as before.
+
+## Management API
+
+Mounted only when the operations adapters are present. Scopes: `read:tenant_operations`, `create:tenant_operations`.
+
+| Route                                  | Purpose                                                                                            |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `GET /api/v2/tenants/{id}/operations`  | Paginated history for a tenant (filters: `kind`, `status`)                                         |
+| `GET /api/v2/operations/{id}`          | One operation plus its full event timeline                                                         |
+| `POST /api/v2/tenants/{id}/operations` | Enqueue `{ "kind": "upgrade" }` (control-plane only; retry = enqueue again — steps are idempotent) |
+
+Clients poll `GET /operations/{id}` while an operation runs; the inline engine returns it already terminal.
+
+## Durable provisioning on Cloudflare Workflows
+
+`@authhero/cloudflare-adapter/workflows` runs the full provision sequence as one durable engine instance per tenant:
+
+```
+mark-running → create-database → apply-migrations → upload-script →
+upload-secrets → seed-defaults → verify → mark-ready
+```
+
+Two steps close the "ready but empty D1" incident class permanently:
+
+- **seed-defaults** is a retried step _before_ `ready` whose per-entity errors fail the operation (not a `console.error`).
+- **verify** queries the tenant D1 (via the same REST path migrations use) and throws until it actually holds signing keys and the tenant row — a propagation race becomes a few retried verifies.
+
+The workflow writes back to the operation log inside every `step.do`, so the history is durable too. If an instance dies before its terminal write, `reconcileTenantOperations` (run from the worker's `scheduled` handler — at least daily; engine retention is 30 days) copies the engine's terminal state into the database.
+
+### Wiring the downstream worker
+
+The deploy repo owns the ~10-line `WorkflowEntrypoint` shell (only it can import `cloudflare:workers`); everything else comes from the library. See `entrypoint.example.ts` in `@authhero/cloudflare-adapter` for the full reference, including `buildProvisionDeps(env)` and the `scheduled` handler.
+
+Tenant create flips from inline provisioning to a durable enqueue:
+
+```typescript
+const workflowHook = createWfpWorkflowProvisioningHook({
+  tenants: adapters.tenants,
+  inline: inlineHook, // upgrade/deprovision stay inline for now
+  enqueueOperation: (input) =>
+    enqueueTenantOperation(
+      stores,
+      createCloudflareWorkflowsExecutor({
+        binding: env.TENANT_OPERATIONS_WORKFLOW,
+      }),
+      input,
+    ),
+});
+
+// databaseIsolation: {
+//   onProvision: workflowHook.onProvision,
+//   onDeprovision: workflowHook.onDeprovision,
+//   recordProvisionOperations: false, // the workflow owns the operation row
+// }
+```
+
+::: warning Semantic change
+With the workflow hook, tenant-create returns while the tenant is still `provisioning_state: "pending"` — the workflow marks it `ready` (or `failed`). Clients must poll the tenant row or the operations API instead of assuming a synchronous `ready`. Any best-effort post-create seed should be deleted; the seed is a durable step inside the workflow.
+:::
+
+Rollout order for an existing deployment: apply the control-plane migrations, deploy the worker with both paths available, then flip tenant-create to the workflow hook.
+
+## Roadmap
+
+Later phases add per-tenant durable upgrades, fleet rollouts (waves + canary + health gate over the `rollouts` table), and D1 Time Travel backups — see [issue #1026](https://github.com/markusahlstrand/authhero/issues/1026).

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -28,6 +28,11 @@
       "types": "./dist/wfp.d.ts",
       "require": "./dist/wfp.cjs",
       "import": "./dist/wfp.mjs"
+    },
+    "./workflows": {
+      "types": "./dist/workflows.d.ts",
+      "require": "./dist/workflows.cjs",
+      "import": "./dist/workflows.mjs"
     }
   },
   "scripts": {

--- a/packages/cloudflare/rollup.dts.config.mjs
+++ b/packages/cloudflare/rollup.dts.config.mjs
@@ -15,4 +15,10 @@ export default [
     external,
     plugins: [dts({ respectExternal: false })],
   },
+  {
+    input: "./dist/types/workflows/index.d.ts",
+    output: { file: "./dist/workflows.d.ts", format: "es" },
+    external,
+    plugins: [dts({ respectExternal: false })],
+  },
 ];

--- a/packages/cloudflare/src/workflows/enqueue-hook.ts
+++ b/packages/cloudflare/src/workflows/enqueue-hook.ts
@@ -1,0 +1,95 @@
+import type {
+  TenantOperation,
+  TenantsDataAdapter,
+} from "@authhero/adapter-interfaces";
+import type {
+  WfpTenantProvisioningHook,
+  WfpProvisioningStepReporter,
+} from "../wfp-provisioner/tenant-hook";
+
+export interface WfpWorkflowProvisioningHookOptions {
+  tenants: TenantsDataAdapter;
+  /**
+   * Enqueues a provision operation on the durable engine — typically
+   * `(input) => enqueueTenantOperation(stores, createCloudflareWorkflowsExecutor({ binding }), input)`.
+   * Resolves as soon as the engine instance is created.
+   */
+  enqueueOperation: (input: {
+    kind: "provision";
+    tenant_id: string;
+    initiated_by?: string;
+  }) => Promise<TenantOperation>;
+  /** Same gate + default as the inline hook: `deployment_type === "wfp"`. */
+  shouldProvision?: (tenant: {
+    id: string;
+    deployment_type?: string;
+    storage_kind?: string;
+  }) => boolean;
+  /**
+   * The existing inline hook (`createWfpTenantProvisioningHook(...)`).
+   * Upgrade and deprovision keep running inline until later phases make
+   * them durable.
+   */
+  inline: WfpTenantProvisioningHook;
+}
+
+/**
+ * Drop-in replacement for `createWfpTenantProvisioningHook` on control
+ * planes that run provisioning through Cloudflare Workflows (issue #1026
+ * phase 2): `onProvision` enqueues a durable provision operation and
+ * returns immediately, leaving the tenant `pending` — the workflow's
+ * `mark-ready` / `mark-failed` steps own the terminal snapshot writes, and
+ * the reconciler covers instances that die mid-run.
+ *
+ * Semantic change to plan for downstream: tenant-create now returns with
+ * `provisioning_state: "pending"`; clients poll the tenant row or the
+ * operations API. An enqueue failure still throws, so
+ * `createProvisioningHooks.afterCreate` rolls the tenant row back exactly
+ * like an inline provision failure does today. This also replaces any
+ * best-effort post-create seed — the seed is a durable step inside the
+ * workflow.
+ *
+ * Wire it with `databaseIsolation.recordProvisionOperations: false` — this
+ * hook's `enqueueOperation` creates the operation row itself, and the
+ * multi-tenancy recording wrapper would otherwise write a second row that
+ * gets marked succeeded while the engine run is still in flight.
+ */
+export function createWfpWorkflowProvisioningHook(
+  options: WfpWorkflowProvisioningHookOptions,
+): WfpTenantProvisioningHook {
+  const shouldProvision =
+    options.shouldProvision ??
+    ((tenant: { deployment_type?: string }) =>
+      tenant.deployment_type === "wfp");
+
+  return {
+    async onProvision(
+      tenantId: string,
+      _report?: WfpProvisioningStepReporter,
+    ): Promise<void> {
+      const tenant = await options.tenants.get(tenantId);
+      if (!tenant) return; // Mid-rollback race — nothing to do.
+      if (!shouldProvision(tenant)) return; // Shared deployment, skip.
+
+      // The workflow writes its own step events; the caller's coarse
+      // reporter (from runRecordedTenantOperation) is intentionally unused
+      // — the durable path creates its own operation row via
+      // enqueueOperation.
+      await options.enqueueOperation({
+        kind: "provision",
+        tenant_id: tenantId,
+      });
+    },
+
+    async onUpgrade(
+      tenantId: string,
+      report?: WfpProvisioningStepReporter,
+    ): Promise<void> {
+      await options.inline.onUpgrade(tenantId, report);
+    },
+
+    async onDeprovision(tenantId: string): Promise<void> {
+      await options.inline.onDeprovision(tenantId);
+    },
+  };
+}

--- a/packages/cloudflare/src/workflows/entrypoint.example.ts
+++ b/packages/cloudflare/src/workflows/entrypoint.example.ts
@@ -1,0 +1,118 @@
+/**
+ * REFERENCE ONLY — not part of the published bundle (nothing imports it).
+ *
+ * The downstream control-plane worker (the deploy repo) owns the
+ * `WorkflowEntrypoint` shell, because `cloudflare:workers` only exists in
+ * the Workers runtime. Everything else — orchestration, verify, write-back
+ * — comes from `@authhero/cloudflare-adapter/workflows`.
+ *
+ * wrangler.jsonc:
+ * ```jsonc
+ * {
+ *   "workflows": [
+ *     {
+ *       "name": "tenant-operations",
+ *       "binding": "TENANT_OPERATIONS_WORKFLOW",
+ *       "class_name": "TenantOperationWorkflow"
+ *     }
+ *   ],
+ *   // Reconciler cadence: at least daily (engine retention is 30 days);
+ *   // every 15–60 minutes recommended.
+ *   "triggers": { "crons": ["0,30 * * * *"] }
+ * }
+ * ```
+ *
+ * Worker module:
+ * ```ts
+ * import { WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from "cloudflare:workers";
+ * import {
+ *   createProvisionVerifier,
+ *   createCloudflareWorkflowsExecutor,
+ *   createWfpWorkflowProvisioningHook,
+ *   reconcileTenantOperations,
+ *   runProvisionOperation,
+ *   type ProvisionOperationDeps,
+ *   type TenantOperationWorkflowParams,
+ * } from "@authhero/cloudflare-adapter/workflows";
+ * import { enqueueTenantOperation } from "@authhero/multi-tenancy";
+ * import {
+ *   createWfpProvisionerSteps,
+ *   createWfpTenantProvisioningHook,
+ *   CloudflareApiClient,
+ * } from "@authhero/cloudflare-adapter";
+ * import { createDispatchSyncDefaults } from "@authhero/cloudflare-adapter/wfp";
+ *
+ * // Host-owned: build every workflow dependency from the worker env. Params
+ * // carry only { operation_id, tenant_id, kind } — never secrets.
+ * function buildProvisionDeps(env: Env): ProvisionOperationDeps {
+ *   const adapters = createControlPlaneAdapters(env); // host's DB wiring
+ *   const steps = createWfpProvisionerSteps({
+ *     accountId: env.CLOUDFLARE_ACCOUNT_ID,
+ *     apiToken: env.CLOUDFLARE_API_TOKEN,
+ *     dispatchNamespace: "authhero-tenants",
+ *     controlPlaneBaseUrl: env.PUBLIC_BASE_URL,
+ *     tenantWorkerScript,
+ *     migrations,
+ *     secrets: async (tenantId) => ({ ... }),
+ *   });
+ *   return {
+ *     steps,
+ *     tenants: adapters.tenants,
+ *     stores: {
+ *       tenantOperations: adapters.tenantOperations!,
+ *       tenantOperationEvents: adapters.tenantOperationEvents!,
+ *     },
+ *     syncDefaults: createDispatchSyncDefaults({ ... }),
+ *     verify: createProvisionVerifier({ client: steps.client }),
+ *   };
+ * }
+ *
+ * export class TenantOperationWorkflow extends WorkflowEntrypoint<Env, TenantOperationWorkflowParams> {
+ *   async run(event: WorkflowEvent<TenantOperationWorkflowParams>, step: WorkflowStep) {
+ *     // CF's WorkflowStep satisfies StepRunner structurally.
+ *     await runProvisionOperation(buildProvisionDeps(this.env), event.payload, step);
+ *   }
+ * }
+ *
+ * export default {
+ *   fetch: app.fetch,
+ *   async scheduled(_controller: ScheduledController, env: Env) {
+ *     const adapters = createControlPlaneAdapters(env);
+ *     const result = await reconcileTenantOperations({
+ *       stores: {
+ *         tenantOperations: adapters.tenantOperations!,
+ *         tenantOperationEvents: adapters.tenantOperationEvents!,
+ *       },
+ *       tenants: adapters.tenants,
+ *       binding: env.TENANT_OPERATIONS_WORKFLOW,
+ *     });
+ *     console.log("reconcileTenantOperations", result);
+ *   },
+ * };
+ *
+ * // Tenant create wiring — replaces the inline provision (and any
+ * // best-effort post-create seed) with a durable enqueue:
+ * const inlineHook = createWfpTenantProvisioningHook({ provisioner, tenants, syncDefaults });
+ * const workflowHook = createWfpWorkflowProvisioningHook({
+ *   tenants: adapters.tenants,
+ *   inline: inlineHook, // upgrade/deprovision stay inline until phase 3/4
+ *   enqueueOperation: (input) =>
+ *     enqueueTenantOperation(
+ *       stores,
+ *       createCloudflareWorkflowsExecutor({ binding: env.TENANT_OPERATIONS_WORKFLOW }),
+ *       input,
+ *     ),
+ * });
+ * // databaseIsolation: {
+ * //   getAdapters,
+ * //   onProvision: workflowHook.onProvision,
+ * //   onDeprovision: workflowHook.onDeprovision,
+ * //   recordProvisionOperations: false, // the workflow owns the operation row
+ * // }
+ * ```
+ *
+ * Rollout order for existing deployments: apply the control-plane
+ * migrations first, deploy the worker with both paths available, then flip
+ * tenant-create to the workflow hook.
+ */
+export {};

--- a/packages/cloudflare/src/workflows/executor.ts
+++ b/packages/cloudflare/src/workflows/executor.ts
@@ -1,0 +1,63 @@
+import type { TenantOperation } from "@authhero/adapter-interfaces";
+import {
+  buildEngineInstanceId,
+  type TenantOperationExecutor,
+} from "@authhero/multi-tenancy";
+import type { WorkflowsBinding } from "./types";
+
+export interface CloudflareWorkflowsExecutorOptions {
+  binding: WorkflowsBinding;
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /already exists|already been created|duplicate/i.test(message);
+}
+
+/**
+ * `TenantOperationExecutor` backed by a Cloudflare Workflows binding
+ * (issue #1026 phase 2). Row-first contract: `enqueueTenantOperation` has
+ * already persisted the operation (with its deterministic
+ * `engine_instance_id`) before `start` is called, so an instance can never
+ * exist without a tracking row.
+ *
+ * `start` resolves as soon as the instance is created — the workflow owns
+ * every subsequent write. Creating an instance whose id already exists is
+ * treated as success (idempotent re-enqueue after a crashed caller).
+ */
+export function createCloudflareWorkflowsExecutor(
+  options: CloudflareWorkflowsExecutorOptions,
+): TenantOperationExecutor {
+  return {
+    engine: "cloudflare-workflows",
+
+    async start(operation: TenantOperation): Promise<void> {
+      if (operation.kind !== "provision") {
+        throw new Error(
+          `The Cloudflare Workflows executor does not support "${operation.kind}" operations yet (phase 2 covers provision only)`,
+        );
+      }
+      if (!operation.tenant_id) {
+        throw new Error("provision operations require a tenant_id");
+      }
+
+      const id =
+        operation.engine_instance_id ?? buildEngineInstanceId(operation);
+
+      try {
+        await options.binding.create({
+          id,
+          params: {
+            operation_id: operation.id,
+            tenant_id: operation.tenant_id,
+            kind: operation.kind,
+          },
+        });
+      } catch (error) {
+        if (!isAlreadyExistsError(error)) throw error;
+        // The instance was already created by a previous (crashed) enqueue —
+        // the run is in flight or finished; nothing more to do.
+      }
+    },
+  };
+}

--- a/packages/cloudflare/src/workflows/index.ts
+++ b/packages/cloudflare/src/workflows/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Durable tenant lifecycle operations on Cloudflare Workflows
+ * (issue #1026 phase 2). The control-plane database is the source of
+ * truth; the engine is the executor — the workflow writes back to the
+ * `tenant_operations` / `tenant_operation_events` log at every step
+ * boundary, and `reconcileTenantOperations` sweeps up instances that died
+ * before their terminal write.
+ *
+ * Requires the optional `@authhero/multi-tenancy` peer (like `./wfp`).
+ * Nothing here imports `cloudflare:workers`: the downstream worker
+ * provides the ~10-line `WorkflowEntrypoint` shell (see
+ * `entrypoint.example.ts`) whose `WorkflowStep` satisfies `StepRunner`
+ * structurally.
+ */
+export {
+  runProvisionOperation,
+  type ProvisionOperationDeps,
+  type ProvisionStepName,
+} from "./provision-operation";
+export {
+  createProvisionVerifier,
+  TenantProvisionVerificationError,
+  type ProvisionVerifierOptions,
+} from "./verify";
+export {
+  createCloudflareWorkflowsExecutor,
+  type CloudflareWorkflowsExecutorOptions,
+} from "./executor";
+export {
+  reconcileTenantOperations,
+  type ReconcileTenantOperationsOptions,
+  type ReconcileTenantOperationsResult,
+} from "./reconcile";
+export {
+  createWfpWorkflowProvisioningHook,
+  type WfpWorkflowProvisioningHookOptions,
+} from "./enqueue-hook";
+export {
+  TENANT_OPERATION_ENGINE,
+  type TenantOperationWorkflowParams,
+  type WorkflowInstanceHandle,
+  type WorkflowInstanceStatus,
+  type WorkflowsBinding,
+} from "./types";

--- a/packages/cloudflare/src/workflows/provision-operation.ts
+++ b/packages/cloudflare/src/workflows/provision-operation.ts
@@ -1,0 +1,301 @@
+import type { TenantsDataAdapter } from "@authhero/adapter-interfaces";
+import {
+  createOperationRecorder,
+  type StepConfig,
+  type StepRunner,
+  type TenantOperationStores,
+} from "@authhero/multi-tenancy";
+import type { TenantProvisionerSteps } from "../wfp-provisioner/provisioner-steps";
+import { collectSyncDefaultsErrors } from "../wfp-provisioner/sync-defaults-errors";
+import type { TenantOperationWorkflowParams } from "./types";
+
+export type ProvisionStepName =
+  | "mark-running"
+  | "create-database"
+  | "apply-migrations"
+  | "upload-script"
+  | "upload-secrets"
+  | "seed-defaults"
+  | "verify"
+  | "mark-ready"
+  | "mark-failed";
+
+export interface ProvisionOperationDeps {
+  /** Provider-agnostic provisioner steps (all idempotent) — e.g.
+   * `createWfpProvisionerSteps` for Cloudflare WFP + D1. */
+  steps: TenantProvisionerSteps;
+  /** Control-plane tenants adapter (snapshot writes). */
+  tenants: TenantsDataAdapter;
+  /** Control-plane operation log stores. */
+  stores: TenantOperationStores;
+  /**
+   * Defaults seed (`createDispatchSyncDefaults(...)`). Runs as a retried
+   * step BEFORE `ready`; per-entity errors in the resolved result fail the
+   * step. Optional only for parity with the inline hook — WFP control
+   * planes should always set it.
+   */
+  syncDefaults?: (tenantId: string) => Promise<unknown>;
+  /**
+   * Post-seed verification (`createProvisionVerifier(...)`). Throws until
+   * the tenant database actually holds keys + the tenant row; retried with backoff so a
+   * propagation race becomes a few retries instead of a bad `ready`.
+   */
+  verify?: (databaseId: string, tenantId: string) => Promise<void>;
+  /** Same gate + default as the inline hook: `deployment_type === "wfp"`. */
+  shouldProvision?: (tenant: {
+    id: string;
+    deployment_type?: string;
+    storage_kind?: string;
+  }) => boolean;
+  logger?: Pick<Console, "warn">;
+  /** Per-step overrides of the retry/timeout defaults. */
+  stepConfig?: Partial<Record<ProvisionStepName, StepConfig>>;
+}
+
+const DEFAULT_STEP_CONFIG: StepConfig = {
+  retries: { limit: 5, delay: "5 seconds", backoff: "exponential" },
+  timeout: "2 minutes",
+};
+
+// The verify step retries longer with wider gaps: it exists to absorb
+// propagation races between the seed landing and the data being readable.
+const DEFAULT_VERIFY_CONFIG: StepConfig = {
+  retries: { limit: 8, delay: "10 seconds", backoff: "exponential" },
+  timeout: "1 minute",
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Durable provision-as-workflow (issue #1026 phase 2): the full provision
+ * sequence — resources, migrations, script, secrets, seed, verify — as one
+ * engine step per unit, writing back to the control-plane operation log at
+ * every step boundary. The DB write happens inside the same `step.do` as
+ * the side effect, so it is durable and retried with the step; all side
+ * effects are idempotent, which makes replay after a retry or eviction
+ * safe.
+ *
+ * Terminal writes: `mark-ready` flips the tenant snapshot to `ready` and
+ * the operation to `succeeded`; any failure runs `mark-failed` (persisting
+ * whatever resource ids exist, mirroring the inline hook's failed branch)
+ * and rethrows so the engine instance ends `errored`. If even `mark-failed`
+ * dies, the operation stays `running` and the reconciler sweep copies the
+ * engine's terminal state into the DB.
+ *
+ * Runs against any `StepRunner` — Cloudflare's `WorkflowStep` satisfies it
+ * structurally, and tests use fakes.
+ */
+export async function runProvisionOperation(
+  deps: ProvisionOperationDeps,
+  params: TenantOperationWorkflowParams,
+  step: StepRunner,
+): Promise<void> {
+  const recorder = createOperationRecorder(deps.stores);
+  const shouldProvision =
+    deps.shouldProvision ??
+    ((tenant: { deployment_type?: string }) =>
+      tenant.deployment_type === "wfp");
+
+  const config = (name: ProvisionStepName): StepConfig =>
+    deps.stepConfig?.[name] ??
+    (name === "verify" ? DEFAULT_VERIFY_CONFIG : DEFAULT_STEP_CONFIG);
+
+  const operationId = params.operation_id;
+  const tenantId = params.tenant_id;
+
+  // 1. mark-running — load + gate the tenant, validate config, flip the
+  // operation to running. A missing/non-wfp tenant is a benign race with a
+  // tenant rollback: close the operation as skipped without failing the
+  // engine instance.
+  const started = await step.do(
+    "mark-running",
+    config("mark-running"),
+    async (): Promise<{
+      skipped: boolean;
+      scriptName: string;
+      databaseName: string;
+      databaseVersion?: string;
+      bundleConfiguration?: string;
+      workerVersion?: string;
+    }> => {
+      const tenant = await deps.tenants.get(tenantId);
+      if (!tenant || !shouldProvision(tenant)) {
+        await recorder.appendEvent(operationId, {
+          step: "mark-running",
+          outcome: "skipped",
+          detail: {
+            reason: tenant
+              ? "tenant is not WFP-provisioned"
+              : "tenant row missing (rolled back?)",
+          },
+        });
+        await recorder.markSucceeded(operationId);
+        return { skipped: true, scriptName: "", databaseName: "" };
+      }
+
+      // Config validation runs here so an oversize migration name fails the
+      // run BEFORE any Cloudflare side effects.
+      const versions = deps.steps.validate();
+      const names = deps.steps.names(tenantId);
+
+      await recorder.markRunning(operationId, "mark-running");
+      await recorder.appendEvent(operationId, {
+        step: "mark-running",
+        outcome: "succeeded",
+      });
+      return { skipped: false, ...names, ...versions };
+    },
+  );
+
+  if (started.skipped) return;
+
+  const resourceIds: {
+    d1_database_id?: string;
+    worker_script_name: string;
+    bundle_configuration?: string;
+    worker_version?: string;
+    database_version?: string;
+  } = {
+    worker_script_name: started.scriptName,
+    bundle_configuration: started.bundleConfiguration,
+    worker_version: started.workerVersion,
+    database_version: started.databaseVersion,
+  };
+
+  try {
+    // 2. create-database
+    const database = await step.do(
+      "create-database",
+      config("create-database"),
+      async (): Promise<{ databaseId: string; created: boolean }> => {
+        await recorder.setCurrentStep(operationId, "create-database");
+        const { id, created } = await deps.steps.findOrCreateDatabase(
+          started.databaseName,
+        );
+        await recorder.appendEvent(operationId, {
+          step: "create-database",
+          outcome: "succeeded",
+          detail: { database_id: id, created },
+        });
+        return { databaseId: id, created };
+      },
+    );
+    resourceIds.d1_database_id = database.databaseId;
+
+    // 3. apply-migrations — tracking-table reconcile; `created` comes from
+    // step 2's memoized result, so the pair stays consistent on replay.
+    await step.do("apply-migrations", config("apply-migrations"), async () => {
+      await recorder.setCurrentStep(operationId, "apply-migrations");
+      await deps.steps.applyMigrations(database.databaseId, database.created);
+      await recorder.appendEvent(operationId, {
+        step: "apply-migrations",
+        outcome: "succeeded",
+        detail: { database_version: started.databaseVersion },
+      });
+    });
+
+    // 4. upload-script
+    await step.do("upload-script", config("upload-script"), async () => {
+      await recorder.setCurrentStep(operationId, "upload-script");
+      await deps.steps.uploadScript(started.scriptName, database.databaseId);
+      await recorder.appendEvent(operationId, {
+        step: "upload-script",
+        outcome: "succeeded",
+        detail: { worker_version: started.workerVersion },
+      });
+    });
+
+    // 5. upload-secrets — secrets are resolved inside the step from deps
+    // (built from worker env); they never appear in params or step output.
+    await step.do("upload-secrets", config("upload-secrets"), async () => {
+      await recorder.setCurrentStep(operationId, "upload-secrets");
+      await deps.steps.uploadSecrets(started.scriptName, tenantId);
+      await recorder.appendEvent(operationId, {
+        step: "upload-secrets",
+        outcome: "succeeded",
+      });
+    });
+
+    // 6. seed-defaults — the incident fix, part 1: the seed is a durable,
+    // retried step whose failure fails the operation, not a console.error.
+    if (deps.syncDefaults) {
+      const syncDefaults = deps.syncDefaults;
+      await step.do("seed-defaults", config("seed-defaults"), async () => {
+        await recorder.setCurrentStep(operationId, "seed-defaults");
+        const result = await syncDefaults(tenantId);
+        const seedErrors = collectSyncDefaultsErrors(result);
+        if (seedErrors.length > 0) {
+          throw new Error(
+            `sync-defaults seed reported ${seedErrors.length} error(s): ${seedErrors.join("; ")}`,
+          );
+        }
+        await recorder.appendEvent(operationId, {
+          step: "seed-defaults",
+          outcome: "succeeded",
+        });
+      });
+    }
+
+    // 7. verify — the incident fix, part 2: "ready over an empty database" is
+    // impossible because this step throws (and retries) until the data is
+    // actually there.
+    if (deps.verify) {
+      const verify = deps.verify;
+      await step.do("verify", config("verify"), async () => {
+        await recorder.setCurrentStep(operationId, "verify");
+        await verify(database.databaseId, tenantId);
+        await recorder.appendEvent(operationId, {
+          step: "verify",
+          outcome: "succeeded",
+        });
+      });
+    }
+
+    // 8. mark-ready — both terminal writes in one step: the tenant snapshot
+    // and the operation row.
+    await step.do("mark-ready", config("mark-ready"), async () => {
+      await recorder.setCurrentStep(operationId, "mark-ready");
+      await deps.tenants.update(tenantId, {
+        ...resourceIds,
+        provisioning_state: "ready",
+        provisioning_error: undefined,
+        provisioning_state_changed_at: new Date().toISOString(),
+      });
+      await recorder.appendEvent(operationId, {
+        step: "mark-ready",
+        outcome: "succeeded",
+      });
+      await recorder.markSucceeded(operationId);
+    });
+  } catch (error) {
+    // Terminal failure path: persist whatever resource ids exist (so a
+    // re-provision can find them — mirrors the inline hook), mark the
+    // tenant + operation failed, then rethrow so the instance ends
+    // `errored`. If this step itself dies, the reconciler takes over.
+    await step.do("mark-failed", config("mark-failed"), async () => {
+      const message = errorMessage(error);
+      try {
+        await deps.tenants.update(tenantId, {
+          ...resourceIds,
+          provisioning_state: "failed",
+          provisioning_error: message.slice(0, 2048),
+          provisioning_state_changed_at: new Date().toISOString(),
+        });
+      } catch (writeErr) {
+        deps.logger?.warn(
+          `Failed to write provisioning_state="failed" for tenant ${tenantId}:`,
+          writeErr,
+        );
+      }
+      await recorder.appendEvent(operationId, {
+        step: "mark-failed",
+        outcome: "failed",
+        detail: { message },
+      });
+      await recorder.markFailed(operationId, error);
+    });
+    throw error;
+  }
+}

--- a/packages/cloudflare/src/workflows/reconcile.ts
+++ b/packages/cloudflare/src/workflows/reconcile.ts
@@ -1,0 +1,181 @@
+import type {
+  TenantOperation,
+  TenantsDataAdapter,
+} from "@authhero/adapter-interfaces";
+import {
+  buildEngineInstanceId,
+  createOperationRecorder,
+  isTerminalStatus,
+  type TenantOperationStores,
+} from "@authhero/multi-tenancy";
+import { TENANT_OPERATION_ENGINE, type WorkflowsBinding } from "./types";
+
+export interface ReconcileTenantOperationsOptions {
+  stores: TenantOperationStores;
+  tenants: TenantsDataAdapter;
+  binding: WorkflowsBinding;
+  /**
+   * Only touch operations whose `updated_at` is older than this — fresh
+   * runs write at every step boundary, so a recently-updated operation is
+   * alive. Default 10 minutes.
+   */
+  minAgeMs?: number;
+  /** Max stuck operations per sweep. Default 100. */
+  limit?: number;
+  logger?: Pick<Console, "warn">;
+}
+
+export interface ReconcileTenantOperationsResult {
+  scanned: number;
+  markedFailed: number;
+  markedSucceeded: number;
+  stillRunning: number;
+  instanceMissing: number;
+  errors: number;
+}
+
+/**
+ * Sweep for operations stuck in `pending`/`running` whose engine instance
+ * died before reaching its own terminal write (issue #1026): resolve the
+ * instance (via the stored — or re-derived, it's deterministic — id), and
+ * copy terminal engine states into the control-plane DB.
+ *
+ * The engine retains completed-instance state for at most 30 days, so
+ * hosts must run this at least daily; every 15–60 minutes is recommended
+ * (wire it to the worker's `scheduled` handler). One operation's engine
+ * error never aborts the sweep.
+ *
+ * Decision table per stuck operation:
+ * - handle lookup throws (expired / never created) → `failed`
+ * - engine `errored` / `terminated` → `failed` (engine error copied)
+ * - engine `complete` but operation non-terminal (the final write raced or
+ *   was lost) → decided from the tenant snapshot, which is the source of
+ *   truth: `provisioning_state === "ready"` → `succeeded`, else `failed`
+ * - anything else → still running, left untouched
+ */
+export async function reconcileTenantOperations(
+  options: ReconcileTenantOperationsOptions,
+): Promise<ReconcileTenantOperationsResult> {
+  const { stores, tenants, binding } = options;
+  const recorder = createOperationRecorder(stores);
+  const minAgeMs = options.minAgeMs ?? 10 * 60 * 1000;
+  const limit = options.limit ?? 100;
+
+  const cutoff = new Date(Date.now() - minAgeMs).toISOString();
+  const { operations } = await stores.tenantOperations.list({
+    status: ["pending", "running"],
+    engine: TENANT_OPERATION_ENGINE,
+    updated_before: cutoff,
+    per_page: limit,
+  });
+
+  const result: ReconcileTenantOperationsResult = {
+    scanned: operations.length,
+    markedFailed: 0,
+    markedSucceeded: 0,
+    stillRunning: 0,
+    instanceMissing: 0,
+    errors: 0,
+  };
+
+  for (const operation of operations) {
+    try {
+      await reconcileOne(operation);
+    } catch (error) {
+      result.errors++;
+      options.logger?.warn(
+        `Failed to reconcile tenant operation ${operation.id}:`,
+        error,
+      );
+    }
+  }
+
+  return result;
+
+  async function markFailed(
+    operation: TenantOperation,
+    reason: string,
+  ): Promise<void> {
+    await recorder.appendEvent(operation.id, {
+      step: operation.current_step ?? "reconcile",
+      outcome: "reconciled",
+      detail: { resolution: "failed", reason },
+    });
+    await recorder.markFailed(operation.id, reason);
+
+    // A provision that died mid-run can leave the tenant snapshot stuck in
+    // `pending` — surface the failure there too.
+    if (operation.kind === "provision" && operation.tenant_id) {
+      const tenant = await tenants.get(operation.tenant_id);
+      if (tenant?.provisioning_state === "pending") {
+        await tenants.update(operation.tenant_id, {
+          provisioning_state: "failed",
+          provisioning_error: reason.slice(0, 2048),
+          provisioning_state_changed_at: new Date().toISOString(),
+        });
+      }
+    }
+  }
+
+  async function reconcileOne(operation: TenantOperation): Promise<void> {
+    // Re-check terminality: an instance may have finished (and written its
+    // terminal state) between the list query and now.
+    const current = await stores.tenantOperations.get(operation.id);
+    if (!current || isTerminalStatus(current.status)) return;
+
+    const instanceId =
+      current.engine_instance_id ?? buildEngineInstanceId(current);
+
+    let handle;
+    try {
+      handle = await binding.get(instanceId);
+    } catch {
+      result.instanceMissing++;
+      result.markedFailed++;
+      await markFailed(
+        current,
+        `engine instance "${instanceId}" not found (expired past retention or never started)`,
+      );
+      return;
+    }
+
+    const status = await handle.status();
+
+    if (status.status === "errored" || status.status === "terminated") {
+      const engineError =
+        typeof status.error === "string"
+          ? status.error
+          : (status.error?.message ?? `engine reported ${status.status}`);
+      result.markedFailed++;
+      await markFailed(current, engineError);
+      return;
+    }
+
+    if (status.status === "complete") {
+      // The run completed but its terminal DB write was lost. The tenant
+      // snapshot is the source of truth for what actually happened.
+      const tenant = current.tenant_id
+        ? await tenants.get(current.tenant_id)
+        : null;
+      if (tenant?.provisioning_state === "ready") {
+        result.markedSucceeded++;
+        await recorder.appendEvent(current.id, {
+          step: current.current_step ?? "reconcile",
+          outcome: "reconciled",
+          detail: { resolution: "succeeded" },
+        });
+        await recorder.markSucceeded(current.id);
+      } else {
+        result.markedFailed++;
+        await markFailed(
+          current,
+          "engine instance completed but the operation was never finalized and the tenant is not ready",
+        );
+      }
+      return;
+    }
+
+    // queued / running / waiting / unknown — leave it for the next sweep.
+    result.stillRunning++;
+  }
+}

--- a/packages/cloudflare/src/workflows/types.ts
+++ b/packages/cloudflare/src/workflows/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Structural types for the Cloudflare Workflows engine. Deliberately NOT
+ * imported from `cloudflare:workers` / `@cloudflare/workers-types` — this
+ * package ships platform-agnostic bundles and the real runtime objects
+ * satisfy these shapes structurally (precedent: `@authhero/proxy`'s local
+ * binding types). Only the downstream worker's `WorkflowEntrypoint` shell
+ * touches `cloudflare:workers` (see `entrypoint.example.ts`).
+ */
+
+/**
+ * The ONLY data that crosses the enqueue boundary. Workflows persists
+ * params (and shows them in the dashboard), so never put secrets here —
+ * the workflow re-resolves everything else from its worker env.
+ */
+export interface TenantOperationWorkflowParams {
+  operation_id: string;
+  tenant_id: string;
+  /** Widened beyond "provision" in later phases (upgrade, backup, …). */
+  kind: "provision";
+}
+
+/**
+ * Instance status as reported by the engine. The exact value set has
+ * drifted across Cloudflare releases; the reconciler only branches on the
+ * terminal values and treats anything unrecognized as still-running.
+ */
+export interface WorkflowInstanceStatus {
+  status:
+    | "queued"
+    | "running"
+    | "paused"
+    | "errored"
+    | "terminated"
+    | "complete"
+    | "waiting"
+    | "waitingForPause"
+    | "unknown"
+    | (string & {});
+  error?: { name?: string; message?: string } | string | null;
+  output?: unknown;
+}
+
+/** Structurally satisfied by the handles a `workflows` binding returns. */
+export interface WorkflowInstanceHandle {
+  id: string;
+  status(): Promise<WorkflowInstanceStatus>;
+}
+
+/**
+ * Structurally satisfied by a Workflows binding
+ * (e.g. `env.TENANT_OPERATIONS_WORKFLOW`).
+ */
+export interface WorkflowsBinding {
+  create(options: {
+    id: string;
+    params: TenantOperationWorkflowParams;
+  }): Promise<WorkflowInstanceHandle>;
+  get(id: string): Promise<WorkflowInstanceHandle>;
+}
+
+export const TENANT_OPERATION_ENGINE = "cloudflare-workflows";

--- a/packages/cloudflare/src/workflows/verify.ts
+++ b/packages/cloudflare/src/workflows/verify.ts
@@ -1,0 +1,87 @@
+import { CloudflareApiClient } from "../wfp-provisioner/cf-api";
+import { escapeSqlLiteral } from "../wfp-provisioner/provisioner-steps";
+
+export interface ProvisionVerifierOptions {
+  client: CloudflareApiClient;
+  /** Minimum number of signing keys the tenant D1 must hold. Default 1. */
+  minKeys?: number;
+}
+
+/**
+ * Thrown when the freshly provisioned D1 fails the post-seed checks. The
+ * message is self-contained (it survives workflow step serialization) and
+ * names exactly which check failed — it ends up in
+ * `tenant_operation_events.detail` and, when retries exhaust, in
+ * `tenants.provisioning_error`.
+ */
+export class TenantProvisionVerificationError extends Error {
+  readonly checks: { keyCount: number; tenantRowCount: number };
+
+  constructor(
+    message: string,
+    checks: { keyCount: number; tenantRowCount: number },
+  ) {
+    super(message);
+    this.name = "TenantProvisionVerificationError";
+    this.checks = checks;
+  }
+}
+
+function readCount(result: { results?: unknown[] }[], column: string): number {
+  for (const block of result) {
+    for (const row of block.results ?? []) {
+      if (!row || typeof row !== "object") continue;
+      for (const [key, value] of Object.entries(row)) {
+        if (key !== column) continue;
+        if (typeof value === "number") return value;
+        if (typeof value === "string" && value !== "" && !isNaN(Number(value)))
+          return Number(value);
+      }
+    }
+  }
+  return 0;
+}
+
+/**
+ * Post-provision verification (issue #1026): assert the tenant D1 actually
+ * contains signing keys and its own tenant row before the tenant is marked
+ * `ready`. Queries D1 over the same REST path the provisioner's migrations
+ * use — this is what turns the 2026-07-02 "ready but empty D1" incident
+ * class into a retried workflow step instead of a silent success.
+ *
+ * Limitation (accepted for v1): this proves the rows landed in D1 via the
+ * REST API, not that the tenant worker's binding observes them; a worker
+ * HTTP probe can be layered on later.
+ */
+export function createProvisionVerifier(
+  options: ProvisionVerifierOptions,
+): (databaseId: string, tenantId: string) => Promise<void> {
+  const minKeys = options.minKeys ?? 1;
+
+  return async (databaseId: string, tenantId: string): Promise<void> => {
+    const result = await options.client.execD1(
+      databaseId,
+      `SELECT (SELECT COUNT(*) FROM keys) AS key_count, (SELECT COUNT(*) FROM tenants WHERE id = '${escapeSqlLiteral(tenantId)}') AS tenant_count;`,
+    );
+
+    const keyCount = readCount(result, "key_count");
+    const tenantRowCount = readCount(result, "tenant_count");
+
+    const failures: string[] = [];
+    if (keyCount < minKeys) {
+      failures.push(
+        `expected at least ${minKeys} signing key(s) in "keys", found ${keyCount}`,
+      );
+    }
+    if (tenantRowCount < 1) {
+      failures.push(`tenant row "${tenantId}" missing from "tenants"`);
+    }
+
+    if (failures.length > 0) {
+      throw new TenantProvisionVerificationError(
+        `Tenant D1 verification failed for "${tenantId}": ${failures.join("; ")}`,
+        { keyCount, tenantRowCount },
+      );
+    }
+  };
+}

--- a/packages/cloudflare/test/workflows/enqueue-hook.spec.ts
+++ b/packages/cloudflare/test/workflows/enqueue-hook.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import type { TenantOperation } from "@authhero/adapter-interfaces";
+import { createWfpWorkflowProvisioningHook } from "../../src/workflows";
+import type { WfpTenantProvisioningHook } from "../../src/wfp-provisioner";
+import { fakeTenants } from "./helpers";
+
+function stubOperation(): TenantOperation {
+  const now = new Date().toISOString();
+  return {
+    id: "op_1",
+    tenant_id: "kvartal",
+    rollout_id: null,
+    kind: "provision",
+    status: "pending",
+    current_step: null,
+    engine: "cloudflare-workflows",
+    engine_instance_id: "op-provision-kvartal-op_1",
+    target_worker_version: null,
+    target_database_version: null,
+    error: null,
+    initiated_by: null,
+    created_at: now,
+    updated_at: now,
+    finished_at: null,
+  };
+}
+
+function inlineHook(): WfpTenantProvisioningHook & {
+  upgrades: string[];
+  deprovisions: string[];
+} {
+  const upgrades: string[] = [];
+  const deprovisions: string[] = [];
+  return {
+    upgrades,
+    deprovisions,
+    async onProvision() {
+      throw new Error("inline onProvision must not be called");
+    },
+    async onUpgrade(tenantId: string) {
+      upgrades.push(tenantId);
+    },
+    async onDeprovision(tenantId: string) {
+      deprovisions.push(tenantId);
+    },
+  };
+}
+
+describe("createWfpWorkflowProvisioningHook", () => {
+  it("enqueues a provision operation for wfp tenants and leaves them pending", async () => {
+    const tenants = fakeTenants([
+      { id: "kvartal", deployment_type: "wfp", provisioning_state: "pending" },
+    ]);
+    const enqueueOperation = vi.fn(async () => stubOperation());
+    const hook = createWfpWorkflowProvisioningHook({
+      tenants,
+      enqueueOperation,
+      inline: inlineHook(),
+    });
+
+    await hook.onProvision("kvartal");
+
+    expect(enqueueOperation).toHaveBeenCalledExactlyOnceWith({
+      kind: "provision",
+      tenant_id: "kvartal",
+    });
+    // The hook must not touch the snapshot — the workflow owns it.
+    expect(tenants.store.get("kvartal")).toMatchObject({
+      provisioning_state: "pending",
+    });
+  });
+
+  it("skips shared and missing tenants without enqueueing", async () => {
+    const tenants = fakeTenants([
+      { id: "shared-t", deployment_type: "shared" },
+    ]);
+    const enqueueOperation = vi.fn(async () => stubOperation());
+    const hook = createWfpWorkflowProvisioningHook({
+      tenants,
+      enqueueOperation,
+      inline: inlineHook(),
+    });
+
+    await hook.onProvision("shared-t");
+    await hook.onProvision("does-not-exist");
+
+    expect(enqueueOperation).not.toHaveBeenCalled();
+  });
+
+  it("propagates enqueue failures (afterCreate rollback signal)", async () => {
+    const tenants = fakeTenants([{ id: "kvartal", deployment_type: "wfp" }]);
+    const hook = createWfpWorkflowProvisioningHook({
+      tenants,
+      enqueueOperation: vi.fn(async () => {
+        throw new Error("workflows unavailable");
+      }),
+      inline: inlineHook(),
+    });
+
+    await expect(hook.onProvision("kvartal")).rejects.toThrow(
+      "workflows unavailable",
+    );
+  });
+
+  it("delegates upgrade and deprovision to the inline hook", async () => {
+    const tenants = fakeTenants([{ id: "kvartal", deployment_type: "wfp" }]);
+    const inline = inlineHook();
+    const hook = createWfpWorkflowProvisioningHook({
+      tenants,
+      enqueueOperation: vi.fn(async () => stubOperation()),
+      inline,
+    });
+
+    await hook.onUpgrade("kvartal");
+    await hook.onDeprovision("kvartal");
+
+    expect(inline.upgrades).toEqual(["kvartal"]);
+    expect(inline.deprovisions).toEqual(["kvartal"]);
+  });
+});

--- a/packages/cloudflare/test/workflows/executor.spec.ts
+++ b/packages/cloudflare/test/workflows/executor.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import type { TenantOperation } from "@authhero/adapter-interfaces";
+import { createCloudflareWorkflowsExecutor } from "../../src/workflows";
+import { fakeBinding } from "./helpers";
+
+function operation(overrides: Partial<TenantOperation> = {}): TenantOperation {
+  const now = new Date().toISOString();
+  return {
+    id: "op_abc123",
+    tenant_id: "kvartal",
+    rollout_id: null,
+    kind: "provision",
+    status: "pending",
+    current_step: null,
+    engine: "cloudflare-workflows",
+    engine_instance_id: "op-provision-kvartal-op_abc123",
+    target_worker_version: null,
+    target_database_version: null,
+    error: null,
+    initiated_by: null,
+    created_at: now,
+    updated_at: now,
+    finished_at: null,
+    ...overrides,
+  };
+}
+
+describe("createCloudflareWorkflowsExecutor", () => {
+  it("creates an instance with the stored id and serializable params", async () => {
+    const binding = fakeBinding();
+    const executor = createCloudflareWorkflowsExecutor({ binding });
+
+    await executor.start(operation());
+
+    expect(binding.created).toHaveLength(1);
+    const { id, params } = binding.created[0]!;
+    expect(id).toBe("op-provision-kvartal-op_abc123");
+    expect(id.length).toBeLessThanOrEqual(64);
+    expect(id).toMatch(/^[a-zA-Z0-9_-]+$/);
+    expect(JSON.parse(JSON.stringify(params))).toEqual({
+      operation_id: "op_abc123",
+      tenant_id: "kvartal",
+      kind: "provision",
+    });
+  });
+
+  it("derives the instance id when the row carries none", async () => {
+    const binding = fakeBinding();
+    const executor = createCloudflareWorkflowsExecutor({ binding });
+
+    await executor.start(operation({ engine_instance_id: null }));
+
+    expect(binding.created[0]!.id).toBe("op-provision-kvartal-op_abc123");
+  });
+
+  it("treats a duplicate instance id as success", async () => {
+    const binding = fakeBinding();
+    const executor = createCloudflareWorkflowsExecutor({ binding });
+
+    await executor.start(operation());
+    await expect(executor.start(operation())).resolves.toBeUndefined();
+    expect(binding.created).toHaveLength(1);
+  });
+
+  it("propagates other engine errors", async () => {
+    const binding = fakeBinding();
+    binding.createError = new Error("workflows unavailable");
+    const executor = createCloudflareWorkflowsExecutor({ binding });
+
+    await expect(executor.start(operation())).rejects.toThrow(
+      "workflows unavailable",
+    );
+  });
+
+  it("rejects unsupported kinds and fleet operations", async () => {
+    const binding = fakeBinding();
+    const executor = createCloudflareWorkflowsExecutor({ binding });
+
+    await expect(
+      executor.start(operation({ kind: "upgrade" })),
+    ).rejects.toThrow(/does not support "upgrade"/);
+    await expect(
+      executor.start(operation({ tenant_id: null })),
+    ).rejects.toThrow(/require a tenant_id/);
+  });
+});

--- a/packages/cloudflare/test/workflows/helpers.ts
+++ b/packages/cloudflare/test/workflows/helpers.ts
@@ -1,0 +1,297 @@
+import type {
+  Tenant,
+  TenantOperation,
+  TenantOperationEvent,
+  TenantOperationEventInsert,
+  TenantOperationInsert,
+  TenantOperationUpdate,
+  TenantsDataAdapter,
+  ListTenantOperationsParams,
+} from "@authhero/adapter-interfaces";
+import type {
+  StepConfig,
+  StepRunner,
+  TenantOperationStores,
+} from "@authhero/multi-tenancy";
+import type {
+  WorkflowInstanceHandle,
+  WorkflowInstanceStatus,
+  WorkflowsBinding,
+} from "../../src/workflows";
+
+export interface RecordedStepCall {
+  name: string;
+  config?: StepConfig;
+}
+
+function splitArgs<T>(
+  configOrFn: StepConfig | (() => Promise<T>),
+  maybeFn?: () => Promise<T>,
+): { config?: StepConfig; fn: () => Promise<T> } {
+  if (typeof configOrFn === "function") {
+    return { fn: configOrFn };
+  }
+  if (!maybeFn) throw new Error("StepRunner.do called without a function");
+  return { config: configOrFn, fn: maybeFn };
+}
+
+/** Executes each step's function exactly once, recording name + config. */
+export function fakeStepRunner(): StepRunner & { calls: RecordedStepCall[] } {
+  const calls: RecordedStepCall[] = [];
+  return {
+    calls,
+    async do<T>(
+      name: string,
+      configOrFn: StepConfig | (() => Promise<T>),
+      maybeFn?: () => Promise<T>,
+    ): Promise<T> {
+      const { config, fn } = splitArgs(configOrFn, maybeFn);
+      calls.push({ name, config });
+      return fn();
+    },
+  };
+}
+
+/**
+ * Honors `config.retries.limit` with zero delay — models the engine
+ * retrying a throwing step. Records one call entry per attempt.
+ */
+export function retryingStepRunner(): StepRunner & {
+  calls: RecordedStepCall[];
+} {
+  const calls: RecordedStepCall[] = [];
+  return {
+    calls,
+    async do<T>(
+      name: string,
+      configOrFn: StepConfig | (() => Promise<T>),
+      maybeFn?: () => Promise<T>,
+    ): Promise<T> {
+      const { config, fn } = splitArgs(configOrFn, maybeFn);
+      const attempts = 1 + (config?.retries?.limit ?? 0);
+      let lastError: unknown;
+      for (let attempt = 1; attempt <= attempts; attempt++) {
+        calls.push({ name, config });
+        try {
+          return await fn();
+        } catch (error) {
+          lastError = error;
+        }
+      }
+      throw lastError;
+    },
+  };
+}
+
+/**
+ * Returns memoized results for already-completed steps without invoking
+ * their function — models Workflows resuming after an eviction. Steps not
+ * in the memo run live and are added.
+ */
+export function replayStepRunner(memo: Map<string, unknown>): StepRunner & {
+  executed: string[];
+} {
+  const executed: string[] = [];
+  return {
+    executed,
+    async do<T>(
+      name: string,
+      configOrFn: StepConfig | (() => Promise<T>),
+      maybeFn?: () => Promise<T>,
+    ): Promise<T> {
+      const { fn } = splitArgs(configOrFn, maybeFn);
+      if (memo.has(name)) {
+        return memo.get(name) as T;
+      }
+      executed.push(name);
+      const result = await fn();
+      memo.set(name, result);
+      return result;
+    },
+  };
+}
+
+/** In-memory TenantOperationStores with the filters the reconciler needs. */
+export function fakeStores(): TenantOperationStores & {
+  operations: Map<string, TenantOperation>;
+  events: TenantOperationEvent[];
+} {
+  const operations = new Map<string, TenantOperation>();
+  const events: TenantOperationEvent[] = [];
+  let opSeq = 0;
+  let evtSeq = 0;
+
+  return {
+    operations,
+    events,
+    tenantOperations: {
+      async create(input: TenantOperationInsert): Promise<TenantOperation> {
+        const now = new Date().toISOString();
+        const operation: TenantOperation = {
+          id: `op_${++opSeq}`,
+          tenant_id: input.tenant_id ?? null,
+          rollout_id: input.rollout_id ?? null,
+          kind: input.kind,
+          status: "pending",
+          current_step: null,
+          engine: input.engine,
+          engine_instance_id: input.engine_instance_id ?? null,
+          target_worker_version: input.target_worker_version ?? null,
+          target_database_version: input.target_database_version ?? null,
+          error: null,
+          initiated_by: input.initiated_by ?? null,
+          created_at: now,
+          updated_at: now,
+          finished_at: null,
+        };
+        operations.set(operation.id, operation);
+        return operation;
+      },
+      async get(id: string): Promise<TenantOperation | null> {
+        return operations.get(id) ?? null;
+      },
+      async list(params: ListTenantOperationsParams = {}) {
+        const statuses =
+          params.status === undefined
+            ? undefined
+            : Array.isArray(params.status)
+              ? params.status
+              : [params.status];
+        const all = Array.from(operations.values()).filter((op) => {
+          if (
+            params.tenant_id !== undefined &&
+            op.tenant_id !== params.tenant_id
+          )
+            return false;
+          if (statuses && !statuses.includes(op.status)) return false;
+          if (params.engine !== undefined && op.engine !== params.engine)
+            return false;
+          if (
+            params.updated_before !== undefined &&
+            !(op.updated_at < params.updated_before)
+          )
+            return false;
+          return true;
+        });
+        const limit = params.per_page ?? 50;
+        return {
+          operations: all.slice(0, limit),
+          start: 0,
+          limit,
+          length: Math.min(all.length, limit),
+        };
+      },
+      async update(id: string, patch: TenantOperationUpdate): Promise<boolean> {
+        const current = operations.get(id);
+        if (!current) return false;
+        operations.set(id, {
+          ...current,
+          ...patch,
+          updated_at: new Date().toISOString(),
+        });
+        return true;
+      },
+      async remove(id: string): Promise<boolean> {
+        return operations.delete(id);
+      },
+    },
+    tenantOperationEvents: {
+      async create(
+        input: TenantOperationEventInsert,
+      ): Promise<TenantOperationEvent> {
+        const event: TenantOperationEvent = {
+          id: `evt_${++evtSeq}`,
+          operation_id: input.operation_id,
+          step: input.step,
+          outcome: input.outcome,
+          detail: input.detail ?? null,
+          attempt: input.attempt ?? 1,
+          created_at: new Date().toISOString(),
+        };
+        events.push(event);
+        return event;
+      },
+      async listByOperation(operation_id: string) {
+        const matching = events.filter((e) => e.operation_id === operation_id);
+        return {
+          events: matching,
+          start: 0,
+          limit: 100,
+          length: matching.length,
+        };
+      },
+    },
+  };
+}
+
+export function fakeTenants(
+  initial: Array<Partial<Tenant> & { id: string }>,
+): TenantsDataAdapter & { store: Map<string, Partial<Tenant>> } {
+  const store = new Map<string, Partial<Tenant>>(initial.map((t) => [t.id, t]));
+  return {
+    store,
+    async create(): Promise<Tenant> {
+      throw new Error("not used in tests");
+    },
+    async get(id: string): Promise<Tenant | null> {
+      return (store.get(id) as Tenant | undefined) ?? null;
+    },
+    async list() {
+      return { tenants: Array.from(store.values()) as Tenant[] };
+    },
+    async update(id: string, patch: Partial<Tenant>): Promise<void> {
+      const cur = store.get(id);
+      if (cur) store.set(id, { ...cur, ...patch });
+    },
+    async remove(id: string): Promise<boolean> {
+      return store.delete(id);
+    },
+  };
+}
+
+export function fakeBinding(): WorkflowsBinding & {
+  created: Array<{ id: string; params: unknown }>;
+  statuses: Map<string, WorkflowInstanceStatus>;
+  createError?: Error;
+  missingInstances: Set<string>;
+  getErrors: Map<string, Error>;
+} {
+  const created: Array<{ id: string; params: unknown }> = [];
+  const statuses = new Map<string, WorkflowInstanceStatus>();
+  const missingInstances = new Set<string>();
+  const getErrors = new Map<string, Error>();
+
+  const binding = {
+    created,
+    statuses,
+    createError: undefined as Error | undefined,
+    missingInstances,
+    getErrors,
+    async create(options: {
+      id: string;
+      params: unknown;
+    }): Promise<WorkflowInstanceHandle> {
+      if (binding.createError) throw binding.createError;
+      if (created.some((c) => c.id === options.id)) {
+        throw new Error(`instance with id "${options.id}" already exists`);
+      }
+      created.push(options);
+      return {
+        id: options.id,
+        status: async () => statuses.get(options.id) ?? { status: "running" },
+      };
+    },
+    async get(id: string): Promise<WorkflowInstanceHandle> {
+      const error = getErrors.get(id);
+      if (error) throw error;
+      if (missingInstances.has(id)) {
+        throw new Error(`instance "${id}" not found`);
+      }
+      return {
+        id,
+        status: async () => statuses.get(id) ?? { status: "running" },
+      };
+    },
+  };
+  return binding;
+}

--- a/packages/cloudflare/test/workflows/provision-operation.spec.ts
+++ b/packages/cloudflare/test/workflows/provision-operation.spec.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  runProvisionOperation,
+  type ProvisionOperationDeps,
+} from "../../src/workflows";
+import type { TenantProvisionerSteps } from "../../src/wfp-provisioner";
+import {
+  fakeStepRunner,
+  fakeStores,
+  fakeTenants,
+  replayStepRunner,
+  retryingStepRunner,
+} from "./helpers";
+
+const PARAMS = {
+  operation_id: "op_1",
+  tenant_id: "kvartal",
+  kind: "provision" as const,
+};
+
+function fakeProvisionerSteps(): TenantProvisionerSteps & {
+  callLog: string[];
+} {
+  const callLog: string[] = [];
+  return {
+    callLog,
+    names: (tenantId: string) => ({
+      scriptName: tenantId,
+      databaseName: `tenant-${tenantId}`,
+    }),
+    validate: () => ({
+      databaseVersion: "0001.sql",
+      bundleConfiguration: "authhero-drizzle-d1",
+      workerVersion: "v1.2.3",
+    }),
+    async findOrCreateDatabase(name: string) {
+      callLog.push(`findOrCreateDatabase:${name}`);
+      return { id: "db_x", created: true };
+    },
+    async applyMigrations(databaseId: string, created: boolean) {
+      callLog.push(`applyMigrations:${databaseId}:${created}`);
+    },
+    async uploadScript(scriptName: string, databaseId: string) {
+      callLog.push(`uploadScript:${scriptName}:${databaseId}`);
+    },
+    async uploadSecrets(scriptName: string, tenantId: string) {
+      callLog.push(`uploadSecrets:${scriptName}:${tenantId}`);
+    },
+    async deprovision() {
+      throw new Error("not used");
+    },
+  };
+}
+
+async function seedOperation(stores: ReturnType<typeof fakeStores>) {
+  const op = await stores.tenantOperations.create({
+    tenant_id: "kvartal",
+    kind: "provision",
+    engine: "cloudflare-workflows",
+  });
+  // Align with the deterministic op id the params reference.
+  stores.operations.delete(op.id);
+  stores.operations.set("op_1", { ...op, id: "op_1" });
+}
+
+function baseDeps(
+  overrides: Partial<ProvisionOperationDeps> = {},
+): ProvisionOperationDeps & {
+  stores: ReturnType<typeof fakeStores>;
+  tenants: ReturnType<typeof fakeTenants>;
+} {
+  const stores = fakeStores();
+  const tenants = fakeTenants([
+    { id: "kvartal", deployment_type: "wfp", provisioning_state: "pending" },
+  ]);
+  return {
+    steps: fakeProvisionerSteps(),
+    tenants,
+    stores,
+    syncDefaults: vi.fn(async () => ({})),
+    verify: vi.fn(async () => {}),
+    ...overrides,
+    // keep the concrete fakes accessible in tests
+    ...({} as Record<never, never>),
+  };
+}
+
+describe("runProvisionOperation", () => {
+  it("runs the full step sequence and marks the tenant ready", async () => {
+    const deps = baseDeps();
+    await seedOperation(deps.stores);
+    const step = fakeStepRunner();
+
+    await runProvisionOperation(deps, PARAMS, step);
+
+    expect(step.calls.map((c) => c.name)).toEqual([
+      "mark-running",
+      "create-database",
+      "apply-migrations",
+      "upload-script",
+      "upload-secrets",
+      "seed-defaults",
+      "verify",
+      "mark-ready",
+    ]);
+
+    const operation = deps.stores.operations.get("op_1");
+    expect(operation?.status).toBe("succeeded");
+    expect(operation?.finished_at).toBeTruthy();
+
+    const outcomes = deps.stores.events.map((e) => `${e.step}:${e.outcome}`);
+    expect(outcomes).toEqual([
+      "mark-running:succeeded",
+      "create-database:succeeded",
+      "apply-migrations:succeeded",
+      "upload-script:succeeded",
+      "upload-secrets:succeeded",
+      "seed-defaults:succeeded",
+      "verify:succeeded",
+      "mark-ready:succeeded",
+    ]);
+
+    expect(deps.tenants.store.get("kvartal")).toMatchObject({
+      provisioning_state: "ready",
+      d1_database_id: "db_x",
+      worker_script_name: "kvartal",
+      worker_version: "v1.2.3",
+      database_version: "0001.sql",
+    });
+  });
+
+  it("incident regression: a failing seed can never yield a ready tenant", async () => {
+    const deps = baseDeps({
+      syncDefaults: vi.fn(async () => ({
+        connections: { errors: ["insert failed: SQLITE_ERROR"] },
+      })),
+    });
+    await seedOperation(deps.stores);
+    const step = fakeStepRunner();
+
+    await expect(runProvisionOperation(deps, PARAMS, step)).rejects.toThrow(
+      /sync-defaults seed reported 1 error/,
+    );
+
+    const tenant = deps.tenants.store.get("kvartal");
+    expect(tenant?.provisioning_state).toBe("failed");
+    expect(tenant?.provisioning_error).toMatch(/sync-defaults seed/);
+    // Resource ids persisted for a later re-provision.
+    expect(tenant?.d1_database_id).toBe("db_x");
+
+    const operation = deps.stores.operations.get("op_1");
+    expect(operation?.status).toBe("failed");
+    expect(operation?.error).toMatch(/sync-defaults seed/);
+
+    const verify = deps.verify;
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("incident regression: a propagation race resolves via retried verify", async () => {
+    let attempts = 0;
+    const deps = baseDeps({
+      verify: vi.fn(async () => {
+        attempts++;
+        if (attempts <= 2) {
+          throw new Error("verification failed: 0 keys");
+        }
+      }),
+    });
+    await seedOperation(deps.stores);
+    const step = retryingStepRunner();
+
+    await runProvisionOperation(deps, PARAMS, step);
+
+    expect(attempts).toBe(3);
+    expect(deps.tenants.store.get("kvartal")?.provisioning_state).toBe("ready");
+    expect(deps.stores.operations.get("op_1")?.status).toBe("succeeded");
+  });
+
+  it("fails the operation when verify exhausts its retries", async () => {
+    const deps = baseDeps({
+      verify: vi.fn(async () => {
+        throw new Error("verification failed: 0 keys");
+      }),
+    });
+    await seedOperation(deps.stores);
+    const step = retryingStepRunner();
+
+    await expect(runProvisionOperation(deps, PARAMS, step)).rejects.toThrow(
+      /0 keys/,
+    );
+
+    const tenant = deps.tenants.store.get("kvartal");
+    expect(tenant?.provisioning_state).toBe("failed");
+    expect(tenant?.provisioning_error).toMatch(/0 keys/);
+    expect(deps.stores.operations.get("op_1")?.status).toBe("failed");
+  });
+
+  it("replay after eviction skips completed side effects", async () => {
+    const deps = baseDeps();
+    await seedOperation(deps.stores);
+    const memo = new Map<string, unknown>();
+
+    // First run: dies right after upload-script (simulated by a failing
+    // upload-secrets), leaving steps 1-4 memoized.
+    const failingDeps = {
+      ...deps,
+      steps: {
+        ...deps.steps,
+        uploadSecrets: vi.fn(async () => {
+          throw new Error("evicted");
+        }),
+      },
+    };
+    // Note: the mark-failed step also runs (and memoizes) on this first
+    // pass — but a real eviction wouldn't reach it; drop it from the memo
+    // to model dying mid-run.
+    await expect(
+      runProvisionOperation(failingDeps, PARAMS, replayStepRunner(memo)),
+    ).rejects.toThrow("evicted");
+    memo.delete("mark-failed");
+    memo.delete("upload-secrets");
+
+    // Reset op back to running (a real replay resumes the same instance).
+    await deps.stores.tenantOperations.update("op_1", { status: "running" });
+
+    const stepsSpy = deps.steps;
+    const secondRun = replayStepRunner(memo);
+    await runProvisionOperation(deps, PARAMS, secondRun);
+
+    // Only the steps that never completed run live on replay.
+    expect(secondRun.executed).toEqual([
+      "upload-secrets",
+      "seed-defaults",
+      "verify",
+      "mark-ready",
+    ]);
+    // The heavy side effects from steps 2-4 ran exactly once (first pass).
+    expect(
+      stepsSpy.callLog.filter((c) => c.startsWith("findOrCreateDatabase")),
+    ).toHaveLength(1);
+    expect(deps.stores.operations.get("op_1")?.status).toBe("succeeded");
+  });
+
+  it("closes the operation as skipped when the tenant is missing", async () => {
+    const deps = baseDeps({ tenants: fakeTenants([]) });
+    await seedOperation(deps.stores);
+    const step = fakeStepRunner();
+
+    await runProvisionOperation(deps, PARAMS, step);
+
+    expect(step.calls.map((c) => c.name)).toEqual(["mark-running"]);
+    expect(deps.stores.operations.get("op_1")?.status).toBe("succeeded");
+    expect(deps.stores.events.map((e) => e.outcome)).toEqual(["skipped"]);
+  });
+
+  it("skips non-wfp tenants without touching Cloudflare", async () => {
+    const deps = baseDeps({
+      tenants: fakeTenants([{ id: "kvartal", deployment_type: "shared" }]),
+    });
+    await seedOperation(deps.stores);
+    const step = fakeStepRunner();
+
+    await runProvisionOperation(deps, PARAMS, step);
+
+    const steps = deps.steps;
+    expect(steps.callLog).toEqual([]);
+    expect(deps.stores.operations.get("op_1")?.status).toBe("succeeded");
+  });
+
+  it("step outputs survive JSON serialization (engine persistence)", async () => {
+    const deps = baseDeps();
+    await seedOperation(deps.stores);
+
+    const outputs: unknown[] = [];
+    const step = {
+      async do<T>(
+        _name: string,
+        configOrFn: unknown,
+        maybeFn?: () => Promise<T>,
+      ): Promise<T> {
+        const fn =
+          typeof configOrFn === "function"
+            ? (configOrFn as () => Promise<T>)
+            : maybeFn;
+        const result = await fn!();
+        outputs.push(result);
+        return result;
+      },
+    };
+
+    await runProvisionOperation(deps, PARAMS, step);
+
+    for (const output of outputs) {
+      if (output === undefined) continue;
+      expect(JSON.parse(JSON.stringify(output))).toEqual(output);
+    }
+  });
+});

--- a/packages/cloudflare/test/workflows/reconcile.spec.ts
+++ b/packages/cloudflare/test/workflows/reconcile.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import { reconcileTenantOperations } from "../../src/workflows";
+import { fakeBinding, fakeStores, fakeTenants } from "./helpers";
+
+const OLD = "2020-01-01T00:00:00.000Z";
+
+async function seedStuckOperation(
+  stores: ReturnType<typeof fakeStores>,
+  overrides: {
+    id?: string;
+    status?: "pending" | "running";
+    tenant_id?: string | null;
+    engine_instance_id?: string | null;
+    updated_at?: string;
+  } = {},
+) {
+  const created = await stores.tenantOperations.create({
+    tenant_id:
+      overrides.tenant_id === undefined ? "kvartal" : overrides.tenant_id,
+    kind: "provision",
+    engine: "cloudflare-workflows",
+  });
+  const id = overrides.id ?? created.id;
+  stores.operations.delete(created.id);
+  stores.operations.set(id, {
+    ...created,
+    id,
+    status: overrides.status ?? "running",
+    engine_instance_id:
+      overrides.engine_instance_id === undefined
+        ? `wf-${id}`
+        : overrides.engine_instance_id,
+    updated_at: overrides.updated_at ?? OLD,
+  });
+  return id;
+}
+
+describe("reconcileTenantOperations", () => {
+  it("copies an errored engine state into the operation and tenant", async () => {
+    const stores = fakeStores();
+    const tenants = fakeTenants([
+      { id: "kvartal", deployment_type: "wfp", provisioning_state: "pending" },
+    ]);
+    const binding = fakeBinding();
+    const id = await seedStuckOperation(stores);
+    binding.statuses.set(`wf-${id}`, {
+      status: "errored",
+      error: { name: "Error", message: "step create-d1 exhausted retries" },
+    });
+
+    const result = await reconcileTenantOperations({
+      stores,
+      tenants,
+      binding,
+    });
+
+    expect(result).toMatchObject({ scanned: 1, markedFailed: 1, errors: 0 });
+    const operation = stores.operations.get(id);
+    expect(operation?.status).toBe("failed");
+    expect(operation?.error).toMatch(/exhausted retries/);
+    expect(stores.events.some((e) => e.outcome === "reconciled")).toBe(true);
+    expect(tenants.store.get("kvartal")?.provisioning_state).toBe("failed");
+  });
+
+  it("marks failed when the instance is missing (expired or never started)", async () => {
+    const stores = fakeStores();
+    const tenants = fakeTenants([{ id: "kvartal", deployment_type: "wfp" }]);
+    const binding = fakeBinding();
+    const id = await seedStuckOperation(stores);
+    binding.missingInstances.add(`wf-${id}`);
+
+    const result = await reconcileTenantOperations({
+      stores,
+      tenants,
+      binding,
+    });
+
+    expect(result.instanceMissing).toBe(1);
+    expect(stores.operations.get(id)?.status).toBe("failed");
+    expect(stores.operations.get(id)?.error).toMatch(/not found/);
+  });
+
+  it("resolves complete-but-unfinalized from the tenant snapshot", async () => {
+    const stores = fakeStores();
+    const tenants = fakeTenants([
+      { id: "ready-t", deployment_type: "wfp", provisioning_state: "ready" },
+      { id: "stuck-t", deployment_type: "wfp", provisioning_state: "pending" },
+    ]);
+    const binding = fakeBinding();
+    const readyOp = await seedStuckOperation(stores, {
+      id: "op_ready",
+      tenant_id: "ready-t",
+    });
+    const stuckOp = await seedStuckOperation(stores, {
+      id: "op_stuck",
+      tenant_id: "stuck-t",
+    });
+    binding.statuses.set(`wf-${readyOp}`, { status: "complete" });
+    binding.statuses.set(`wf-${stuckOp}`, { status: "complete" });
+
+    const result = await reconcileTenantOperations({
+      stores,
+      tenants,
+      binding,
+    });
+
+    expect(result.markedSucceeded).toBe(1);
+    expect(result.markedFailed).toBe(1);
+    expect(stores.operations.get("op_ready")?.status).toBe("succeeded");
+    expect(stores.operations.get("op_stuck")?.status).toBe("failed");
+  });
+
+  it("leaves running instances and fresh operations untouched", async () => {
+    const stores = fakeStores();
+    const tenants = fakeTenants([{ id: "kvartal", deployment_type: "wfp" }]);
+    const binding = fakeBinding();
+
+    const runningOp = await seedStuckOperation(stores, { id: "op_running" });
+    binding.statuses.set(`wf-${runningOp}`, { status: "running" });
+    // Fresh operation: updated_at is now, inside the min-age window.
+    await seedStuckOperation(stores, {
+      id: "op_fresh",
+      updated_at: new Date().toISOString(),
+    });
+
+    const result = await reconcileTenantOperations({
+      stores,
+      tenants,
+      binding,
+    });
+
+    expect(result.scanned).toBe(1); // fresh op filtered by updated_before
+    expect(result.stillRunning).toBe(1);
+    expect(stores.operations.get("op_running")?.status).toBe("running");
+    expect(stores.operations.get("op_fresh")?.status).toBe("running");
+  });
+
+  it("derives the instance id when the row carries none", async () => {
+    const stores = fakeStores();
+    const tenants = fakeTenants([{ id: "kvartal", deployment_type: "wfp" }]);
+    const binding = fakeBinding();
+    const id = await seedStuckOperation(stores, {
+      id: "op_noid",
+      engine_instance_id: null,
+    });
+    binding.statuses.set("op-provision-kvartal-op_noid", {
+      status: "terminated",
+      error: "terminated by operator",
+    });
+
+    const result = await reconcileTenantOperations({
+      stores,
+      tenants,
+      binding,
+    });
+
+    expect(result.markedFailed).toBe(1);
+    expect(stores.operations.get(id)?.error).toBe("terminated by operator");
+  });
+
+  it("one operation's engine error does not abort the sweep", async () => {
+    const stores = fakeStores();
+    const tenants = fakeTenants([{ id: "kvartal", deployment_type: "wfp" }]);
+    const binding = fakeBinding();
+
+    const broken = await seedStuckOperation(stores, { id: "op_broken" });
+    // status() itself will throw for this one: make get() succeed but the
+    // handle status throw via a poisoned status map entry.
+    binding.getErrors.set(
+      `wf-${broken}`,
+      Object.assign(new Error("api quota exceeded"), { name: "QuotaError" }),
+    );
+    const errored = await seedStuckOperation(stores, { id: "op_errored" });
+    binding.statuses.set(`wf-${errored}`, { status: "errored", error: "boom" });
+
+    const result = await reconcileTenantOperations({
+      stores,
+      tenants,
+      binding,
+    });
+
+    // The quota error is treated as instance-missing (get threw) — the
+    // matching is deliberately permissive; the sweep still processes the
+    // second operation.
+    expect(result.scanned).toBe(2);
+    expect(stores.operations.get("op_errored")?.status).toBe("failed");
+  });
+});

--- a/packages/cloudflare/test/workflows/verify.spec.ts
+++ b/packages/cloudflare/test/workflows/verify.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { CloudflareApiClient } from "../../src/wfp-provisioner";
+import {
+  createProvisionVerifier,
+  TenantProvisionVerificationError,
+} from "../../src/workflows";
+
+const ACCOUNT_ID = "acc_test";
+const API_BASE = "https://api.cloudflare.com/client/v4";
+const DB_ID = "db_x";
+
+const server = setupServer();
+let capturedSql: string[];
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+beforeEach(() => {
+  server.resetHandlers();
+  capturedSql = [];
+});
+
+function mockQueryResult(keyCount: number, tenantCount: number) {
+  server.use(
+    http.post(
+      `${API_BASE}/accounts/${ACCOUNT_ID}/d1/database/${DB_ID}/query`,
+      async ({ request }) => {
+        const body = (await request.json()) as { sql: string };
+        capturedSql.push(body.sql);
+        return HttpResponse.json({
+          success: true,
+          result: [
+            {
+              success: true,
+              results: [{ key_count: keyCount, tenant_count: tenantCount }],
+            },
+          ],
+        });
+      },
+    ),
+  );
+}
+
+function verifier() {
+  const client = new CloudflareApiClient({
+    accountId: ACCOUNT_ID,
+    apiToken: "token",
+  });
+  return createProvisionVerifier({ client });
+}
+
+describe("createProvisionVerifier", () => {
+  it("resolves when keys and the tenant row exist", async () => {
+    mockQueryResult(2, 1);
+    await expect(verifier()(DB_ID, "kvartal")).resolves.toBeUndefined();
+    expect(capturedSql[0]).toContain("FROM keys");
+    expect(capturedSql[0]).toContain("FROM tenants WHERE id = 'kvartal'");
+  });
+
+  it("throws naming the keys check when the keys table is empty", async () => {
+    mockQueryResult(0, 1);
+    await expect(verifier()(DB_ID, "kvartal")).rejects.toThrow(
+      /at least 1 signing key/,
+    );
+  });
+
+  it("throws naming the tenant row when it is missing", async () => {
+    mockQueryResult(3, 0);
+    const error = await verifier()(DB_ID, "kvartal")
+      .then(() => null)
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TenantProvisionVerificationError);
+    if (error instanceof TenantProvisionVerificationError) {
+      expect(error.message).toMatch(/tenant row "kvartal" missing/);
+      expect(error.checks).toEqual({ keyCount: 3, tenantRowCount: 0 });
+    }
+  });
+
+  it("escapes the tenant id in the SQL literal", async () => {
+    mockQueryResult(1, 1);
+    await verifier()(DB_ID, "kvar'tal");
+    expect(capturedSql[0]).toContain("id = 'kvar''tal'");
+  });
+
+  it("propagates Cloudflare API errors", async () => {
+    server.use(
+      http.post(
+        `${API_BASE}/accounts/${ACCOUNT_ID}/d1/database/${DB_ID}/query`,
+        () => HttpResponse.json({ success: false }, { status: 500 }),
+      ),
+    );
+    await expect(verifier()(DB_ID, "kvartal")).rejects.toThrow();
+  });
+});

--- a/packages/cloudflare/vite.config.ts
+++ b/packages/cloudflare/vite.config.ts
@@ -25,12 +25,14 @@ export default defineConfig({
   build: {
     outDir: "./dist",
     lib: {
-      // Two entries: the main barrel (`.`) and the WFP control-plane-sync
-      // surface (`./wfp`). The main bundle name is unchanged so the `.` export
-      // stays byte-stable.
+      // Three entries: the main barrel (`.`), the WFP control-plane-sync
+      // surface (`./wfp`), and the durable tenant-operations surface
+      // (`./workflows`). The main bundle name is unchanged so the `.`
+      // export stays byte-stable.
       entry: {
         [getPackageName()]: path.resolve(__dirname, "src/index.ts"),
         wfp: path.resolve(__dirname, "src/wfp/index.ts"),
+        workflows: path.resolve(__dirname, "src/workflows/index.ts"),
       },
       formats,
       fileName: (format, entryName) =>

--- a/packages/multi-tenancy/src/hooks/provisioning.ts
+++ b/packages/multi-tenancy/src/hooks/provisioning.ts
@@ -62,18 +62,24 @@ export function createProvisioningHooks(
       // 2. Provision database if isolation is enabled. When the control
       // plane carries the tenant-operations adapters (issue #1026), the
       // provision run is recorded as an operation with step events;
-      // otherwise it runs exactly as before.
+      // otherwise it runs exactly as before. Hooks that create their own
+      // operation rows (the durable workflow hook) opt out via
+      // `recordProvisionOperations: false`.
       if (databaseIsolation?.onProvision) {
         const onProvision = databaseIsolation.onProvision;
-        await runRecordedTenantOperation(
-          ctx.adapters,
-          {
-            kind: "provision",
-            tenant_id: tenant.id,
-            initiated_by: ctx.ctx?.var.user?.sub,
-          },
-          (report) => onProvision(tenant.id, report),
-        );
+        if (databaseIsolation.recordProvisionOperations === false) {
+          await onProvision(tenant.id);
+        } else {
+          await runRecordedTenantOperation(
+            ctx.adapters,
+            {
+              kind: "provision",
+              tenant_id: tenant.id,
+              initiated_by: ctx.ctx?.var.user?.sub,
+            },
+            (report) => onProvision(tenant.id, report),
+          );
+        }
       }
     },
 

--- a/packages/multi-tenancy/src/types.ts
+++ b/packages/multi-tenancy/src/types.ts
@@ -142,6 +142,17 @@ export interface DatabaseIsolationConfig {
   onProvision?: (tenantId: string, report?: StepReporter) => Promise<void>;
 
   /**
+   * Whether `afterCreate` wraps `onProvision` in
+   * `runRecordedTenantOperation` (default true). Set to `false` when the
+   * hook manages its own operation rows — e.g.
+   * `createWfpWorkflowProvisioningHook`, whose durable workflow creates
+   * and finalizes the operation itself; the wrapper would otherwise write
+   * a second, immediately-"succeeded" row for a run that is still in
+   * flight on the engine.
+   */
+  recordProvisionOperations?: boolean;
+
+  /**
    * Called when a tenant is being deleted to cleanup its database.
    * Use this to delete the database, backup data, etc.
    *


### PR DESCRIPTION
Re-lands #1040, which was merged into `ma/tenant-operations-provisioner-steps` *after* that branch had already been merged to main (#1039), so its commit never reached main. Same content, no changes. Part 4/5 of the issue #1026 stack.

This is the part that would have prevented the 2026-07-02 "ready but empty D1" incident.

## What

New `@authhero/cloudflare-adapter/workflows` subpath (third build entry, same pattern as `./wfp`; requires the optional `@authhero/multi-tenancy` peer):

- **`runProvisionOperation`** — the full provision sequence as one durable engine step each: `mark-running → create-database → apply-migrations → upload-script → upload-secrets → seed-defaults → verify → mark-ready`. The operation-log write happens inside the same `step.do` as the side effect (durable + retried; side effects are idempotent so replay is safe). Two steps close the incident class:
  - `seed-defaults` is a retried step **before** `ready` whose per-entity errors fail the operation — not a `console.error`.
  - `verify` queries the tenant D1 over the same REST path migrations use and throws until it holds signing keys + the tenant row (default: 8 retries, exponential backoff) — a propagation race becomes a few retried verifies.
  Any failure runs `mark-failed` (persisting resource ids, mirroring the inline hook) and rethrows so the instance ends `errored`.
- **`createCloudflareWorkflowsExecutor`** — implements the row-first executor contract over a *structural* Workflows binding. No `cloudflare:workers` import anywhere in the library; the downstream worker owns the ~10-line `WorkflowEntrypoint` shell (full reference incl. `buildProvisionDeps(env)`, wrangler config, and the `scheduled` handler in `entrypoint.example.ts`). Params carry only `{operation_id, tenant_id, kind}` — never secrets.
- **`reconcileTenantOperations`** — sweeps operations stuck in `pending`/`running` whose instance died before its terminal write: missing/errored/terminated instances → `failed` (+ tenant snapshot when still `pending`); `complete`-but-unfinalized resolved from the tenant snapshot as source of truth. Run from a `scheduled` handler at least daily (engine retention is 30 days); 15–60 min recommended.
- **`createWfpWorkflowProvisioningHook`** — flips tenant create from inline provisioning to a durable enqueue; upgrade/deprovision keep delegating inline until phases 3/4. Wire with the new `databaseIsolation.recordProvisionOperations: false` so the multi-tenancy recording wrapper doesn't write a second row for a run the workflow owns.

**Semantic change to plan for downstream (sesamy/auth):** tenant-create returns with `provisioning_state: "pending"`; clients poll. The best-effort post-create seed gets deleted — the seed is a durable step inside the workflow. Docs page: `apps/docs/customization/multi-tenancy/tenant-operations.md`.

## To pin during downstream integration

Cloudflare's exact instance-status values, the `create` duplicate-id error shape, and the instance-id length limit (design is safe at ≤64) — matching is deliberately permissive.

## Tests

28 new tests across 5 specs using fake/retrying/replay StepRunners and MSW — including the two incident regressions (a failing seed can never yield `ready`; a propagation race resolves via retried verify), replay-after-eviction skipping completed side effects, JSON-serializability of step outputs, and a table-driven reconciler matrix. Package suite: 118/118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

