### PR TITLE
fix: persist auth_strategy on login sessions for front-channel flows

### DIFF
--- a/.changeset/persist-auth-strategy-front-channel.md
+++ b/.changeset/persist-auth-strategy-front-channel.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Persist auth_strategy on the login session for flows that authenticate via createFrontChannelAuthResponse (password, passwordless OTP, passkey, ticket auth, silent SSO reuse). Previously only flows going through finalizeAuthenticatedSession (enterprise/social redirects) wrote auth_strategy, leaving auth_strategy_strategy/auth_strategy_strategy_type NULL for all password logins.

--- a/.changeset/persist-auth-strategy-front-channel.md
+++ b/.changeset/persist-auth-strategy-front-channel.md
@@ -2,4 +2,8 @@
 "authhero": patch
 ---
 
-Persist auth_strategy on the login session for flows that authenticate via createFrontChannelAuthResponse (password, passwordless OTP, passkey, ticket auth, silent SSO reuse). Previously only flows going through finalizeAuthenticatedSession (enterprise/social redirects) wrote auth_strategy, leaving auth_strategy_strategy/auth_strategy_strategy_type NULL for all password logins.
+Persist auth_strategy on login sessions everywhere it was being dropped:
+
+- createFrontChannelAuthResponse now passes authStrategy through to authenticateLoginSession, so password, passwordless OTP, passkey, ticket auth and SSO-reuse logins record auth_strategy (previously only enterprise/social flows via finalizeAuthenticatedSession did, leaving auth_strategy NULL for all password logins).
+- silentAuth now copies auth_strategy from the originating login session onto the login session it creates (and re-points the session at), so the strategy survives silent token renewals instead of being severed on the first prompt=none call.
+- silentAuth keeps the re-pointed login session alive for the session's full remaining lifetime (falling back to the session's absolute expiry when the tenant has no idle_session_lifetime), so cleanup can't reap it while strategy/connection recovery still needs it.

--- a/packages/authhero/src/authentication-flows/common.ts
+++ b/packages/authhero/src/authentication-flows/common.ts
@@ -1508,6 +1508,7 @@ export async function createFrontChannelAuthResponse(
       loginSession: params.loginSession,
       existingSessionId: params.existingSessionIdToLink,
       authConnection: params.authConnection,
+      authStrategy: params.authStrategy,
     });
     // Pick up the state authenticateLoginSession just wrote (AUTHENTICATED,
     // session_id, user_id, auth_connection, …) so the checks below operate

--- a/packages/authhero/src/authentication-flows/silent.ts
+++ b/packages/authhero/src/authentication-flows/silent.ts
@@ -349,6 +349,13 @@ export async function silentAuth({
     expires_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(), // 5 minutes
     session_id: session.id,
     ...(auth_connection ? { auth_connection } : {}),
+    // Carry auth_strategy along the login-session chain. The session is
+    // re-pointed at this login session below, so without the copy the
+    // strategy recorded at interactive login would be lost on the first
+    // silent renewal (and recoverSessionAuthStrategy would find nothing).
+    ...(originalLoginSession?.auth_strategy
+      ? { auth_strategy: originalLoginSession.auth_strategy }
+      : {}),
     ip: ctx.var.ip,
     useragent: ctx.var.useragent,
   });
@@ -437,10 +444,18 @@ export async function silentAuth({
     idle_expires_at: newIdleExpiresAt,
   });
 
-  // Keep the login_session alive as long as the session is active
-  if (newIdleExpiresAt) {
+  // Keep the login_session alive as long as the session is active. The
+  // session now points at this login session (auth_strategy/auth_connection
+  // recovery reads it back), so it must survive cleanup for the session's
+  // whole remaining lifetime — fall back to the session's absolute expiry
+  // when the tenant has no idle_session_lifetime.
+  const keepAliveMs = Math.max(
+    newIdleExpiresAt ? new Date(newIdleExpiresAt).getTime() : 0,
+    session.expires_at ? new Date(session.expires_at).getTime() : 0,
+  );
+  if (keepAliveMs > Date.now()) {
     await env.data.loginSessions.update(client.tenant.id, loginSession.id, {
-      expires_at: newIdleExpiresAt,
+      expires_at: new Date(keepAliveMs).toISOString(),
     });
   }
 

--- a/packages/authhero/test/authentication-flows/silent.spec.ts
+++ b/packages/authhero/test/authentication-flows/silent.spec.ts
@@ -516,6 +516,121 @@ describe("silent", () => {
     expect(newLoginSession?.auth_connection).toEqual("vipps");
   });
 
+  it("should carry auth_strategy along the login-session chain and keep it alive across silent renewals", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const oauthClient = testClient(oauthApp, env);
+
+    // Interactive password login recorded the strategy on the originating
+    // login session.
+    const originLoginSession = await env.data.loginSessions.create(
+      "tenantId",
+      {
+        expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+        csrf_token: "csrfToken",
+        authParams: {
+          client_id: "clientId",
+          redirect_uri: "https://example.com/callback",
+          response_type: AuthorizationResponseType.CODE,
+        },
+        auth_connection: "Username-Password-Authentication",
+        auth_strategy: {
+          strategy: "Username-Password-Authentication",
+          strategy_type: "database",
+        },
+      },
+    );
+
+    const sessionExpiresAt = new Date(
+      Date.now() + 30 * 24 * 3600 * 1000,
+    ).toISOString();
+    const session = await env.data.sessions.create("tenantId", {
+      id: "sessionId",
+      user_id: "email|userId",
+      used_at: new Date().toISOString(),
+      login_session_id: originLoginSession.id,
+      device: {
+        last_ip: "",
+        initial_ip: "",
+        last_user_agent: "",
+        initial_user_agent: "",
+        initial_asn: "",
+        last_asn: "",
+      },
+      expires_at: sessionExpiresAt,
+      idle_expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      clients: ["clientId"],
+    });
+
+    const silentRenewal = async () => {
+      const response = await oauthClient.authorize.$get(
+        {
+          query: {
+            client_id: "clientId",
+            redirect_uri: "https://example.com/callback",
+            state: "state",
+            prompt: "none",
+            response_type: AuthorizationResponseType.CODE,
+            response_mode: AuthorizationResponseMode.WEB_MESSAGE,
+            code_challenge: "ZLQ3m0EnuZ-kdlU1aRGNOPN_dTW8ewOVqEEfZd0cFZE",
+          },
+        },
+        {
+          headers: {
+            origin: "https://example.com",
+            cookie: `tenantId-auth-token=${session.id}`,
+          },
+        },
+      );
+      expect(response.status).toEqual(200);
+      const codeMatch = (await response.text()).match(/"code":"([^"]+)"/);
+      const code = await env.data.codes.get(
+        "tenantId",
+        codeMatch?.[1] || "",
+        "authorization_code",
+      );
+      const loginSession = await env.data.loginSessions.get(
+        "tenantId",
+        code?.login_id || "",
+      );
+      if (!loginSession) {
+        throw new Error("Login session not found for silent renewal");
+      }
+      return loginSession;
+    };
+
+    // First renewal: the session gets re-pointed at a new login session,
+    // which must inherit the strategy from the originating one.
+    const firstRenewalLoginSession = await silentRenewal();
+    expect(firstRenewalLoginSession.id).not.toEqual(originLoginSession.id);
+    expect(firstRenewalLoginSession.auth_strategy).toEqual({
+      strategy: "Username-Password-Authentication",
+      strategy_type: "database",
+    });
+
+    const updatedSession = await env.data.sessions.get("tenantId", session.id);
+    expect(updatedSession?.login_session_id).toEqual(
+      firstRenewalLoginSession.id,
+    );
+
+    // The login session the session now points at must outlive the session
+    // (it's what strategy/connection recovery reads back), not keep its
+    // initial 5-minute expiry.
+    expect(
+      new Date(firstRenewalLoginSession.expires_at).getTime(),
+    ).toBeGreaterThanOrEqual(new Date(sessionExpiresAt).getTime());
+
+    // Second renewal: the strategy must survive hops where the previous
+    // link in the chain is itself a silent-auth login session.
+    const secondRenewalLoginSession = await silentRenewal();
+    expect(secondRenewalLoginSession.id).not.toEqual(
+      firstRenewalLoginSession.id,
+    );
+    expect(secondRenewalLoginSession.auth_strategy).toEqual({
+      strategy: "Username-Password-Authentication",
+      strategy_type: "database",
+    });
+  });
+
   it("should fall back to user.connection when the original login session has no auth_connection", async () => {
     const { oauthApp, env } = await getTestServer();
     const oauthClient = testClient(oauthApp, env);

--- a/packages/authhero/test/routes/universal-login/passwords.spec.ts
+++ b/packages/authhero/test/routes/universal-login/passwords.spec.ts
@@ -5,6 +5,7 @@ import {
   LogTypes,
   AuthorizationResponseType,
   Strategy,
+  StrategyType,
 } from "@authhero/adapter-interfaces";
 import { getTestServer } from "../../helpers/test-server";
 import { u2Screen } from "../../helpers/u2-screen";
@@ -126,6 +127,19 @@ describe("passwords", () => {
       throw new Error("User not found");
     }
     expect(user.app_metadata.strategy).toBe(Strategy.USERNAME_PASSWORD);
+
+    // The login session must record how the user authenticated. This is what
+    // analytics/session-strategy recovery read back, and the password path
+    // (createFrontChannelAuthResponse without a /authorize/resume hop) used
+    // to drop it, leaving auth_strategy NULL for all password logins.
+    const completedLoginSession = await env.data.loginSessions.get(
+      "tenantId",
+      state,
+    );
+    expect(completedLoginSession?.auth_strategy).toEqual({
+      strategy: Strategy.USERNAME_PASSWORD,
+      strategy_type: StrategyType.DATABASE,
+    });
 
     // --------------------------------
     // request password reset


### PR DESCRIPTION
## Problem

`login_sessions.auth_strategy_strategy` / `auth_strategy_strategy_type` were NULL for every password login (and passwordless OTP, passkey, ticket auth, and silent SSO reuse). Production data for a password-heavy tenant showed thousands of completed, authenticated login sessions with NULL strategy and zero `Username-Password-Authentication` rows, while enterprise/social strategies (okta, waad, google-oauth2, oidc) were recorded fine.

## Cause

`createFrontChannelAuthResponse` calls `authenticateLoginSession` for PENDING/EXPIRED login sessions but did not pass `authStrategy` through, so the conditional write `...(authStrategy ? { auth_strategy: authStrategy } : {})` never fired. Only flows going through `finalizeAuthenticatedSession` (enterprise/social redirect callbacks) passed it. The value was still forwarded to `completeLogin` for logs and hooks, which is why SUCCESS_LOGIN logs looked correct while the login session rows stayed NULL.

## Fix

Pass `authStrategy: params.authStrategy` in the `authenticateLoginSession` call inside `createFrontChannelAuthResponse`.

This also makes silent SSO reuse persist the strategy recovered by `recoverSessionAuthStrategy` onto the new login session. Note there is a remaining, separate gap: recovery reads the *originating* login session, which the cleanup job deletes ~8 days after creation, so renewals of older sessions still can't recover their strategy. The durable fix for that is persisting the strategy on the `sessions` row — left as a follow-up.

## Test

Extended `passwords.spec.ts` "should login using a password" to assert the completed login session carries `auth_strategy = { strategy: Username-Password-Authentication, strategy_type: database }`. Verified the assertion fails (received `undefined`) without the fix. Full package suite passes: 1725 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication method details are now saved consistently for front-channel login flows, including password, passwordless OTP, passkey, ticket, and silent SSO reuse.
  * Password logins now record the completed session’s authentication strategy details correctly.

* **Tests**
  * Expanded coverage to verify that successful password sign-ins persist the expected session authentication information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->