### PR TITLE
ci(conformance): move actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -65,7 +65,7 @@ jobs:
       code-hash: ${{ steps.hash.outputs.hash }}
       already-passed: ${{ steps.marker.outputs.cache-hit }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Only local git commands run here — no credentialed operations.
           persist-credentials: false
@@ -79,7 +79,7 @@ jobs:
 
       - name: Check for a prior passing run of this code
         id: marker
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .conformance-passed
           key: conformance-pass-v1-${{ steps.hash.outputs.hash }}
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # By the time an approved run starts, its commit may no longer be the
       # head of changeset-release/main. Concurrency is per-SHA (see above),
@@ -117,13 +117,13 @@ jobs:
             exit 1
           fi
 
+      # No version input — pnpm/action-setup v4+ reads the packageManager
+      # field from package.json (and errors if both are set and disagree).
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22.x"
           cache: "pnpm"
@@ -183,7 +183,7 @@ jobs:
       # bump it manually when a fresh suite build is needed.
       - name: Cache conformance suite build
         id: suite-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/conformance-suite/target
@@ -226,7 +226,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
@@ -267,14 +267,14 @@ jobs:
 
       - name: Save pass marker
         if: needs.precheck.outputs.already-passed != 'true' && (github.event_name == 'pull_request' || inputs.grep == '')
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .conformance-passed
           key: conformance-pass-v1-${{ needs.precheck.outputs.code-hash }}
 
       - name: Upload Playwright HTML report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: apps/conformance-runner/playwright-report/
@@ -282,7 +282,7 @@ jobs:
 
       - name: Upload OIDF conformance plan reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: conformance-reports
           path: apps/conformance-runner/conformance-reports/
@@ -291,7 +291,7 @@ jobs:
 
       - name: Upload Playwright traces
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-traces
           path: apps/conformance-runner/test-results/


### PR DESCRIPTION
## Summary

CI shows this deprecation warning on every conformance job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache/restore@v4, actions/checkout@v4.

The warning is about the actions' own runtimes, not the `node-version` used for the build (which stays at 22.x, the current LTS). This bumps each action in `conformance.yml` to the lowest major that targets node24:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/cache (+ restore/save) | v4 | v5 |
| actions/setup-node | v4 | v5 |
| actions/upload-artifact | v4 | v6 (v5 still runs node20) |
| pnpm/action-setup | v2 | v6 |

pnpm/action-setup v4+ reads the `packageManager` field from package.json (`pnpm@10.20.0`) and errors if an explicit `version` input disagrees, so the `version: 10` input is dropped.

Notes:
- cache v5 uses the same cache service/keys as v4, so existing suite/Playwright caches stay valid.
- The precheck code hash includes this workflow file, so the first release-PR run after merge does one full conformance run as expected.
- unit-tests.yml, release.yml and deploy-docs.yml still use the v4 actions and will warn the same way — left out of scope here.

No changeset: CI-only, no versioned package touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions workflow to newer major versions for checkout, Node setup, pnpm setup, caching, and artifact upload steps.
  * Improved compatibility with the latest workflow action releases across the conformance pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->