### PR TITLE
refactor: tolerant database-connection strategy matching, seed strategy "auth0"

### DIFF
--- a/.changeset/database-connection-strategy-auth0.md
+++ b/.changeset/database-connection-strategy-auth0.md
@@ -1,0 +1,13 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+"@authhero/admin": patch
+---
+
+Recognize every spelling of the database-connection strategy and write the Auth0-canonical value on new connections.
+
+- `@authhero/adapter-interfaces` exports `DATABASE_CONNECTION_STRATEGY` (`"auth0"`, what Auth0 stores on database connections) and `isDatabaseConnectionStrategy()`, which matches the canonical `"auth0"` plus the two legacy spellings still present in existing data: `"Username-Password-Authentication"` (the connection name reused as strategy) and `"auth2"` (the legacy provider literal).
+- All readers that detect a password connection — universal-login screens, password/ticket/dbconnections flows, callback error routing, and the admin UI — now use the tolerant matcher instead of comparing against the exact `"Username-Password-Authentication"` string. Tenants whose connection rows carry a legacy strategy value get correct password-login behavior everywhere.
+- `seed()` now creates the database connection with `strategy: "auth0"` (name stays `"Username-Password-Authentication"`), matching Auth0's management API shape.
+
+This is the prerequisite for backfilling existing connection rows to `strategy = "auth0"`: once this version is deployed, the backfill is a plain UPDATE and no reader depends on the old spellings.

--- a/apps/admin/src/resources/connections/edit.tsx
+++ b/apps/admin/src/resources/connections/edit.tsx
@@ -3,7 +3,7 @@ import { DeleteButton } from "@/components/admin/delete-button";
 import { useRecordContext } from "ra-core";
 import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UrlTabs } from "@/components/ui/url-tabs";
-import { Strategy } from "@/utils/Strategy";
+import { isDatabaseConnectionStrategy } from "@/utils/Strategy";
 import { DetailsTab } from "./tabs/details-tab";
 import { AttributesTab } from "./tabs/attributes-tab";
 import { AuthenticationMethodsTab } from "./tabs/authentication-methods-tab";
@@ -30,7 +30,7 @@ function stripNulls(value: unknown): unknown {
 
 function ConnectionTabs() {
   const record = useRecordContext();
-  const isDb = record?.strategy === Strategy.USERNAME_PASSWORD;
+  const isDb = isDatabaseConnectionStrategy(record?.strategy);
 
   return (
     <UrlTabs defaultValue="details" className="w-full">

--- a/apps/admin/src/resources/connections/tabs/details-tab.tsx
+++ b/apps/admin/src/resources/connections/tabs/details-tab.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/admin";
 import { useWatch } from "react-hook-form";
 import { SecretInput } from "@/common/SecretInput";
-import { Strategy } from "@/utils/Strategy";
+import { Strategy, isDatabaseConnectionStrategy } from "@/utils/Strategy";
 import {
   Card,
   CardContent,
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/card";
 
 const isDbConnection = (strategy?: string) =>
-  strategy === Strategy.USERNAME_PASSWORD;
+  isDatabaseConnectionStrategy(strategy);
 
 // Strategies that don't have a registered redirect handler in authhero's
 // findHrdConnection eligibility check, so HRD can't route to them.

--- a/apps/admin/src/resources/connections/try-connection-button.tsx
+++ b/apps/admin/src/resources/connections/try-connection-button.tsx
@@ -24,7 +24,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Strategy } from "@/utils/Strategy";
+import { isDatabaseConnectionStrategy } from "@/utils/Strategy";
 
 interface ConnectionRecord {
   id: string;
@@ -147,7 +147,7 @@ export function TryConnectionButton() {
   const popupRef = useRef<Window | null>(null);
   const popupOriginRef = useRef<string | null>(null);
 
-  const isDb = record?.strategy === Strategy.USERNAME_PASSWORD;
+  const isDb = isDatabaseConnectionStrategy(record?.strategy);
 
   const callTry = useCallback(
     async (body?: { username?: string; password?: string }) => {

--- a/apps/admin/src/resources/users/create.tsx
+++ b/apps/admin/src/resources/users/create.tsx
@@ -6,22 +6,9 @@ import {
   BooleanInput,
 } from "@/components/admin";
 import { useGetList, useResourceContext } from "ra-core";
-import { Strategy } from "@/utils/Strategy";
+import { Strategy, isDatabaseConnectionStrategy } from "@/utils/Strategy";
 
 const USERNAME_PASSWORD_PROVIDER = "auth0";
-
-// Legacy tenants persist database connections with the strategy field set
-// to a provider literal ("auth2", or "auth0" after migration) instead of
-// the canonical Auth0 strategy name. All of them are password connections,
-// and none of these literals may be forwarded as the provider — new users
-// must never be created with the legacy "auth2" provider.
-function isPasswordStrategy(strategy: string): boolean {
-  return (
-    strategy === Strategy.USERNAME_PASSWORD ||
-    strategy === "auth2" ||
-    strategy === "auth0"
-  );
-}
 
 interface ConnectionRecord {
   name: string;
@@ -42,7 +29,7 @@ export function UserCreate() {
     if (data.connection && connections) {
       const connection = connections.find((c) => c.name === data.connection);
       if (connection) {
-        if (isPasswordStrategy(connection.strategy)) {
+        if (isDatabaseConnectionStrategy(connection.strategy)) {
           data.provider = USERNAME_PASSWORD_PROVIDER;
           // Store the canonical Auth0 connection name regardless of what the
           // tenant's database connection happens to be named (e.g. "password"),

--- a/apps/admin/src/utils/Strategy.ts
+++ b/apps/admin/src/utils/Strategy.ts
@@ -1,1 +1,4 @@
-export { Strategy } from "@authhero/adapter-interfaces";
+export {
+  Strategy,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";

--- a/packages/adapter-interfaces/src/types/Strategy.ts
+++ b/packages/adapter-interfaces/src/types/Strategy.ts
@@ -21,3 +21,30 @@ export const StrategyType = {
   SOCIAL: "social",
   PASSWORDLESS: "passwordless",
 } as const;
+
+/**
+ * The strategy value Auth0 stores on database connections. The canonical
+ * target for new connection rows; see isDatabaseConnectionStrategy for
+ * the legacy spellings still present in existing data.
+ */
+export const DATABASE_CONNECTION_STRATEGY = "auth0";
+
+/**
+ * True when a connection's `strategy` field marks it as a native database
+ * (username/password) connection.
+ *
+ * Auth0 stores database connections with `strategy: "auth0"`. Existing
+ * AuthHero data also contains two legacy spellings: the connection NAME
+ * ("Username-Password-Authentication") reused as the strategy, and the
+ * legacy provider literal ("auth2"). All readers must accept all three
+ * until connection rows are backfilled to "auth0".
+ */
+export function isDatabaseConnectionStrategy(
+  strategy: string | undefined | null,
+): boolean {
+  return (
+    strategy === DATABASE_CONNECTION_STRATEGY ||
+    strategy === Strategy.USERNAME_PASSWORD ||
+    strategy === "auth2"
+  );
+}

--- a/packages/authhero/src/authentication-flows/password.ts
+++ b/packages/authhero/src/authentication-flows/password.ts
@@ -10,6 +10,7 @@ import {
   Strategy,
   StrategyType,
   User,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import { EnrichedClient } from "../helpers/client";
 import { Bindings, GrantFlowUserResult, Variables } from "../types";
@@ -310,8 +311,8 @@ export async function passwordGrant(
     // (e.g. "Password") would never resolve, so fall back to matching by
     // strategy on the client's connections in that case.
     if (!realmDbConnection && realm === Strategy.USERNAME_PASSWORD) {
-      const usernamePasswordConnections = client.connections.filter(
-        (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+      const usernamePasswordConnections = client.connections.filter((c) =>
+        isDatabaseConnectionStrategy(c.strategy),
       );
       if (usernamePasswordConnections.length > 1) {
         throw new JSONHTTPException(400, {
@@ -592,8 +593,8 @@ export async function requestPasswordReset(
   });
 
   if (!existingUser) {
-    const passwordConnection = client.connections.find(
-      (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+    const passwordConnection = client.connections.find((c) =>
+      isDatabaseConnectionStrategy(c.strategy),
     );
     const validation = await validateSignupEmail(
       ctx,

--- a/packages/authhero/src/authentication-flows/ticket.ts
+++ b/packages/authhero/src/authentication-flows/ticket.ts
@@ -2,6 +2,7 @@ import {
   AuthParams,
   Strategy,
   StrategyType,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import { JSONHTTPException } from "../errors/json-http-exception";
 import { Context } from "hono";
@@ -73,10 +74,9 @@ export async function ticketAuth(
     (isUsernamePasswordProvider(provider)
       ? Strategy.USERNAME_PASSWORD
       : Strategy.EMAIL);
-  const strategy_type =
-    strategy === Strategy.USERNAME_PASSWORD
-      ? StrategyType.DATABASE
-      : StrategyType.PASSWORDLESS;
+  const strategy_type = isDatabaseConnectionStrategy(strategy)
+    ? StrategyType.DATABASE
+    : StrategyType.PASSWORDLESS;
 
   let user =
     realm === Strategy.USERNAME_PASSWORD

--- a/packages/authhero/src/authentication-flows/universal.ts
+++ b/packages/authhero/src/authentication-flows/universal.ts
@@ -5,6 +5,7 @@ import {
   Session,
   Strategy,
   promptSettingSchema,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import { EnrichedClient } from "../helpers/client";
 import { Bindings, Variables } from "../types";
@@ -218,8 +219,8 @@ export async function universalAuth({
     const settings = promptSettingSchema.parse(promptSettings || {});
 
     // Check if password connection is available
-    const hasPasswordConnection = client.connections.some(
-      (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+    const hasPasswordConnection = client.connections.some((c) =>
+      isDatabaseConnectionStrategy(c.strategy),
     );
 
     // If identifier_first is explicitly false and password auth is available,

--- a/packages/authhero/src/components/EnterCodePage.tsx
+++ b/packages/authhero/src/components/EnterCodePage.tsx
@@ -7,7 +7,11 @@ import Icon from "./Icon";
 import ErrorMessage from "./ErrorMessage";
 import FormComponent from "./Form";
 import { GoBack } from "./GoBack";
-import { Theme, Branding, Strategy } from "@authhero/adapter-interfaces";
+import {
+  Theme,
+  Branding,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";
 import { EnrichedClient } from "../helpers/client";
 import Trans from "./Trans";
 
@@ -36,8 +40,8 @@ const EnterCodePage: FC<Props> = ({
     state,
   });
 
-  const showPasswordLogin = client.connections.some(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const showPasswordLogin = client.connections.some((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
 
   return (

--- a/packages/authhero/src/components/IdentifierPage.tsx
+++ b/packages/authhero/src/components/IdentifierPage.tsx
@@ -5,6 +5,7 @@ import {
   Branding,
   Strategy,
   getConnectionIdentifierConfig,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import { EnrichedClient } from "../helpers/client";
 import Layout from "./Layout";
@@ -49,8 +50,8 @@ const IdentifierPage: FC<Props> = ({
   const showPhoneInput = connectionStrategies.includes(Strategy.SMS);
 
   // Check if the password connection has username identifier enabled
-  const passwordConnection = client.connections.find(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const passwordConnection = client.connections.find((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
   const requiresUsername =
     getConnectionIdentifierConfig(passwordConnection).usernameIdentifierActive;

--- a/packages/authhero/src/components/stories/LoginForm.stories.tsx
+++ b/packages/authhero/src/components/stories/LoginForm.stories.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource react */
 import type { Meta, StoryObj } from "@storybook/react";
-import { USERNAME_PASSWORD_PROVIDER } from "../../constants";
-import { Strategy } from "@authhero/adapter-interfaces";
+import {
+  DATABASE_CONNECTION_STRATEGY,
+  Strategy,
+} from "@authhero/adapter-interfaces";
 import {
   HonoJSXWrapper,
   renderHonoComponent,
@@ -24,8 +26,8 @@ const mockClient = {
   connections: [
     { name: "email", strategy: Strategy.EMAIL },
     {
-      name: USERNAME_PASSWORD_PROVIDER,
-      strategy: Strategy.USERNAME_PASSWORD,
+      name: Strategy.USERNAME_PASSWORD,
+      strategy: DATABASE_CONNECTION_STRATEGY,
     },
   ],
 } as any;

--- a/packages/authhero/src/routes/auth-api/callback.ts
+++ b/packages/authhero/src/routes/auth-api/callback.ts
@@ -2,8 +2,8 @@ import { HTTPException } from "hono/http-exception";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import {
   LogTypes,
-  Strategy,
   promptSettingSchema,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import { Context } from "hono";
 import { setSearchParams } from "../../utils/url";
@@ -84,8 +84,8 @@ async function returnError(
           ctx.var.tenant_id,
         );
         const settings = promptSettingSchema.parse(promptSettings || {});
-        const hasPasswordConnection = client.connections.some(
-          (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+        const hasPasswordConnection = client.connections.some((c) =>
+          isDatabaseConnectionStrategy(c.strategy),
         );
         if (settings.identifier_first === false && hasPasswordConnection) {
           loginPath = "/login";

--- a/packages/authhero/src/routes/auth-api/dbconnections.ts
+++ b/packages/authhero/src/routes/auth-api/dbconnections.ts
@@ -1,6 +1,11 @@
 import { HTTPException } from "hono/http-exception";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { AuthParams, LogTypes, Strategy } from "@authhero/adapter-interfaces";
+import {
+  AuthParams,
+  LogTypes,
+  Strategy,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";
 import { Bindings, Variables } from "../../types";
 import { logMessage } from "../../helpers/logging";
 import {
@@ -65,8 +70,8 @@ const postSignup = defineRoute({
     setTenantId(ctx, client.tenant.id);
 
     // Find the password connection from the client's connections to get the correct password policy
-    const passwordConnection = client.connections.find(
-      (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+    const passwordConnection = client.connections.find((c) =>
+      isDatabaseConnectionStrategy(c.strategy),
     );
     const connectionName =
       passwordConnection?.name || Strategy.USERNAME_PASSWORD;

--- a/packages/authhero/src/routes/universal-login/identifier.tsx
+++ b/packages/authhero/src/routes/universal-login/identifier.tsx
@@ -11,8 +11,8 @@ import { validateSignupEmail } from "../../hooks";
 import { logMessage } from "../../helpers/logging";
 import {
   LogTypes,
-  Strategy,
   getConnectionIdentifierConfig,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import i18next from "i18next";
 import generateOTP from "../../utils/otp";
@@ -179,8 +179,8 @@ const postRoot = defineRoute({
     }
 
     // Check if the password connection has username identifier enabled
-    const passwordConnection = client.connections.find(
-      (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+    const passwordConnection = client.connections.find((c) =>
+      isDatabaseConnectionStrategy(c.strategy),
     );
     const identifierConfig = getConnectionIdentifierConfig(passwordConnection);
     const requiresUsername = identifierConfig.usernameIdentifierActive;
@@ -253,7 +253,7 @@ const postRoot = defineRoute({
     if (!hasValidConnection && connectionType === "email" && username) {
       const hasMigrationConnection = client.connections.some(
         (c) =>
-          c.strategy === Strategy.USERNAME_PASSWORD &&
+          isDatabaseConnectionStrategy(c.strategy) &&
           c.options?.import_mode === true &&
           typeof c.options?.configuration === "object" &&
           c.options.configuration !== null,

--- a/packages/authhero/src/routes/universal-login/reset-password.tsx
+++ b/packages/authhero/src/routes/universal-login/reset-password.tsx
@@ -1,7 +1,10 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import bcryptjs from "bcryptjs";
-import { LogTypes, Strategy } from "@authhero/adapter-interfaces";
+import {
+  LogTypes,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";
 import i18next from "i18next";
 import { Bindings, Variables } from "../../types";
 import { initJSXRoute } from "./common";
@@ -135,8 +138,8 @@ const postRoot = defineRoute({
     // Find the password connection by strategy to get the correct connection name
     // This is needed because user.connection may contain "Username-Password-Authentication"
     // (a hardcoded fallback) instead of the actual connection name
-    const passwordConnection = client.connections.find(
-      (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+    const passwordConnection = client.connections.find((c) =>
+      isDatabaseConnectionStrategy(c.strategy),
     );
     const connectionName = passwordConnection?.name || user.connection;
 

--- a/packages/authhero/src/routes/universal-login/screens/accept-invitation.ts
+++ b/packages/authhero/src/routes/universal-login/screens/accept-invitation.ts
@@ -14,7 +14,11 @@ import type {
   FormNodeComponent,
   User,
 } from "@authhero/adapter-interfaces";
-import { LogTypes, Strategy } from "@authhero/adapter-interfaces";
+import {
+  LogTypes,
+  Strategy,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult, ScreenDefinition } from "./types";
 import { createTranslation } from "../../../i18n";
 import {
@@ -261,8 +265,8 @@ export const acceptInvitationScreenDefinition: ScreenDefinition = {
         };
       }
 
-      const passwordConnection = client.connections.find(
-        (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+      const passwordConnection = client.connections.find((c) =>
+        isDatabaseConnectionStrategy(c.strategy),
       );
       const connection = passwordConnection?.name || Strategy.USERNAME_PASSWORD;
 

--- a/packages/authhero/src/routes/universal-login/screens/email-otp-challenge.ts
+++ b/packages/authhero/src/routes/universal-login/screens/email-otp-challenge.ts
@@ -5,7 +5,10 @@
  */
 
 import type { UiScreen, FormNodeComponent } from "@authhero/adapter-interfaces";
-import { LoginSessionState, Strategy } from "@authhero/adapter-interfaces";
+import {
+  LoginSessionState,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult, ScreenDefinition } from "./types";
 import { getLoginPath } from "./types";
 import { escapeHtml } from "../sanitization-utils";
@@ -93,8 +96,8 @@ export async function emailOtpChallengeScreen(
 
   // Determine the back link: if there's no password connection, the user
   // is in a passwordless flow and should go back to the passwordless identifier
-  const hasPasswordConnection = context.connections.some(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const hasPasswordConnection = context.connections.some((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
   const backPath = hasPasswordConnection
     ? await getLoginPath(context)

--- a/packages/authhero/src/routes/universal-login/screens/forgot-password.ts
+++ b/packages/authhero/src/routes/universal-login/screens/forgot-password.ts
@@ -5,7 +5,7 @@
  */
 
 import type { UiScreen, FormNodeComponent } from "@authhero/adapter-interfaces";
-import { Strategy } from "@authhero/adapter-interfaces";
+import { isDatabaseConnectionStrategy } from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult, ScreenDefinition } from "./types";
 import { getLoginPath } from "./types";
 import { createTranslation } from "../../../i18n";
@@ -215,8 +215,8 @@ export const forgotPasswordScreenDefinition: ScreenDefinition = {
       // Check the connection's verification_method. In the u2 flow we default
       // to "code" when unset, so the user stays on-page instead of relying on
       // an emailed link (the link points at the legacy /u routes).
-      const passwordConnection = context.client.connections.find(
-        (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+      const passwordConnection = context.client.connections.find((c) =>
+        isDatabaseConnectionStrategy(c.strategy),
       );
       const verificationMethod =
         passwordConnection?.options?.attributes?.email?.verification_method ??

--- a/packages/authhero/src/routes/universal-login/screens/identifier.ts
+++ b/packages/authhero/src/routes/universal-login/screens/identifier.ts
@@ -9,6 +9,7 @@ import {
   getConnectionIdentifierConfig,
   Strategy,
   StrategyType,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult, ScreenDefinition } from "./types";
 import {
@@ -53,7 +54,7 @@ function buildSocialButtons(
     if (
       c.strategy === Strategy.EMAIL ||
       c.strategy === Strategy.SMS ||
-      c.strategy === Strategy.USERNAME_PASSWORD
+      isDatabaseConnectionStrategy(c.strategy)
     ) {
       return false;
     }
@@ -103,7 +104,7 @@ function buildSocialButtons(
     (c) =>
       c.strategy === Strategy.EMAIL ||
       c.strategy === Strategy.SMS ||
-      c.strategy === Strategy.USERNAME_PASSWORD,
+      isDatabaseConnectionStrategy(c.strategy),
   );
 
   if (hasPasswordOrEmailOrSms) {
@@ -152,12 +153,12 @@ export async function identifierScreen(
     (c) =>
       c.strategy === Strategy.EMAIL ||
       c.strategy === Strategy.SMS ||
-      c.strategy === Strategy.USERNAME_PASSWORD,
+      isDatabaseConnectionStrategy(c.strategy),
   );
 
   // Check if the password connection has username identifier enabled
-  const passwordConnection = context.connections.find(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const passwordConnection = context.connections.find((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
   const identifierConfig = getConnectionIdentifierConfig(passwordConnection);
   const requiresUsername = identifierConfig.usernameIdentifierActive;
@@ -425,8 +426,8 @@ export const identifierScreenDefinition: ScreenDefinition = {
       const username = (data.username as string)?.toLowerCase()?.trim();
 
       // Check if the password connection has username identifier enabled
-      const passwordConnection = client.connections.find(
-        (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+      const passwordConnection = client.connections.find((c) =>
+        isDatabaseConnectionStrategy(c.strategy),
       );
       const identifierConfig =
         getConnectionIdentifierConfig(passwordConnection);

--- a/packages/authhero/src/routes/universal-login/screens/login.ts
+++ b/packages/authhero/src/routes/universal-login/screens/login.ts
@@ -12,6 +12,7 @@ import {
   getConnectionIdentifierConfig,
   Strategy,
   StrategyType,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult, ScreenDefinition } from "./types";
 import {
@@ -107,8 +108,8 @@ function buildSocialButtons(
   };
 
   // Add divider if we have social buttons and a password connection
-  const hasPasswordConnection = connections.some(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const hasPasswordConnection = connections.some((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
 
   if (hasPasswordConnection) {
@@ -153,8 +154,8 @@ export async function loginScreen(
   const socialButtonCount = socialButtons.length;
 
   // Check if we have a password connection
-  const passwordConnection = context.connections.find(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const passwordConnection = context.connections.find((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
   const hasPasswordConnection = !!passwordConnection;
   const identifierConfig = getConnectionIdentifierConfig(passwordConnection);
@@ -491,8 +492,8 @@ export const loginScreenDefinition: ScreenDefinition = {
       );
 
       // Check if the password connection has username identifier enabled
-      const passwordConnection = client.connections.find(
-        (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+      const passwordConnection = client.connections.find((c) =>
+        isDatabaseConnectionStrategy(c.strategy),
       );
       const identifierConfig =
         getConnectionIdentifierConfig(passwordConnection);

--- a/packages/authhero/src/routes/universal-login/screens/login.ts
+++ b/packages/authhero/src/routes/universal-login/screens/login.ts
@@ -47,7 +47,7 @@ function buildSocialButtons(
   const { connections } = context;
 
   const socialConnections = connections.filter(
-    (c) => c.strategy !== Strategy.USERNAME_PASSWORD,
+    (c) => !isDatabaseConnectionStrategy(c.strategy),
   );
 
   if (socialConnections.length === 0) {

--- a/packages/authhero/src/routes/universal-login/screens/magic-link-sent.ts
+++ b/packages/authhero/src/routes/universal-login/screens/magic-link-sent.ts
@@ -6,7 +6,7 @@
  */
 
 import type { UiScreen, FormNodeComponent } from "@authhero/adapter-interfaces";
-import { Strategy } from "@authhero/adapter-interfaces";
+import { isDatabaseConnectionStrategy } from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult } from "./types";
 import { escapeHtml } from "../sanitization-utils";
 import { createTranslation } from "../../../i18n";
@@ -68,8 +68,8 @@ export async function magicLinkSentScreen(
   ];
 
   // Back link
-  const hasPasswordConnection = context.connections.some(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const hasPasswordConnection = context.connections.some((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
   const backPath = hasPasswordConnection
     ? `${routePrefix}/login/identifier`

--- a/packages/authhero/src/routes/universal-login/screens/reset-password.ts
+++ b/packages/authhero/src/routes/universal-login/screens/reset-password.ts
@@ -5,7 +5,10 @@
  */
 
 import type { UiScreen, FormNodeComponent } from "@authhero/adapter-interfaces";
-import { LogTypes, Strategy } from "@authhero/adapter-interfaces";
+import {
+  LogTypes,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult, ScreenDefinition } from "./types";
 import bcryptjs from "bcryptjs";
 import { getUsernamePasswordUser } from "../../../utils/username-password-provider";
@@ -46,8 +49,8 @@ export async function executePasswordReset(params: {
   }
 
   // Find the password connection by strategy
-  const passwordConnection = client.connections.find(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const passwordConnection = client.connections.find((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
   const connectionName = passwordConnection?.name || user.connection;
 

--- a/packages/authhero/src/routes/universal-login/screens/signup.ts
+++ b/packages/authhero/src/routes/universal-login/screens/signup.ts
@@ -9,7 +9,10 @@ import type {
   FormNodeComponent,
   User,
 } from "@authhero/adapter-interfaces";
-import { Strategy } from "@authhero/adapter-interfaces";
+import {
+  Strategy,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";
 import type { ScreenContext, ScreenResult, ScreenDefinition } from "./types";
 import { getLoginPath } from "./types";
 import { createTranslation } from "../../../i18n";
@@ -39,8 +42,8 @@ export async function signupScreen(
   const { m } = createTranslation("signup", "signup", locale, customText);
 
   // Check if we have password signup available
-  const hasPasswordSignup = context.connections.some(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const hasPasswordSignup = context.connections.some((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
 
   const components: FormNodeComponent[] = [];
@@ -228,8 +231,8 @@ export const signupScreenDefinition: ScreenDefinition = {
       }
 
       // Find the password connection from the client's connections
-      const passwordConnection = client.connections.find(
-        (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+      const passwordConnection = client.connections.find((c) =>
+        isDatabaseConnectionStrategy(c.strategy),
       );
       const connection = passwordConnection?.name || Strategy.USERNAME_PASSWORD;
 

--- a/packages/authhero/src/routes/universal-login/screens/types.ts
+++ b/packages/authhero/src/routes/universal-login/screens/types.ts
@@ -10,7 +10,7 @@ import {
   Connection,
   CustomText,
   promptSettingSchema,
-  Strategy,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import { EnrichedClient } from "../../../helpers/client";
 import { Bindings, Variables } from "../../../types";
@@ -177,8 +177,8 @@ export async function getLoginPath(context: ScreenContext): Promise<string> {
     context.tenant.id,
   );
   const settings = promptSettingSchema.parse(promptSettings || {});
-  const hasPasswordConnection = context.connections.some(
-    (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+  const hasPasswordConnection = context.connections.some((c) =>
+    isDatabaseConnectionStrategy(c.strategy),
   );
   return settings.identifier_first === false && hasPasswordConnection
     ? `${routePrefix}/login`

--- a/packages/authhero/src/routes/universal-login/signup.tsx
+++ b/packages/authhero/src/routes/universal-login/signup.tsx
@@ -2,7 +2,10 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import bcryptjs from "bcryptjs";
 import i18next from "i18next";
-import { Strategy } from "@authhero/adapter-interfaces";
+import {
+  Strategy,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";
 import { Bindings, Variables } from "../../types";
 import { initJSXRoute } from "./common";
 import SignupPage from "../../components/SignUpPage";
@@ -142,8 +145,8 @@ const postRoot = defineRoute({
       }
 
       // Find the password connection from the client's connections
-      const passwordConnection = client.connections.find(
-        (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+      const passwordConnection = client.connections.find((c) =>
+        isDatabaseConnectionStrategy(c.strategy),
       );
       const connection = passwordConnection?.name || Strategy.USERNAME_PASSWORD;
       ctx.set("connection", connection);

--- a/packages/authhero/src/seed.ts
+++ b/packages/authhero/src/seed.ts
@@ -1,4 +1,8 @@
-import { DataAdapters, Strategy } from "@authhero/adapter-interfaces";
+import {
+  DATABASE_CONNECTION_STRATEGY,
+  DataAdapters,
+  Strategy,
+} from "@authhero/adapter-interfaces";
 import { createX509Certificate } from "./utils/encryption";
 import { userIdGenerate } from "./utils/user-id";
 import { nanoid } from "nanoid";
@@ -787,9 +791,11 @@ export async function seed(
     if (debug) {
       console.log("Creating password connection...");
     }
+    // Auth0 stores database connections with strategy "auth0"; only the
+    // connection NAME is "Username-Password-Authentication".
     await adapters.connections.create(tenantId, {
       name: Strategy.USERNAME_PASSWORD,
-      strategy: Strategy.USERNAME_PASSWORD,
+      strategy: DATABASE_CONNECTION_STRATEGY,
       options: {
         attributes: {
           username: {

--- a/packages/authhero/src/utils/username-password-provider.ts
+++ b/packages/authhero/src/utils/username-password-provider.ts
@@ -33,23 +33,10 @@ import {
 const LEGACY_PROVIDER = "auth2";
 const TARGET_PROVIDER = "auth0";
 
-/**
- * True when a connection's `strategy` field marks it as a native database
- * (username/password) connection. Legacy tenants persist the provider
- * literal ("auth2") in the strategy field instead of the canonical Auth0
- * strategy name, and either provider literal must never leak into new
- * user rows as the provider — write sites go through
- * {@link resolveUsernamePasswordProvider} instead.
- */
-export function isDatabaseConnectionStrategy(
-  strategy: string | undefined | null,
-): boolean {
-  return (
-    strategy === "Username-Password-Authentication" ||
-    strategy === LEGACY_PROVIDER ||
-    strategy === TARGET_PROVIDER
-  );
-}
+// Shared with the admin UI via adapter-interfaces. None of the matched
+// strategy spellings may ever leak into new user rows as the provider —
+// write sites go through {@link resolveUsernamePasswordProvider} instead.
+export { isDatabaseConnectionStrategy } from "@authhero/adapter-interfaces";
 
 export type UsernamePasswordProviderValue =
   | typeof LEGACY_PROVIDER

--- a/packages/authhero/test/routes/auth-api/callback.spec.ts
+++ b/packages/authhero/test/routes/auth-api/callback.spec.ts
@@ -224,7 +224,10 @@ describe("callback", () => {
       throw new Error("No location header");
     }
     const redirectUri = new URL(location);
-    expect(redirectUri.pathname).toEqual("/u2/login/identifier");
+    // The fixture tenant has identifier_first: false (the default) and a
+    // password connection (legacy "auth2" strategy, now recognized by the
+    // tolerant matcher), so errors land on the combined login screen.
+    expect(redirectUri.pathname).toEqual("/u2/login");
     expect(redirectUri.searchParams.get("error")).toEqual("access_denied");
     expect(redirectUri.searchParams.get("error_description")).toEqual(
       "Signup disabled",


### PR DESCRIPTION
Steps 1 and 2 of converging `connection.strategy` on Auth0's canonical `"auth0"` value for database connections (follow-up to #1048).

## Step 1 — make all readers tolerant

`@authhero/adapter-interfaces` now exports:

- `DATABASE_CONNECTION_STRATEGY = "auth0"` — what Auth0 stores on database connections
- `isDatabaseConnectionStrategy()` — matches `"auth0"` plus the two legacy spellings still present in existing data: `"Username-Password-Authentication"` (the connection name reused as strategy — what prod rows carry today) and `"auth2"` (the provider literal some old tenants persisted)

Every site that detected a password connection with an exact `strategy === "Username-Password-Authentication"` comparison (~30 in the universal-login screens and auth flows, 4 in the admin UI) now uses the tolerant matcher. The authhero-internal helper from #1048 delegates to the shared one.

Side effect that is a fix, not a regression: tenants whose connection row carries a legacy strategy spelling now get correct password-connection behavior everywhere (e.g. the combined login screen when `identifier_first` is false). One test expectation updated accordingly — the fixture models a legacy `"auth2"`-strategy tenant, and its error redirect now correctly lands on `/u2/login` instead of `/u2/login/identifier`.

## Step 2 — write the canonical value

`seed()` creates the database connection with `strategy: "auth0"`, `name: "Username-Password-Authentication"` — matching Auth0's management API shape.

## What this enables (and a warning)

Backfilling existing connection rows (`UPDATE connections SET strategy = 'auth0' WHERE strategy IN ('Username-Password-Authentication', 'auth2')`) becomes a safe no-op behavior-wise **once this version is deployed**. Running that backfill **before** deploying this change would break password login on the affected tenants, since the currently deployed code only recognizes the exact `"Username-Password-Authentication"` string.

## Testing

- Full `authhero` suite: 1723 passed
- Admin UI tests: 25 passed
- `tsc --noEmit` clean in `packages/authhero` and `apps/admin`
- Changeset: `@authhero/adapter-interfaces` minor, `authhero` minor, `@authhero/admin` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database connections now use a consistent strategy value when created, improving compatibility across login, signup, reset password, and invitation flows.
  * Login screens and admin connection settings now recognize all supported database-connection variants, reducing issues for existing tenants.

* **Bug Fixes**
  * Fixed password-based login and recovery paths so they work correctly with legacy connection strategy values.
  * Improved routing and UI behavior for identifier-first, universal login, and callback flows when password connections are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->