### PR TITLE
feat(analytics): surface spm password migrations in logs filter and analytics

### DIFF
--- a/.changeset/spm-logs-filter-analytics.md
+++ b/.changeset/spm-logs-filter-analytics.md
@@ -1,0 +1,10 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+"@authhero/admin": patch
+"@authhero/drizzle": patch
+"@authhero/kysely-adapter": patch
+"@authhero/cloudflare-adapter": patch
+---
+
+Surface the `spm` (Success Password Migration) log type: add a `password-migrations` analytics resource (`GET /api/v2/analytics/password-migrations`) backed by the drizzle, kysely, and Analytics Engine adapters, show it as "Password Migrations" on the admin analytics page, add `spm` to the admin logs type filter, and sort both the logs type filter and the analytics resource dropdown alphabetically.

--- a/apps/admin/src/resources/analytics/AnalyticsPage.tsx
+++ b/apps/admin/src/resources/analytics/AnalyticsPage.tsx
@@ -38,6 +38,7 @@ import {
   resolveInterval,
 } from "./analyticsTime";
 
+// Ordered alphabetically by label — this drives the resource dropdown.
 const RESOURCES: Array<{
   value: AnalyticsResource;
   label: string;
@@ -51,16 +52,46 @@ const RESOURCES: Array<{
     dims: ["time", "connection", "client_id", "user_type"],
   },
   {
+    value: "codes-sent",
+    label: "Codes Sent",
+    metric: "codes_sent",
+    dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
+  {
+    value: "email-verifications",
+    label: "Email Verifications",
+    metric: "email_verifications",
+    dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
+  {
     value: "logins",
     label: "Logins",
     metric: "logins",
     dims: ["time", "connection", "client_id", "user_type", "event"],
   },
   {
-    value: "signups",
-    label: "Signups",
-    metric: "signups",
+    value: "logouts",
+    label: "Logouts",
+    metric: "logouts",
     dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
+  {
+    value: "mfa",
+    label: "MFA",
+    metric: "mfa",
+    dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
+  {
+    value: "password-changes",
+    label: "Password Changes",
+    metric: "password_changes",
+    dims: ["time", "connection", "client_id", "user_type", "event"],
+  },
+  {
+    value: "password-migrations",
+    label: "Password Migrations",
+    metric: "password_migrations",
+    dims: ["time", "connection", "client_id", "user_type"],
   },
   {
     value: "refresh-tokens",
@@ -75,33 +106,9 @@ const RESOURCES: Array<{
     dims: ["time", "client_id"],
   },
   {
-    value: "logouts",
-    label: "Logouts",
-    metric: "logouts",
-    dims: ["time", "connection", "client_id", "user_type", "event"],
-  },
-  {
-    value: "password-changes",
-    label: "Password Changes",
-    metric: "password_changes",
-    dims: ["time", "connection", "client_id", "user_type", "event"],
-  },
-  {
-    value: "mfa",
-    label: "MFA",
-    metric: "mfa",
-    dims: ["time", "connection", "client_id", "user_type", "event"],
-  },
-  {
-    value: "email-verifications",
-    label: "Email Verifications",
-    metric: "email_verifications",
-    dims: ["time", "connection", "client_id", "user_type", "event"],
-  },
-  {
-    value: "codes-sent",
-    label: "Codes Sent",
-    metric: "codes_sent",
+    value: "signups",
+    label: "Signups",
+    metric: "signups",
     dims: ["time", "connection", "client_id", "user_type", "event"],
   },
 ];

--- a/apps/admin/src/resources/analytics/useAnalyticsQuery.ts
+++ b/apps/admin/src/resources/analytics/useAnalyticsQuery.ts
@@ -19,6 +19,7 @@ export type AnalyticsResource =
   | "sessions"
   | "logouts"
   | "password-changes"
+  | "password-migrations"
   | "mfa"
   | "email-verifications"
   | "codes-sent";

--- a/apps/admin/src/resources/logs/LogsTable.tsx
+++ b/apps/admin/src/resources/logs/LogsTable.tsx
@@ -25,6 +25,7 @@ const FILTER_TYPES: readonly string[] = [
   LogTypes.FAILED_CHANGE_EMAIL,
   LogTypes.SUCCESS_CHANGE_PASSWORD,
   LogTypes.FAILED_CHANGE_PASSWORD,
+  LogTypes.SUCCESS_PASSWORD_MIGRATION,
   LogTypes.SUCCESS_HOOK,
   LogTypes.FAILED_HOOK,
 ];
@@ -32,7 +33,7 @@ const FILTER_TYPES: readonly string[] = [
 const typeChoices = FILTER_TYPES.map((id) => ({
   id,
   name: getLogTypeDescription(id),
-}));
+})).sort((a, b) => a.name.localeCompare(b.name));
 
 const statusChoices = [
   { id: "true", name: "Success" },

--- a/packages/adapter-interfaces/src/types/Analytics.ts
+++ b/packages/adapter-interfaces/src/types/Analytics.ts
@@ -8,6 +8,7 @@ export const analyticsResourceSchema = z.enum([
   "sessions",
   "logouts",
   "password-changes",
+  "password-migrations",
   "mfa",
   "email-verifications",
   "codes-sent",

--- a/packages/authhero/src/routes/management-api/analytics.ts
+++ b/packages/authhero/src/routes/management-api/analytics.ts
@@ -21,6 +21,7 @@ const VALID_GROUP_BY: Record<AnalyticsResource, AnalyticsGroupBy[]> = {
   sessions: ["time", "client_id"],
   logouts: ["time", "connection", "client_id", "user_type", "event"],
   "password-changes": ["time", "connection", "client_id", "user_type", "event"],
+  "password-migrations": ["time", "connection", "client_id", "user_type"],
   mfa: ["time", "connection", "client_id", "user_type", "event"],
   "email-verifications": [
     "time",
@@ -48,6 +49,7 @@ const METRIC_BY_RESOURCE: Record<AnalyticsResource, string> = {
   sessions: "sessions",
   logouts: "logouts",
   "password-changes": "password_changes",
+  "password-migrations": "password_migrations",
   mfa: "mfa",
   "email-verifications": "email_verifications",
   "codes-sent": "codes_sent",
@@ -436,6 +438,7 @@ export function createAnalyticsRoutes(options: AnalyticsRoutesOptions = {}) {
     "sessions",
     "logouts",
     "password-changes",
+    "password-migrations",
     "mfa",
     "email-verifications",
     "codes-sent",

--- a/packages/cloudflare/src/analytics-engine-logs/analytics.ts
+++ b/packages/cloudflare/src/analytics-engine-logs/analytics.ts
@@ -19,6 +19,7 @@ const RESOURCE_EVENTS: Record<AnalyticsResource, readonly string[]> = {
   sessions: ["slo"],
   logouts: ["slo", "flo"],
   "password-changes": ["scp", "fcp", "scpr", "fcpr"],
+  "password-migrations": ["spm"],
   mfa: ["gd_auth_succeed", "gd_auth_failed", "gd_auth_rejected"],
   "email-verifications": ["sv", "fv", "svr", "fvr"],
   "codes-sent": ["cls", "cs"],
@@ -61,6 +62,11 @@ const METRIC_BY_RESOURCE: Record<
   "password-changes": {
     expr: "count()",
     alias: "password_changes",
+    type: "UInt64",
+  },
+  "password-migrations": {
+    expr: "count()",
+    alias: "password_migrations",
     type: "UInt64",
   },
   mfa: { expr: "count()", alias: "mfa", type: "UInt64" },

--- a/packages/drizzle/src/adapters/analytics.ts
+++ b/packages/drizzle/src/adapters/analytics.ts
@@ -17,6 +17,7 @@ const RESOURCE_EVENTS: Record<AnalyticsResource, readonly string[]> = {
   sessions: ["slo"],
   logouts: ["slo", "flo"],
   "password-changes": ["scp", "fcp", "scpr", "fcpr"],
+  "password-migrations": ["spm"],
   mfa: ["gd_auth_succeed", "gd_auth_failed", "gd_auth_rejected"],
   "email-verifications": ["sv", "fv", "svr", "fvr"],
   "codes-sent": ["cls", "cs"],
@@ -34,6 +35,11 @@ const METRIC_BY_RESOURCE: Record<
   logouts: { alias: "logouts", type: "UInt64", agg: "count" },
   "password-changes": {
     alias: "password_changes",
+    type: "UInt64",
+    agg: "count",
+  },
+  "password-migrations": {
+    alias: "password_migrations",
     type: "UInt64",
     agg: "count",
   },

--- a/packages/kysely/src/analytics/index.ts
+++ b/packages/kysely/src/analytics/index.ts
@@ -17,6 +17,7 @@ const RESOURCE_EVENTS: Record<AnalyticsResource, readonly string[]> = {
   sessions: ["slo"],
   logouts: ["slo", "flo"],
   "password-changes": ["scp", "fcp", "scpr", "fcpr"],
+  "password-migrations": ["spm"],
   mfa: ["gd_auth_succeed", "gd_auth_failed", "gd_auth_rejected"],
   "email-verifications": ["sv", "fv", "svr", "fvr"],
   "codes-sent": ["cls", "cs"],
@@ -38,6 +39,11 @@ const METRIC_BY_RESOURCE: Record<
   logouts: { alias: "logouts", type: "UInt64", agg: "count" },
   "password-changes": {
     alias: "password_changes",
+    type: "UInt64",
+    agg: "count",
+  },
+  "password-migrations": {
+    alias: "password_migrations",
     type: "UInt64",
     agg: "count",
   },


### PR DESCRIPTION
## Summary

Makes the `spm` (Success Password Migration) log type — written when a password is validated against the upstream Auth0 tenant and imported locally during lazy migration — visible in the admin UI:

- **New `password-migrations` analytics resource**: added to the `AnalyticsResource` enum, registered as `GET /api/v2/analytics/password-migrations` in the management API (group-by: time, connection, client_id, user_type), and mapped to the `spm` event in all three analytics adapters (drizzle, kysely, Cloudflare Analytics Engine).
- **Admin analytics page**: "Password Migrations" appears in the resource dropdown; the resource list is now ordered alphabetically.
- **Admin logs filter**: `spm` added to the type filter dropdown, and the type choices are now sorted alphabetically by label.
- Metrics stay disjoint: `spm` is not counted under `password-changes`.

## Testing

- Cloudflare Analytics Engine tests (17) pass
- authhero analytics route tests (9) pass
- admin `tsc --noEmit` clean, admin tests (25) pass
- All touched packages rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)