### PR TITLE
fix: treat auth0-strategy database connections as UI connections in login flows

### DIFF
--- a/.changeset/authorize-database-strategy-auth0.md
+++ b/.changeset/authorize-database-strategy-auth0.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Fix /authorize failing with "Strategy auth0 not found" when a client's only connection is a database connection stored with the canonical `auth0` strategy. The single-connection provider-redirect shortcut, the login-strategy resolution, and the identifier screens now all match database connections via `isDatabaseConnectionStrategy` (accepting the `auth0`, `auth2`, and `Username-Password-Authentication` spellings) instead of comparing against `Username-Password-Authentication` only. This broke the OIDC conformance suite after the seed switched to `strategy: "auth0"`.

--- a/packages/authhero/src/components/IdentifierForm.tsx
+++ b/packages/authhero/src/components/IdentifierForm.tsx
@@ -4,6 +4,7 @@ import {
   Theme,
   Branding,
   Strategy,
+  isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";
 import { EnrichedClient } from "../helpers/client";
 import i18next from "i18next";
@@ -48,18 +49,17 @@ const IdentifierForm: FC<Props> = ({
     ({ strategy }) => strategy,
   );
 
-  // Determine which input fields to show based on available connections
+  // Determine which input fields to show based on available connections.
+  // Database connections are matched via isDatabaseConnectionStrategy since
+  // their strategy field can be any of the
+  // "auth0"/"auth2"/"Username-Password-Authentication" spellings.
   const showEmailInput =
     connectionStrategies.includes(Strategy.EMAIL) ||
-    connectionStrategies.includes(Strategy.USERNAME_PASSWORD);
+    connectionStrategies.some(isDatabaseConnectionStrategy);
   const showPhoneInput = connectionStrategies.includes(Strategy.SMS);
 
   // Strategies that are handled by form inputs, not social/enterprise buttons.
-  const formStrategies = new Set<string>([
-    Strategy.EMAIL,
-    Strategy.SMS,
-    Strategy.USERNAME_PASSWORD,
-  ]);
+  const formStrategies = new Set<string>([Strategy.EMAIL, Strategy.SMS]);
 
   // Get all available social/enterprise connections with their configs.
   // HRD-enabled connections (those with domain_aliases) are hidden by default
@@ -67,7 +67,11 @@ const IdentifierForm: FC<Props> = ({
   // An explicit `show_as_button: true` opts back in; `show_as_button: false`
   // always hides regardless of HRD configuration.
   const socialConnections = client.connections
-    .filter((connection) => !formStrategies.has(connection.strategy))
+    .filter(
+      (connection) =>
+        !formStrategies.has(connection.strategy) &&
+        !isDatabaseConnectionStrategy(connection.strategy),
+    )
     .filter((connection) => {
       if (connection.show_as_button === false) return false;
       if (connection.show_as_button === true) return true;

--- a/packages/authhero/src/components/IdentifierPage.tsx
+++ b/packages/authhero/src/components/IdentifierPage.tsx
@@ -43,25 +43,23 @@ const IdentifierPage: FC<Props> = ({
     ({ strategy }) => strategy,
   );
 
-  // Determine which input fields to show based on available connections
-  const showEmailInput =
-    connectionStrategies.includes(Strategy.EMAIL) ||
-    connectionStrategies.includes(Strategy.USERNAME_PASSWORD);
-  const showPhoneInput = connectionStrategies.includes(Strategy.SMS);
-
-  // Check if the password connection has username identifier enabled
+  // Check if the password connection has username identifier enabled.
+  // Matched via isDatabaseConnectionStrategy since the strategy field can be
+  // any of the "auth0"/"auth2"/"Username-Password-Authentication" spellings.
   const passwordConnection = client.connections.find((c) =>
     isDatabaseConnectionStrategy(c.strategy),
   );
   const requiresUsername =
     getConnectionIdentifierConfig(passwordConnection).usernameIdentifierActive;
 
+  // Determine which input fields to show based on available connections
+  const showEmailInput =
+    connectionStrategies.includes(Strategy.EMAIL) ||
+    Boolean(passwordConnection);
+  const showPhoneInput = connectionStrategies.includes(Strategy.SMS);
+
   // Strategies that are handled by form inputs, not social/enterprise buttons.
-  const formStrategies = new Set<string>([
-    Strategy.EMAIL,
-    Strategy.SMS,
-    Strategy.USERNAME_PASSWORD,
-  ]);
+  const formStrategies = new Set<string>([Strategy.EMAIL, Strategy.SMS]);
 
   // Get all available social/enterprise connections with their configs.
   // HRD-enabled connections (those with domain_aliases) are hidden by default
@@ -69,7 +67,11 @@ const IdentifierPage: FC<Props> = ({
   // An explicit `show_as_button: true` opts back in; `show_as_button: false`
   // always hides regardless of HRD configuration.
   const socialConnections = client.connections
-    .filter((connection) => !formStrategies.has(connection.strategy))
+    .filter(
+      (connection) =>
+        !formStrategies.has(connection.strategy) &&
+        !isDatabaseConnectionStrategy(connection.strategy),
+    )
     .filter((connection) => {
       if (connection.show_as_button === false) return false;
       if (connection.show_as_button === true) return true;

--- a/packages/authhero/src/routes/auth-api/authorize.ts
+++ b/packages/authhero/src/routes/auth-api/authorize.ts
@@ -11,6 +11,7 @@ import {
   LoginSessionState,
   Strategy,
   claimsRequestSchema,
+  isDatabaseConnectionStrategy,
   tokenResponseSchema,
 } from "@authhero/adapter-interfaces";
 import { Bindings, Variables } from "../../types";
@@ -693,11 +694,15 @@ const getRoot = defineRoute({
       });
     }
 
-    // If there's only one connection and it's a OIDC provider, we can redirect to that provider directly
+    // If there's only one connection and it's a OIDC provider, we can redirect
+    // to that provider directly. Database connections are excluded via
+    // isDatabaseConnectionStrategy since their strategy field can be any of
+    // the "auth0"/"auth2"/"Username-Password-Authentication" spellings.
     if (
       client.connections.length === 1 &&
       client.connections[0] &&
-      !UI_STRATEGIES.includes(client.connections[0].strategy || "")
+      !UI_STRATEGIES.includes(client.connections[0].strategy || "") &&
+      !isDatabaseConnectionStrategy(client.connections[0].strategy)
     ) {
       return connectionAuth(
         ctx,

--- a/packages/authhero/src/routes/universal-login/common.tsx
+++ b/packages/authhero/src/routes/universal-login/common.tsx
@@ -10,7 +10,10 @@ import {
 } from "../../helpers/users";
 import { getPrimaryUsernamePasswordUser } from "../../utils/username-password-provider";
 import { RedirectException } from "../../errors/redirect-exception";
-import { Strategy } from "@authhero/adapter-interfaces";
+import {
+  Strategy,
+  isDatabaseConnectionStrategy,
+} from "@authhero/adapter-interfaces";
 import { Bindings, Variables } from "../../types";
 import { getAuthCookie } from "../../utils/cookies";
 import { setTenantId } from "../../helpers/set-tenant-id";
@@ -234,6 +237,16 @@ const STRATEGY_MAP: Record<string, LoginStrategy> = {
   [Strategy.SMS]: "sms",
 };
 
+// Database connections store their strategy as any of the
+// "auth0"/"auth2"/"Username-Password-Authentication" spellings — collapse
+// them all to "password" before the map lookup.
+function toLoginStrategy(
+  strategy: string | undefined | null,
+): LoginStrategy | undefined {
+  if (isDatabaseConnectionStrategy(strategy)) return "password";
+  return strategy ? STRATEGY_MAP[strategy] : undefined;
+}
+
 export async function getLoginStrategy(
   ctx: Context,
   client: EnrichedClient,
@@ -279,14 +292,14 @@ export async function getLoginStrategy(
           });
 
   // Check user's preferred login method (last used)
-  const userStrategy = user?.app_metadata?.strategy;
-  if (userStrategy && STRATEGY_MAP[userStrategy]) {
-    return STRATEGY_MAP[userStrategy];
+  const preferredStrategy = toLoginStrategy(user?.app_metadata?.strategy);
+  if (preferredStrategy) {
+    return preferredStrategy;
   }
 
   // Get available strategies from client connections
   const availableStrategies = client.connections
-    .map((c) => STRATEGY_MAP[c.strategy])
+    .map((c) => toLoginStrategy(c.strategy))
     .filter((s): s is LoginStrategy => s !== undefined);
 
   // If only one option is available, use it

--- a/packages/authhero/test/routes/auth-api/authorize.spec.ts
+++ b/packages/authhero/test/routes/auth-api/authorize.spec.ts
@@ -214,6 +214,44 @@ describe("authorize", () => {
     expect(authorizationUrl.searchParams.get("firstName")).toEqual("firstName");
   });
 
+  it("should redirect to the universal login when the only connection is a database connection with strategy auth0", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    // Leave a single database connection stored with the canonical Auth0
+    // strategy value. The single-connection shortcut in /authorize must not
+    // treat it as a redirectable provider (getStrategy("auth0") would throw).
+    await env.data.connections.remove("tenantId", "email");
+    await env.data.connections.remove("tenantId", "mock-strategy");
+    await env.data.connections.update(
+      "tenantId",
+      "Username-Password-Authentication",
+      { strategy: "auth0" },
+    );
+
+    const response = await oauthClient.authorize.$get(
+      {
+        query: {
+          client_id: "clientId",
+          redirect_uri: "https://example.com/callback",
+          state: "state",
+          scope: "openid",
+          response_type: AuthorizationResponseType.CODE,
+        },
+      },
+      {
+        headers: {
+          origin: "https://example.com",
+        },
+      },
+    );
+
+    expect(response.status).toEqual(302);
+    const location = response.headers.get("location");
+    const redirectUri = new URL("https://example.com" + location);
+    expect(redirectUri.pathname).toEqual("/u/login/identifier");
+  });
+
   it("should not store fragments in redirect_uri according to RFC 6749 section 3.1.2", async () => {
     const { oauthApp, env } = await getTestServer();
     const oauthClient = testClient(oauthApp, env);


### PR DESCRIPTION
## Problem

The OIDC conformance gate on the changeset release PR fails with browser-flow timeouts — the page never leaves `/authorize`. Server logs show:

```
Error: Strategy auth0 not found
```

Since #1055, the seed stores database connections with the canonical Auth0 strategy value `"auth0"`, but four call sites still matched database connections against the `Username-Password-Authentication` spelling only:

1. **`/authorize` single-connection shortcut** — treated the database connection as a redirectable provider and called `getStrategy("auth0")`, which throws. Every `/authorize` request returned a 500. This is what broke conformance. Unit tests missed it because the fixture tenant has three connections, so the single-connection branch never fires there.
2. **`getLoginStrategy`** — dropped the connection from the available strategies, routing identifier submits to email OTP instead of the password screen.
3. **`IdentifierPage` / `IdentifierForm`** — hid the email/username input and let the connection fall through to the social-button pipeline.

## Fix

Match all four sites via `isDatabaseConnectionStrategy`, which accepts the `auth0`/`auth2`/`Username-Password-Authentication` spellings — same predicate the rest of the #1055 sweep uses. The legacy fallbacks stay until connection rows are backfilled (#1056).

## Testing

- New regression test: `/authorize` with a single `auth0`-strategy connection redirects to `/u/login/identifier` (fails without the fix with a 500).
- Full `authhero` suite passes (1724 tests).
- Verified end-to-end against a freshly seeded local conformance auth server (reproduces the exact CI state — one connection, strategy `auth0`): `/authorize` → identifier → password → form_post callback with an authorization code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `/authorize` flows for tenants whose only connection is a database connection using the canonical `auth0` strategy.
  * Improved login and identifier screens to recognize database connections more consistently, preventing incorrect strategy handling and missing redirects.

* **Tests**
  * Added coverage to verify single-connection database tenants redirect to universal login as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->