### PR TITLE
fix(logs): match canonical auth0 strategy when resolving the password realm

### DIFF
--- a/.changeset/password-connection-strategy-auth0.md
+++ b/.changeset/password-connection-strategy-auth0.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": patch
+---
+
+Fix the connection create form so the "Password" option sets the strategy to the canonical Auth0 database value `auth0` instead of the connection name `Username-Password-Authentication`.

--- a/.changeset/password-connection-strategy-resolution.md
+++ b/.changeset/password-connection-strategy-resolution.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Resolve the password realm against connections with the canonical "auth0" strategy (and other legacy spellings), not just the literal "Username-Password-Authentication" strategy. Tenants whose database connection uses a custom name with strategy "auth0" logged password logins with the generic connection literal and an empty connection_id.

--- a/apps/admin/src/resources/connections/create.tsx
+++ b/apps/admin/src/resources/connections/create.tsx
@@ -1,5 +1,5 @@
 import { Create, SimpleForm, TextInput, SelectInput } from "@/components/admin";
-import { Strategy } from "@/utils/Strategy";
+import { Strategy, DATABASE_CONNECTION_STRATEGY } from "@/utils/Strategy";
 
 const strategyChoices = [
   { id: Strategy.EMAIL, name: "Email" },
@@ -13,7 +13,7 @@ const strategyChoices = [
   { id: Strategy.OAUTH2, name: "OAuth2" },
   { id: Strategy.OIDC, name: "OpenID Connect" },
   { id: Strategy.OKTA, name: "Okta" },
-  { id: Strategy.USERNAME_PASSWORD, name: "Password" },
+  { id: DATABASE_CONNECTION_STRATEGY, name: "Password" },
   { id: Strategy.SMS, name: "SMS" },
   { id: Strategy.SAMLP, name: "SAML" },
 ];

--- a/apps/admin/src/utils/Strategy.ts
+++ b/apps/admin/src/utils/Strategy.ts
@@ -1,4 +1,5 @@
 export {
   Strategy,
+  DATABASE_CONNECTION_STRATEGY,
   isDatabaseConnectionStrategy,
 } from "@authhero/adapter-interfaces";

--- a/packages/authhero/src/authentication-flows/password.ts
+++ b/packages/authhero/src/authentication-flows/password.ts
@@ -375,8 +375,8 @@ export async function passwordGrant(
   // ambiguous (multiple username-password connections) keep the realm as-is.
   let targetConnection = client.connections.find((c) => c.name === realm);
   if (!targetConnection && realm === Strategy.USERNAME_PASSWORD) {
-    const usernamePasswordConnections = client.connections.filter(
-      (c) => c.strategy === Strategy.USERNAME_PASSWORD,
+    const usernamePasswordConnections = client.connections.filter((c) =>
+      isDatabaseConnectionStrategy(c.strategy),
     );
     if (usernamePasswordConnections.length === 1) {
       targetConnection = usernamePasswordConnections[0];

--- a/packages/authhero/test/routes/universal-login/passwords.spec.ts
+++ b/packages/authhero/test/routes/universal-login/passwords.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { testClient } from "hono/testing";
 import bcryptjs from "bcryptjs";
 import {
+  DATABASE_CONNECTION_STRATEGY,
   LogTypes,
   AuthorizationResponseType,
   Strategy,
@@ -207,6 +208,90 @@ describe("passwords", () => {
     });
 
     expect(resetPasswordGetResponse.status).toBe(200);
+  });
+
+  it("should log the real connection name and id when the password connection has a custom name and the canonical auth0 strategy", async () => {
+    // Regression test: a tenant whose database connection uses the canonical
+    // "auth0" strategy and a custom name (e.g. "password") logged successful
+    // password logins with the generic Username-Password-Authentication
+    // literal and an empty connection_id, because the realm fallback only
+    // matched the legacy name-as-strategy spelling.
+    const { universalApp, oauthApp, env } = await getTestServer({
+      testTenantLanguage: "en",
+    });
+    const oauthClient = testClient(oauthApp, env);
+    const universalClient = testClient(universalApp, env);
+
+    // Replace the default password connection with one shaped like a
+    // production tenant: custom name + canonical "auth0" strategy.
+    await env.data.connections.remove("tenantId", Strategy.USERNAME_PASSWORD);
+    await env.data.connections.create("tenantId", {
+      id: "con_customPassword",
+      name: "password",
+      strategy: DATABASE_CONNECTION_STRATEGY,
+      options: {},
+    });
+
+    await env.data.users.create("tenantId", {
+      email: "custom-conn@example.com",
+      email_verified: true,
+      name: "Custom Connection User",
+      nickname: "customconn",
+      connection: Strategy.USERNAME_PASSWORD,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      is_social: false,
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|customConnUser`,
+    });
+    await env.data.passwords.create("tenantId", {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|customConnUser`,
+      password: await bcryptjs.hash("password", 10),
+      algorithm: "bcrypt",
+    });
+
+    const authorizeResponse = await oauthClient.authorize.$get({
+      query: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+        state: "state",
+        nonce: "nonce",
+        scope: "openid email profile",
+        response_type: AuthorizationResponseType.CODE,
+      },
+    });
+    expect(authorizeResponse.status).toBe(302);
+
+    const location = authorizeResponse.headers.get("location");
+    const universalUrl = new URL(`https://example.com${location}`);
+    const state = universalUrl.searchParams.get("state");
+    if (!state) {
+      throw new Error("No state found");
+    }
+
+    const identifierResponse = await universalClient.login.identifier.$post({
+      query: { state },
+      form: { username: "custom-conn@example.com" },
+    });
+    expect(identifierResponse.status).toBe(302);
+
+    const enterPasswordPostResponse = await universalClient[
+      "enter-password"
+    ].$post({
+      query: { state },
+      form: { password: "password" },
+    });
+    expect(enterPasswordPostResponse.status).toBe(302);
+
+    const { logs } = await env.data.logs.list("tenantId", {
+      page: 0,
+      per_page: 100,
+      include_totals: false,
+    });
+    const successLoginLog = logs.find(
+      (log) => log.type === LogTypes.SUCCESS_LOGIN,
+    );
+    expect(successLoginLog).toBeDefined();
+    expect(successLoginLog?.connection).toBe("password");
+    expect(successLoginLog?.connection_id).toBe("con_customPassword");
   });
 
   it("should log password reset request when email is sent", async () => {


### PR DESCRIPTION
## Problem

Prod log from linkfire (`id.linkfire.com`) showed a successful password login recorded with `connection: "Username-Password-Authentication"` and an empty `connection_id`, even though the tenant's database connection is named `password`.

The realm-resolution fallback added in b79464e4 (shipped in `authhero@8.17.0`) only matched connections whose `strategy` is the literal `"Username-Password-Authentication"`. Linkfire's connection carries `strategy: "auth0"` — the **canonical** spelling that `DATABASE_CONNECTION_STRATEGY` declares as the target for all new connection rows — so the fallback never matched, `ctx.var.connection` fell back to the generic literal, and the log enrichment couldn't resolve a `connection_id` from a connection name that doesn't exist on the tenant.

## Fix

Use `isDatabaseConnectionStrategy()` in the fallback filter — the same helper the lazy-migration block 60 lines up already uses — so all three accepted spellings (`auth0`, `auth2`, and the legacy name-as-strategy) resolve. The single-match ambiguity guard is unchanged.

## Follow-up: admin UI create form (commit c72ddd24)

The same canonical-strategy issue existed on the write side. The connection **create** form's "Password" option sent `strategy: "Username-Password-Authentication"` — the connection *name*, not a strategy — so every new database connection created through the admin UI persisted a non-canonical strategy that only worked via the `isDatabaseConnectionStrategy()` fallback (the very fallback this PR patches on the read side).

It now sends `DATABASE_CONNECTION_STRATEGY` (`"auth0"`), matching `seed.ts` and Auth0's actual behaviour (strategy `auth0`, name free-text). Includes an `@authhero/admin` patch changeset.

Note: existing connections already created with the name-as-strategy value are unaffected and keep working via the fallback; this only fixes connections created going forward.

## Testing

- New regression test mirroring the linkfire shape (connection named `password` with strategy `auth0`): asserts the success-login log records `connection: "password"` and the real `connection_id`. Verified it fails without the src change.
- Full `authhero` suite passes (1727 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
