### PR TITLE
fix: never create users with the legacy auth2 provider

### DIFF
--- a/.changeset/never-create-auth2-users.md
+++ b/.changeset/never-create-auth2-users.md
@@ -1,0 +1,13 @@
+---
+"authhero": minor
+"@authhero/admin": patch
+---
+
+Never create users with the legacy "auth2" provider — new username/password users are always stamped with "auth0".
+
+- `resolveUsernamePasswordProvider` now defaults to `"auth0"` when no `usernamePasswordProvider` resolver is configured; return `"auth2"` from the resolver to pin a tenant on the legacy value during a staged cutover.
+- The management API `POST /users` no longer derives the provider from a database connection's `strategy` field (which legacy tenants persist as the `"auth2"` literal) and no longer honors a caller-supplied `"auth2"` provider — database users always get the tenant's resolved username-password provider.
+- The exported `USERNAME_PASSWORD_PROVIDER` constant changed from `"auth2"` to `"auth0"`; seeding and the `ensureUsername` pre-defined hook now create `auth0|*` accounts, while their lookups keep matching existing `auth2|*` rows so no duplicates are created.
+- The admin UI user-create form treats connections whose strategy is stored as `"auth2"`/`"auth0"` as password connections and always submits `provider: "auth0"`.
+
+Reads remain dual-provider: existing `auth2|*` users keep resolving and logging in.

--- a/apps/admin/src/resources/users/create.tsx
+++ b/apps/admin/src/resources/users/create.tsx
@@ -10,6 +10,19 @@ import { Strategy } from "@/utils/Strategy";
 
 const USERNAME_PASSWORD_PROVIDER = "auth0";
 
+// Legacy tenants persist database connections with the strategy field set
+// to a provider literal ("auth2", or "auth0" after migration) instead of
+// the canonical Auth0 strategy name. All of them are password connections,
+// and none of these literals may be forwarded as the provider — new users
+// must never be created with the legacy "auth2" provider.
+function isPasswordStrategy(strategy: string): boolean {
+  return (
+    strategy === Strategy.USERNAME_PASSWORD ||
+    strategy === "auth2" ||
+    strategy === "auth0"
+  );
+}
+
 interface ConnectionRecord {
   name: string;
   strategy: string;
@@ -29,7 +42,7 @@ export function UserCreate() {
     if (data.connection && connections) {
       const connection = connections.find((c) => c.name === data.connection);
       if (connection) {
-        if (connection.strategy === Strategy.USERNAME_PASSWORD) {
+        if (isPasswordStrategy(connection.strategy)) {
           data.provider = USERNAME_PASSWORD_PROVIDER;
           // Store the canonical Auth0 connection name regardless of what the
           // tenant's database connection happens to be named (e.g. "password"),

--- a/packages/authhero/src/constants.ts
+++ b/packages/authhero/src/constants.ts
@@ -1,4 +1,8 @@
-export const USERNAME_PASSWORD_PROVIDER = "auth2";
+// Provider value stamped on NEW username/password user rows. Legacy rows
+// (and some tenants' connection.strategy fields) still carry "auth2" —
+// reads must keep matching both via isUsernamePasswordProvider(); new
+// users must NEVER be created with "auth2".
+export const USERNAME_PASSWORD_PROVIDER = "auth0";
 
 export const JWKS_CACHE_TIMEOUT_IN_SECONDS = 60 * 5; // 5 minutes
 export const SILENT_AUTH_MAX_AGE_IN_SECONDS = 30 * 24 * 60 * 60; // 30 days

--- a/packages/authhero/src/hooks/pre-defined/ensure-username.ts
+++ b/packages/authhero/src/hooks/pre-defined/ensure-username.ts
@@ -3,6 +3,10 @@ import { userIdGenerate } from "../../utils/user-id";
 import { USERNAME_PASSWORD_PROVIDER } from "../../constants";
 import { Strategy } from "@authhero/adapter-interfaces";
 import { isUniqueConstraintError } from "../../errors/is-unique-constraint-error";
+import {
+  USERNAME_PASSWORD_PROVIDERS,
+  isUsernamePasswordProvider,
+} from "../../utils/username-password-provider";
 
 export interface EnsureUsernameOptions {
   /**
@@ -98,16 +102,21 @@ async function isUsernameTaken(
   userAdapter: { list: (tenant_id: string, params?: any) => Promise<any> },
   tenantId: string,
   username: string,
-  provider: string,
+  providers: readonly string[],
 ): Promise<boolean> {
-  const { users } = await userAdapter.list(tenantId, {
-    page: 0,
-    per_page: 1,
-    include_totals: false,
-    q: `username:${username} provider:${provider}`,
-  });
+  for (const provider of providers) {
+    const { users } = await userAdapter.list(tenantId, {
+      page: 0,
+      per_page: 1,
+      include_totals: false,
+      q: `username:${username} provider:${provider}`,
+    });
+    if (users.length > 0) {
+      return true;
+    }
+  }
 
-  return users.length > 0;
+  return false;
 }
 
 /**
@@ -124,12 +133,12 @@ async function findUniqueUsername(
   userAdapter: { list: (tenant_id: string, params?: any) => Promise<any> },
   tenantId: string,
   candidates: string[],
-  provider: string,
+  providers: readonly string[],
   maxRetries: number,
 ): Promise<string | undefined> {
   for (const base of candidates) {
     // Try the base candidate first
-    if (!(await isUsernameTaken(userAdapter, tenantId, base, provider))) {
+    if (!(await isUsernameTaken(userAdapter, tenantId, base, providers))) {
       return base;
     }
 
@@ -137,7 +146,7 @@ async function findUniqueUsername(
     for (let i = 2; i <= maxRetries + 1; i++) {
       const candidate = `${base}${i}`;
       if (
-        !(await isUsernameTaken(userAdapter, tenantId, candidate, provider))
+        !(await isUsernameTaken(userAdapter, tenantId, candidate, providers))
       ) {
         return candidate;
       }
@@ -160,10 +169,10 @@ function userHasUsername(
       profileData?: { username?: string };
     }> | null;
   },
-  provider: string,
+  matchesProvider: (provider?: string) => boolean,
 ): boolean {
   // If the user itself is a username-type account with a username set
-  if (user.provider === provider && user.username) {
+  if (matchesProvider(user.provider) && user.username) {
     return true;
   }
 
@@ -171,7 +180,7 @@ function userHasUsername(
   if (user.identities) {
     return user.identities.some(
       (identity) =>
-        identity.provider === provider && identity.profileData?.username,
+        matchesProvider(identity.provider) && identity.profileData?.username,
     );
   }
 
@@ -222,7 +231,16 @@ export function ensureUsername(
   options?: EnsureUsernameOptions,
 ): OnExecutePostLogin {
   const connection = options?.connection ?? Strategy.USERNAME_PASSWORD;
-  const provider = options?.provider ?? USERNAME_PASSWORD_PROVIDER;
+  // Value stamped on NEWLY created username accounts. Reads must keep
+  // matching legacy "auth2" rows too, so lookups use matchesProvider /
+  // lookupProviders rather than this single value.
+  const writeProvider = options?.provider ?? USERNAME_PASSWORD_PROVIDER;
+  const matchesProvider = options?.provider
+    ? (provider?: string) => provider === options.provider
+    : isUsernamePasswordProvider;
+  const lookupProviders: readonly string[] = options?.provider
+    ? [options.provider]
+    : USERNAME_PASSWORD_PROVIDERS;
   const maxRetries = Math.max(0, Math.floor(options?.maxRetries ?? 10));
 
   return async (event, _api) => {
@@ -236,22 +254,24 @@ export function ensureUsername(
     const data = ctx.env.data;
 
     // Already has a username — nothing to do
-    if (userHasUsername(user, provider)) {
+    if (userHasUsername(user, matchesProvider)) {
       return;
     }
 
     // Check if any linked user in the DB already has a username account.
     // The identities array on the primary user may not be populated, so we
     // query the database directly to avoid creating duplicate username accounts.
-    if (user.provider !== provider) {
-      const { users: linkedUsernameUsers } = await data.users.list(tenantId, {
-        page: 0,
-        per_page: 1,
-        include_totals: false,
-        q: `linked_to:${user.user_id} provider:${provider}`,
-      });
-      if (linkedUsernameUsers.length > 0) {
-        return;
+    if (!matchesProvider(user.provider)) {
+      for (const lookupProvider of lookupProviders) {
+        const { users: linkedUsernameUsers } = await data.users.list(tenantId, {
+          page: 0,
+          per_page: 1,
+          include_totals: false,
+          q: `linked_to:${user.user_id} provider:${lookupProvider}`,
+        });
+        if (linkedUsernameUsers.length > 0) {
+          return;
+        }
       }
     }
 
@@ -273,7 +293,7 @@ export function ensureUsername(
         data.users,
         tenantId,
         candidates,
-        provider,
+        lookupProviders,
         maxRetries,
       );
 
@@ -285,18 +305,18 @@ export function ensureUsername(
       }
 
       try {
-        if (user.provider === provider) {
+        if (matchesProvider(user.provider)) {
           // This IS a username-type account — just set the username field
           await data.users.update(tenantId, user.user_id, { username });
         } else {
           // Different provider — create a linked username account
-          const usernameUserId = `${provider}|${userIdGenerate()}`;
+          const usernameUserId = `${writeProvider}|${userIdGenerate()}`;
 
           await data.users.create(tenantId, {
             user_id: usernameUserId,
             username,
             name: username,
-            provider,
+            provider: writeProvider,
             connection,
             email_verified: false,
             is_social: false,

--- a/packages/authhero/src/routes/management-api/connections.ts
+++ b/packages/authhero/src/routes/management-api/connections.ts
@@ -9,7 +9,6 @@ import {
   connectionSchema,
   totalsSchema,
   LogTypes,
-  Strategy,
 } from "@authhero/adapter-interfaces";
 import { parseSort } from "../../utils/sort";
 import { generateConnectionId } from "../../utils/entity-id";
@@ -21,19 +20,10 @@ import { getEnrichedClient } from "../../helpers/client";
 import { getTenantCustomDomain } from "../../helpers/custom-domain";
 import { getAuthUrl } from "../../variables";
 import { passwordGrant } from "../../authentication-flows/password";
-import { USERNAME_PASSWORD_PROVIDER } from "../../constants";
+import { isDatabaseConnectionStrategy } from "../../utils/username-password-provider";
 import { nanoid } from "nanoid";
 
 import { defineRoute } from "../../utils/define-route";
-// Some tenants persist database connections with the strategy field set to
-// the provider literal ("auth2") rather than the canonical Auth0 strategy
-// name. Treat both as a database connection for the try-flow.
-function isDatabaseConnection(strategy: string): boolean {
-  return (
-    strategy === Strategy.USERNAME_PASSWORD ||
-    strategy === USERNAME_PASSWORD_PROVIDER
-  );
-}
 
 const connectionsWithTotalsSchema = totalsSchema.extend({
   connections: z.array(connectionSchema),
@@ -610,7 +600,7 @@ const postByIdTry = defineRoute({
     });
 
     // Database connections complete inline — no browser round-trip needed.
-    if (isDatabaseConnection(connection.strategy)) {
+    if (isDatabaseConnectionStrategy(connection.strategy)) {
       const body = ctx.req.valid("json") ?? {};
       if (!body.username || !body.password) {
         throw new HTTPException(400, {

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -22,7 +22,11 @@ import {
   organizationSchema,
 } from "@authhero/adapter-interfaces";
 import { getProviderFromConnection } from "../../strategies";
-import { isUsernamePasswordProvider } from "../../utils/username-password-provider";
+import {
+  isDatabaseConnectionStrategy,
+  isUsernamePasswordProvider,
+  resolveUsernamePasswordProvider,
+} from "../../utils/username-password-provider";
 import { getIssuer } from "../../variables";
 import { withDefaultPicture } from "../../helpers/avatar";
 
@@ -59,7 +63,6 @@ const usersWithTotalsSchema = totalsSchema.extend({
 const sessionsWithTotalsSchema = totalsSchema.extend({
   sessions: z.array(sessionSchema),
 });
-
 
 const logsWithTotalsSchema = totalsSchema.extend({
   logs: z.array(logSchema),
@@ -363,10 +366,23 @@ const postRoot = defineRoute({
       connection,
     );
 
+    // Database (username/password) users get the tenant's configured
+    // username-password provider — never the connection's strategy field,
+    // which legacy tenants persist as the "auth2" provider literal, and
+    // never a caller-supplied "auth2". The lookup above is by connection
+    // id, so also classify by connection name / provider for tenants whose
+    // password connection has a generated id.
+    const isDatabaseUser = connectionRecord
+      ? isDatabaseConnectionStrategy(connectionRecord.strategy)
+      : connection === Strategy.USERNAME_PASSWORD ||
+        isUsernamePasswordProvider(providedProvider);
+
     // Derive provider from connection, or use provided provider for migration
-    const provider = connectionRecord
-      ? getProviderFromConnection(connectionRecord)
-      : providedProvider || connection;
+    const provider = isDatabaseUser
+      ? await resolveUsernamePasswordProvider(ctx.env, ctx.var.tenant_id)
+      : connectionRecord
+        ? getProviderFromConnection(connectionRecord)
+        : providedProvider || connection;
 
     // Parse user_id to avoid double-prefixing if client sends provider-prefixed id
     const rawUserId = body["user_id"];

--- a/packages/authhero/src/types/AuthHeroConfig.ts
+++ b/packages/authhero/src/types/AuthHeroConfig.ts
@@ -194,11 +194,11 @@ export type UserLinkingModeOption = UserLinkingMode | UserLinkingModeResolver;
 /**
  * Resolver for the per-tenant username/password provider value.
  *
- * The native database provider has historically been written as `"auth2"`.
- * Returning `"auth0"` for selected tenants lets you migrate them onto the
- * `"auth0"` provider value (matching what the legacy Auth0 import format
- * used) one tenant at a time. Reads always accept both values, so existing
- * `auth2|*` rows keep resolving during and after the cutover.
+ * The native database provider has historically been written as `"auth2"`;
+ * new rows now default to `"auth0"`. Returning `"auth2"` for selected
+ * tenants pins them on the legacy value during a staged cutover. Reads
+ * always accept both values, so existing `auth2|*` rows keep resolving
+ * during and after the cutover.
  *
  * TRANSITIONAL: this resolver and the dual-read fallback can be removed
  * once every tenant has been migrated to a single value.
@@ -576,11 +576,12 @@ export interface AuthHeroConfig {
 
   /**
    * Per-tenant override for the username/password provider value used on
-   * NEW user rows. Returning `"auth0"` for a tenant migrates new signups,
-   * password resets, etc. onto the `auth0|*` user_id format. Existing
+   * NEW user rows. Omit to write `"auth0"` for every tenant — new signups,
+   * password resets, etc. use the `auth0|*` user_id format. Existing
    * `auth2|*` rows keep working — reads accept either value.
    *
-   * Omit to keep the legacy `"auth2"` value for every tenant.
+   * Returning `"auth2"` pins a tenant on the legacy value during a staged
+   * cutover.
    *
    * TRANSITIONAL: this hook and the dual-read fallback in the password
    * flows can be removed once all tenants have been backfilled.

--- a/packages/authhero/src/types/Bindings.ts
+++ b/packages/authhero/src/types/Bindings.ts
@@ -89,9 +89,9 @@ export type Bindings = {
   userLinkingMode?: UserLinkingModeOption;
 
   // Per-tenant override for the native database provider value written on
-  // new password users. When unset, all tenants use the legacy "auth2".
-  // Returning "auth0" for a tenant migrates that tenant onto the "auth0"
-  // provider value. TRANSITIONAL — remove once all tenants are backfilled.
+  // new password users. When unset, all tenants write "auth0". Returning
+  // "auth2" pins a tenant on the legacy provider value during a staged
+  // cutover. TRANSITIONAL — remove once all tenants are backfilled.
   usernamePasswordProvider?: UsernamePasswordProviderResolver;
 
   // Per-tenant signing-key bucket selector. When unset, every tenant

--- a/packages/authhero/src/utils/username-password-provider.ts
+++ b/packages/authhero/src/utils/username-password-provider.ts
@@ -12,15 +12,15 @@ import {
  * TRANSITIONAL helpers for the auth2 → auth0 provider migration.
  *
  * Historically every native database user has been stored with
- * `provider = "auth2"` and `user_id = "auth2|<id>"`. We're moving onto the
- * `"auth0"` provider value, one tenant at a time, by setting
- * `init({ usernamePasswordProvider })` to return `"auth0"` for the
- * migrated tenants.
+ * `provider = "auth2"` and `user_id = "auth2|<id>"`. New rows are now
+ * written with the `"auth0"` provider value everywhere; the
+ * `init({ usernamePasswordProvider })` resolver only exists to pin a
+ * tenant back onto `"auth2"` during a staged cutover.
  *
  * Two surfaces are exposed:
  *
  * - {@link resolveUsernamePasswordProvider} — used at WRITE sites to pick
- *   the value to stamp on a new row. Defaults to `"auth2"`.
+ *   the value to stamp on a new row. Defaults to `"auth0"`.
  * - {@link isUsernamePasswordProvider} / {@link getUsernamePasswordUser} /
  *   {@link getPrimaryUsernamePasswordUser} — used at READ sites to match
  *   existing rows under EITHER value, so a tenant can have a mix of
@@ -33,16 +33,41 @@ import {
 const LEGACY_PROVIDER = "auth2";
 const TARGET_PROVIDER = "auth0";
 
+/**
+ * True when a connection's `strategy` field marks it as a native database
+ * (username/password) connection. Legacy tenants persist the provider
+ * literal ("auth2") in the strategy field instead of the canonical Auth0
+ * strategy name, and either provider literal must never leak into new
+ * user rows as the provider — write sites go through
+ * {@link resolveUsernamePasswordProvider} instead.
+ */
+export function isDatabaseConnectionStrategy(
+  strategy: string | undefined | null,
+): boolean {
+  return (
+    strategy === "Username-Password-Authentication" ||
+    strategy === LEGACY_PROVIDER ||
+    strategy === TARGET_PROVIDER
+  );
+}
+
 export type UsernamePasswordProviderValue =
   | typeof LEGACY_PROVIDER
   | typeof TARGET_PROVIDER;
+
+/**
+ * Both native database provider values, legacy first — for read sites
+ * that need to enumerate rather than predicate-match.
+ */
+export const USERNAME_PASSWORD_PROVIDERS: readonly UsernamePasswordProviderValue[] =
+  [LEGACY_PROVIDER, TARGET_PROVIDER];
 
 export async function resolveUsernamePasswordProvider(
   env: Bindings,
   tenant_id: string,
 ): Promise<UsernamePasswordProviderValue> {
   if (!env.usernamePasswordProvider) {
-    return LEGACY_PROVIDER;
+    return TARGET_PROVIDER;
   }
   return env.usernamePasswordProvider({ tenant_id });
 }

--- a/packages/authhero/test/helpers/test-server.ts
+++ b/packages/authhero/test/helpers/test-server.ts
@@ -30,7 +30,6 @@ import { Bindings } from "../../src/types";
 import { MockEmailService } from "./mock-email-service";
 import { MockSmsService } from "./mock-sms-service";
 import { mockStrategy } from "./mock-strategy";
-import { USERNAME_PASSWORD_PROVIDER } from "../../src/constants";
 
 type getEnvParams = {
   testTenantLanguage?: string;
@@ -178,11 +177,13 @@ export async function getTestServer(
     },
   });
 
-  // Add the Username-Password-Authentication connection
+  // Add the Username-Password-Authentication connection. Legacy tenants
+  // persist the strategy as the "auth2" provider literal — keep that here
+  // so tests prove new users are still stamped with the "auth0" provider.
   await data.connections.create("tenantId", {
     id: "Username-Password-Authentication",
     name: "Username-Password-Authentication",
-    strategy: USERNAME_PASSWORD_PROVIDER,
+    strategy: "auth2",
     options: {},
   });
 

--- a/packages/authhero/test/routes/management-api/try-connection.spec.ts
+++ b/packages/authhero/test/routes/management-api/try-connection.spec.ts
@@ -50,7 +50,9 @@ describe("POST /api/v2/connections/:id/try", () => {
     expect(body.mode).toBe("inline");
     expect(body.status).toBe("success");
     expect(body.connection_name).toBe("Username-Password-Authentication");
-    expect(body.strategy).toBe(USERNAME_PASSWORD_PROVIDER);
+    // The fixture models a legacy tenant whose connection row persists the
+    // "auth2" provider literal in the strategy field.
+    expect(body.strategy).toBe("auth2");
     expect(body.userinfo?.email).toBe("testuser@example.com");
   });
 

--- a/packages/authhero/test/routes/management-api/users.spec.ts
+++ b/packages/authhero/test/routes/management-api/users.spec.ts
@@ -909,11 +909,13 @@ describe("users management API endpoint", () => {
           is_social: false,
         });
 
+        // Legacy native user — must stay the literal "auth2" to model
+        // rows written before the auth0 provider cutover.
         await env.data.users.create("tenantId", {
-          user_id: `${USERNAME_PASSWORD_PROVIDER}|linked-user`,
+          user_id: "auth2|linked-user",
           email: "imported@example.com",
           email_verified: true,
-          provider: USERNAME_PASSWORD_PROVIDER,
+          provider: "auth2",
           connection: Strategy.USERNAME_PASSWORD,
           is_social: false,
           linked_to: "auth0|primary-user",
@@ -943,7 +945,7 @@ describe("users management API endpoint", () => {
 
         const auth2Password = await env.data.passwords.get(
           "tenantId",
-          `${USERNAME_PASSWORD_PROVIDER}|linked-user`,
+          "auth2|linked-user",
         );
         expect(auth2Password).toBeDefined();
 

--- a/packages/authhero/test/utils/username-password-provider.spec.ts
+++ b/packages/authhero/test/utils/username-password-provider.spec.ts
@@ -22,10 +22,10 @@ describe("isUsernamePasswordProvider", () => {
 });
 
 describe("resolveUsernamePasswordProvider", () => {
-  it("defaults to auth2 when no resolver is configured", async () => {
+  it("defaults to auth0 when no resolver is configured", async () => {
     const { env } = await getTestServer();
     expect(await resolveUsernamePasswordProvider(env, "tenantId")).toBe(
-      "auth2",
+      "auth0",
     );
   });
 


### PR DESCRIPTION
## Problem

The admin UI could still create `auth2|*` users. Three places could stamp the legacy provider:

1. **Admin UI create form** only recognized password connections by the canonical `Username-Password-Authentication` strategy. Legacy tenants persist the connection with `strategy: "auth2"`, so the form fell through and sent `provider: "auth2"`.
2. **Management API `POST /users`** derived the provider straight from `connection.strategy` (the `"auth2"` literal on legacy tenants), ignoring the provider the client sent — and when the connection lookup missed (name vs generated id), it honored a caller-supplied `"auth2"`.
3. **`resolveUsernamePasswordProvider`** still defaulted to `"auth2"` for deployments without a `usernamePasswordProvider` config, so signup / ticket / password-reset flows defaulted to the legacy value too.

## Changes

- `resolveUsernamePasswordProvider` now defaults to `"auth0"`; the `usernamePasswordProvider` config remains as an escape hatch to pin a tenant on `"auth2"` during a staged cutover.
- Management API `POST /users`: database users always get the tenant's resolved username-password provider — never the connection's strategy field and never a caller-supplied `"auth2"`. Added shared `isDatabaseConnectionStrategy()` that recognizes all three stored strategy spellings (`Username-Password-Authentication`, `auth2`, `auth0`); the try-connection route now uses it too.
- Admin UI create form treats `"auth2"`/`"auth0"` strategy values as password connections and always submits `provider: "auth0"` with the canonical connection name.
- `USERNAME_PASSWORD_PROVIDER` constant flipped to `"auth0"` — seeding and the `ensureUsername` hook create `auth0|*` accounts, while their lookups (has-username, linked-account, uniqueness) now match both provider values so legacy `auth2` username accounts don't get duplicated.

Reads stay dual-provider throughout (`auth2` first, since that row carries the working bcrypt hash), so existing `auth2|*` users keep resolving and logging in. Tenant export/import is unaffected — it writes through the adapters directly.

The test fixture now deliberately models a legacy tenant (`strategy: "auth2"`) to prove new users are still stamped `auth0`.

## Note for sesamy/auth

With the new default, a `usernamePasswordProvider` config that returns `"auth2"` for unmigrated tenants will keep creating auth2 users there — removing the config now gives `auth0` everywhere.

## Testing

- Full `authhero` suite: 1723 passed
- Admin UI tests: 25 passed
- `tsc --noEmit` clean in both `packages/authhero` and `apps/admin`
- Changeset included (`authhero` minor, `@authhero/admin` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New username/password accounts are now created with the updated default provider value, while existing accounts continue to sign in normally.
  * User creation and connection flows now handle both legacy and current password-based account formats.

* **Bug Fixes**
  * Prevented new legacy-style password users from being created unintentionally.
  * Improved user lookup and username assignment to avoid duplicate accounts during migration or cutover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->