### PR TITLE
docs(claude): correct the grant-type list in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ This is a **pnpm monorepo** implementing a multi-tenant authentication/IAM syste
 
 ### Packages
 
-- **`packages/authhero`** — Core Hono.js HTTP application. Contains all auth routes, login UI (React + TailwindCSS), authentication flows (authorization code, refresh token, device flow, etc.), and state machines. Built with Vite; outputs CJS + ESM bundles. i18n handled at build time via Paraglide.
+- **`packages/authhero`** — Core Hono.js HTTP application. Contains all auth routes, login UI (React + TailwindCSS), authentication flows (authorization code, refresh token, client credentials, token exchange, passwordless OTP, etc.), and state machines. Built with Vite; outputs CJS + ESM bundles. i18n handled at build time via Paraglide.
 - **`packages/adapter-interfaces`** — TypeScript interfaces defining the adapter contract (CRUD for tenants, users, clients, connections, etc.). All database adapters must implement these.
 - **`packages/kysely`** — Kysely ORM adapter for PlanetScale (MySQL) and other SQL databases. Kept while PlanetScale runs in production; new deployments should use drizzle. ~39 entity modules each handling one domain entity.
 - **`packages/drizzle`** — Primary database adapter (Drizzle ORM, SQLite/D1). Used by all create-authhero templates; ships pre-generated migrations in `drizzle/`.


### PR DESCRIPTION
During the docs staleness sweep (#1050) the code check showed that device flow (RFC 8628) is not implemented anywhere — no device authorization route, no `device_code` grant in the token endpoint, and the endpoint is not advertised in discovery — yet CLAUDE.md listed it as an implemented flow.

Replace it with the grants that actually exist: client credentials, token exchange (RFC 8693), and passwordless OTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)