### PR TITLE
fix(cloudflare): export createWfpProvisionerSteps from package root

### DIFF
--- a/.changeset/export-wfp-provisioner-steps.md
+++ b/.changeset/export-wfp-provisioner-steps.md
@@ -1,0 +1,5 @@
+---
+"@authhero/cloudflare-adapter": patch
+---
+
+Export `createWfpProvisionerSteps` and its types (`TenantProvisionerSteps`, `TenantProvisionNames`, `WfpProvisionerSteps`) from the package root. They were exported from the internal `wfp-provisioner` module but missing from the public entry point, so consumers wiring the steps into a durable workflow (e.g. Cloudflare Workflows) could not import them.

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -77,6 +77,7 @@ export { createR2SQLStatsAdapter } from "./r2-sql-logs";
 // per-tenant D1 + namespaced worker on every tenant create.
 export {
   createCloudflareWfpD1Provisioner,
+  createWfpProvisionerSteps,
   createWfpTenantProvisioningHook,
   createWfpForwardMiddleware,
   CloudflareApiClient,
@@ -85,6 +86,9 @@ export {
 export type {
   CloudflareWfpD1Provisioner,
   CloudflareWfpD1ProvisionerOptions,
+  TenantProvisionerSteps,
+  TenantProvisionNames,
+  WfpProvisionerSteps,
   ProvisionResult,
   ProvisionerMigration,
   TenantSecretsResolver,


### PR DESCRIPTION
## Summary
- `createWfpProvisionerSteps` (added in #1039) was exported from the internal `wfp-provisioner` module but never re-exported from the package root, and no subpath export (`/wfp`, `/workflows`) exposes it — so the published `@authhero/cloudflare-adapter@2.38.0` cannot be used to wire the provisioner steps into a durable workflow.
- Adds `createWfpProvisionerSteps` plus the `TenantProvisionerSteps`, `TenantProvisionNames`, and `WfpProvisionerSteps` types to the root export, with a patch changeset.

This unblocks sesamy/auth CI, which imports `createWfpProvisionerSteps` in its tenant-operations workflow and currently fails type-check against the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)