### PR TITLE
fix(drizzle): make data.transaction() safe on Cloudflare D1

### DIFF
--- a/.changeset/tidy-donuts-shake.md
+++ b/.changeset/tidy-donuts-shake.md
@@ -1,0 +1,5 @@
+---
+"@authhero/drizzle": patch
+---
+
+Fix data.transaction() throwing on Cloudflare D1. The generic transaction wrapper (and actionVersions.create) issued raw BEGIN/COMMIT/ROLLBACK, which D1 rejects, so every flow wrapping writes in data.transaction() (user create, link-users, register, logout, ...) failed with a 500. The wrapper now feature-detects batch-capable drivers the same way runAtomic does: on D1 the callback runs directly (non-atomic, same as useTransactions: false) while per-adapter multi-statement writes stay atomic via db.batch(); better-sqlite3 keeps interactive transactions. actionVersions.create now routes its deployed-clear + insert through runAtomic.

--- a/packages/drizzle/src/adapters/actionVersions.ts
+++ b/packages/drizzle/src/adapters/actionVersions.ts
@@ -101,6 +101,7 @@ export function createActionVersionsAdapter(
                 and(
                   eq(actionVersions.tenant_id, tenant_id),
                   eq(actionVersions.action_id, version.action_id),
+                  eq(actionVersions.deployed, 1),
                 ),
               ),
             insertStatement,

--- a/packages/drizzle/src/adapters/actionVersions.ts
+++ b/packages/drizzle/src/adapters/actionVersions.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, count as countFn, sql } from "drizzle-orm";
+import { eq, and, desc, count as countFn } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type {
   ActionVersion,
@@ -9,6 +9,7 @@ import type {
 } from "@authhero/adapter-interfaces";
 import { actionVersions } from "../schema/sqlite";
 import { parseJsonIfString } from "../helpers/transform";
+import { runAtomic, type AtomicStatementList } from "./atomic";
 import type { DrizzleDb } from "./types";
 
 function rowToVersion(row: any): ActionVersion {
@@ -27,7 +28,8 @@ function rowToVersion(row: any): ActionVersion {
     ...rest,
     runtime: runtime ?? undefined,
     deployed: !!deployed,
-    secrets: parseJsonIfString<Array<{ name: string; value?: string }>>(secrets),
+    secrets:
+      parseJsonIfString<Array<{ name: string; value?: string }>>(secrets),
     dependencies:
       parseJsonIfString<Array<{ name: string; version: string }>>(dependencies),
     supported_triggers:
@@ -51,65 +53,61 @@ export function createActionVersionsAdapter(
       const id = `ver_${nanoid()}`;
       const deployed = version.deployed !== false;
 
-      // Wrap latest-lookup, deployed-clear and insert in a transaction so the
-      // sequential per-action `number` can't observe a half-applied state. The
-      // unique (tenant_id, action_id, number) index still rejects any race that
-      // beats the read. Manual BEGIN/COMMIT because Drizzle's db.transaction()
-      // doesn't support async callbacks with better-sqlite3.
-      await db.run(sql`BEGIN`);
-      let next: number;
-      try {
-        const latest = await db
-          .select({ number: actionVersions.number })
-          .from(actionVersions)
-          .where(
-            and(
-              eq(actionVersions.tenant_id, tenant_id),
-              eq(actionVersions.action_id, version.action_id),
-            ),
-          )
-          .orderBy(desc(actionVersions.number))
-          .limit(1)
-          .get();
+      // Read the latest `number` first, then apply the deployed-clear and
+      // insert as one atomic unit via runAtomic (db.batch() on D1, manual
+      // BEGIN/COMMIT on better-sqlite3 — D1 rejects interactive BEGIN). The
+      // unique (tenant_id, action_id, number) index rejects any race that
+      // beats the read.
+      const latest = await db
+        .select({ number: actionVersions.number })
+        .from(actionVersions)
+        .where(
+          and(
+            eq(actionVersions.tenant_id, tenant_id),
+            eq(actionVersions.action_id, version.action_id),
+          ),
+        )
+        .orderBy(desc(actionVersions.number))
+        .limit(1)
+        .get();
 
-        next = (latest?.number ?? 0) + 1;
+      const next = (latest?.number ?? 0) + 1;
 
-        if (deployed) {
-          await db
-            .update(actionVersions)
-            .set({ deployed: 0, updated_at_ts: now })
-            .where(
-              and(
-                eq(actionVersions.tenant_id, tenant_id),
-                eq(actionVersions.action_id, version.action_id),
+      const insertStatement = db.insert(actionVersions).values({
+        id,
+        tenant_id,
+        action_id: version.action_id,
+        number: next,
+        code: version.code,
+        runtime: version.runtime ?? null,
+        secrets: version.secrets ? JSON.stringify(version.secrets) : null,
+        dependencies: version.dependencies
+          ? JSON.stringify(version.dependencies)
+          : null,
+        supported_triggers: version.supported_triggers
+          ? JSON.stringify(version.supported_triggers)
+          : null,
+        deployed: deployed ? 1 : 0,
+        created_at_ts: now,
+        updated_at_ts: now,
+      });
+
+      const statements: AtomicStatementList = deployed
+        ? [
+            db
+              .update(actionVersions)
+              .set({ deployed: 0, updated_at_ts: now })
+              .where(
+                and(
+                  eq(actionVersions.tenant_id, tenant_id),
+                  eq(actionVersions.action_id, version.action_id),
+                ),
               ),
-            );
-        }
+            insertStatement,
+          ]
+        : [insertStatement];
 
-        await db.insert(actionVersions).values({
-          id,
-          tenant_id,
-          action_id: version.action_id,
-          number: next,
-          code: version.code,
-          runtime: version.runtime ?? null,
-          secrets: version.secrets ? JSON.stringify(version.secrets) : null,
-          dependencies: version.dependencies
-            ? JSON.stringify(version.dependencies)
-            : null,
-          supported_triggers: version.supported_triggers
-            ? JSON.stringify(version.supported_triggers)
-            : null,
-          deployed: deployed ? 1 : 0,
-          created_at_ts: now,
-          updated_at_ts: now,
-        });
-
-        await db.run(sql`COMMIT`);
-      } catch (e) {
-        await db.run(sql`ROLLBACK`);
-        throw e;
-      }
+      await runAtomic(db, statements);
 
       return {
         id,

--- a/packages/drizzle/src/adapters/atomic.ts
+++ b/packages/drizzle/src/adapters/atomic.ts
@@ -19,7 +19,7 @@ interface BatchCapableDb {
   batch(statements: AtomicStatements): Promise<unknown[]>;
 }
 
-function hasBatch(db: DrizzleDb): db is DrizzleDb & BatchCapableDb {
+export function hasBatch(db: DrizzleDb): db is DrizzleDb & BatchCapableDb {
   const candidate: unknown = db;
   return (
     typeof candidate === "object" &&

--- a/packages/drizzle/src/adapters/index.ts
+++ b/packages/drizzle/src/adapters/index.ts
@@ -48,6 +48,7 @@ import { createSessionCleanup } from "./cleanup";
 import { createTenantOperationsAdapter } from "./tenantOperations";
 import { createTenantOperationEventsAdapter } from "./tenantOperationEvents";
 import { createRolloutsAdapter } from "./rollouts";
+import { hasBatch } from "./atomic";
 import type { DrizzleDb } from "./types";
 
 export interface CreateAdaptersOptions {
@@ -128,14 +129,18 @@ export default function createAdapters(
       if (databaseOptions.useTransactions === false) {
         return fn(adapters);
       }
-      // Use manual BEGIN/COMMIT/ROLLBACK so we can properly await the
-      // async callback before deciding whether to commit or roll back.
-      // Drizzle's built-in db.transaction() runs the callback synchronously
-      // for better-sqlite3, which means async throws don't trigger rollback.
-      // NOTE: this pattern works for sync drivers only. For D1 support, the
-      // per-adapter call sites should migrate to db.batch() in a follow-up PR;
-      // this generic wrapper cannot be expressed as a batch because it takes
-      // an arbitrary async callback.
+      // D1 rejects interactive BEGIN/COMMIT outright, and an arbitrary async
+      // callback can't be expressed as a db.batch(). On batch-capable (D1)
+      // drivers we therefore run the callback directly, non-atomically — the
+      // same as useTransactions: false. Multi-statement writes inside the
+      // individual adapters stay atomic via runAtomic's batch path.
+      if (hasBatch(db)) {
+        return fn(adapters);
+      }
+      // Sync drivers (better-sqlite3): manual BEGIN/COMMIT/ROLLBACK so we can
+      // properly await the async callback before deciding whether to commit
+      // or roll back. Drizzle's built-in db.transaction() runs the callback
+      // synchronously there, which means async throws don't trigger rollback.
       await db.run(sql`BEGIN`);
       try {
         const result = await fn(adapters);

--- a/packages/drizzle/test/adapters/transaction.test.ts
+++ b/packages/drizzle/test/adapters/transaction.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { sql } from "drizzle-orm";
+import createAdapters from "../../src/adapters";
+import type { DrizzleDb } from "../../src/adapters/types";
+
+describe("createAdapters transaction()", () => {
+  describe("batch-capable driver (D1)", () => {
+    function makeBatchDb() {
+      const run = vi.fn(async () => {});
+      const batch = vi.fn(async () => []);
+      return { run, batch, db: { run, batch } as unknown as DrizzleDb };
+    }
+
+    it("runs the callback without BEGIN/COMMIT/ROLLBACK and returns its result", async () => {
+      const { run, batch, db } = makeBatchDb();
+      const data = createAdapters(db);
+
+      const callback = vi.fn(async () => "result");
+      const result = await data.transaction(callback);
+
+      expect(result).toBe("result");
+      expect(callback).toHaveBeenCalledTimes(1);
+      // No interactive transaction statements — D1 rejects raw BEGIN.
+      expect(run).not.toHaveBeenCalled();
+      expect(batch).not.toHaveBeenCalled();
+    });
+
+    it("propagates a throwing callback without issuing ROLLBACK", async () => {
+      const { run, db } = makeBatchDb();
+      const data = createAdapters(db);
+
+      await expect(
+        data.transaction(async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+      expect(run).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sync driver (better-sqlite3)", () => {
+    function makeSyncDb() {
+      const run = vi.fn(async (_query: unknown) => {});
+      return { run, db: { run } as unknown as DrizzleDb };
+    }
+
+    it("wraps the callback in BEGIN/COMMIT on success", async () => {
+      const { run, db } = makeSyncDb();
+      const data = createAdapters(db);
+
+      const order: string[] = [];
+      run.mockImplementation(async () => {
+        order.push("run");
+      });
+      const result = await data.transaction(async () => {
+        order.push("callback");
+        return 42;
+      });
+
+      expect(result).toBe(42);
+      expect(order).toEqual(["run", "callback", "run"]);
+      expect(run.mock.calls.map(([query]) => query)).toEqual([
+        sql`BEGIN`,
+        sql`COMMIT`,
+      ]);
+    });
+
+    it("issues ROLLBACK and rethrows when the callback fails", async () => {
+      const { run, db } = makeSyncDb();
+      const data = createAdapters(db);
+
+      await expect(
+        data.transaction(async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      expect(run.mock.calls.map(([query]) => query)).toEqual([
+        sql`BEGIN`,
+        sql`ROLLBACK`,
+      ]);
+    });
+  });
+
+  describe("useTransactions: false", () => {
+    it("skips transaction statements on a sync driver too", async () => {
+      const run = vi.fn(async () => {});
+      const db = { run } as unknown as DrizzleDb;
+      const data = createAdapters(db, { useTransactions: false });
+
+      const result = await data.transaction(async () => "plain");
+
+      expect(result).toBe("plain");
+      expect(run).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The generic `transaction()` wrapper in `@authhero/drizzle` issues raw `BEGIN`/`COMMIT`/`ROLLBACK`, which Cloudflare D1 rejects:

```
D1_ERROR: To execute a transaction, please use the state.storage.transaction()
or state.storage.transactionSync() APIs instead of the SQL BEGIN TRANSACTION
or SAVEPOINT statements.
```

Since `createAdapters` defaults `useTransactions: true`, every authhero flow that wraps writes in `data.transaction(...)` 500s on D1 — found via `POST /api/v2/users` on a WFP tenant worker failing with `DrizzleQueryError: Failed query: BEGIN`. Other affected call sites: link-users, user-update, user-deletion hooks, register, logout/oidc-logout.

## Fix

- `transaction()` now feature-detects the driver the same way `runAtomic` does (`hasBatch`, now exported from `atomic.ts`). On the batch-capable D1 driver it runs the callback directly — non-atomic, same as `useTransactions: false` — since an arbitrary async callback can't be expressed as a `db.batch()`. Multi-statement writes inside the individual adapters stay atomic via `runAtomic`'s batch path. better-sqlite3 keeps the exact `BEGIN`/`COMMIT`/`ROLLBACK` behavior, and the explicit `useTransactions: false` escape hatch is unchanged.
- `actionVersions.create` had its own manual `BEGIN` with the same bug. It now reads the latest version `number` first, then applies the deployed-clear + insert through `runAtomic` (matching `users`/`sessions`/`refreshTokens`), so those writes are genuinely atomic on D1 — stronger than before. The unique `(tenant_id, action_id, number)` index still rejects any race that beats the read.

Cross-adapter atomicity on D1 (true transactional outbox) is a design change tracked in #1057.

## Tests

- New `test/adapters/transaction.test.ts`: a fake batch-capable db proves `transaction()` never issues `BEGIN`/`COMMIT`/`ROLLBACK`, awaits and returns the callback result, and propagates throws; a fake sync db proves `BEGIN`→`COMMIT` on success and `BEGIN`→`ROLLBACK` on failure; plus a `useTransactions: false` case.
- Existing integration rollback test (`tenants.test.ts`, real better-sqlite3) still passes.
- Full drizzle suite: 68 tests / 9 files passing; `tsc --noEmit` clean.

## Verification

In sesamy/auth the tenant worker currently works around this with `createDataAdapters(db, { useTransactions: false })` — with it, `POST /api/v2/users` on a WFP tenant went from 500 to 201. Once this lands, that override can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction handling for database writes so actions like creating users, linking accounts, registering, and logging out no longer fail with 500 errors in supported environments.
  * Improved transaction behavior to match database capabilities, reducing rollback issues and preserving reliable saves.
  * Updated action version publishing so the deployed version is switched safely in a single step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->