### PR TITLE
fix(users): persist the full profile on POST /users

### DIFF
--- a/.changeset/post-users-persist-full-profile.md
+++ b/.changeset/post-users-persist-full-profile.md
@@ -1,0 +1,6 @@
+---
+"authhero": patch
+"@authhero/kysely-adapter": patch
+---
+
+Persist the full user profile on `POST /users`. The management-api create handler previously hand-copied a whitelist of fields and silently dropped the rest (`given_name`, `family_name`, `nickname`, `picture`, `locale`, `gender`, `birthdate`, `zoneinfo`, `website`, `middle_name`, `preferred_username`, `app_metadata`, `user_metadata`, `address`, etc.) even though they are valid on the schema and the adapter already stores them — forcing a create-then-PATCH workaround. It now forwards all validated profile fields, matching Auth0 and the `PATCH /users` behaviour. Also fixes the kysely adapter's `create` to return `app_metadata`/`user_metadata` as objects (not serialized JSON strings) so the create response matches `get`/`list`.

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -358,6 +358,22 @@ const postRoot = defineRoute({
       provider: providedProvider,
       connection,
       password,
+      // Pulled out so they don't leak through ...profileFields below:
+      //   user_id/provider are re-derived, verify_email is never persisted,
+      //   last_ip/is_social/last_login are set by the server, and
+      //   registration_completed_at is an internal self-healing flag callers
+      //   must not be able to spoof.
+      user_id: _providedUserId,
+      verify_email: _verifyEmail,
+      last_ip: _lastIp,
+      is_social: _isSocial,
+      last_login: _lastLogin,
+      registration_completed_at: _registrationCompletedAt,
+      // Everything else on userInsertSchema (given_name, family_name,
+      // nickname, picture, app_metadata, user_metadata, address, birthdate,
+      // etc.) is forwarded verbatim so it is actually persisted instead of
+      // being silently dropped.
+      ...profileFields
     } = body;
 
     // Look up the connection to derive the provider
@@ -399,6 +415,9 @@ const postRoot = defineRoute({
       // ctx.env.data is already wrapped with hooks by the management API middleware,
       // so we can use it directly to enable automatic account linking
       const userToCreate = {
+        // Forward the remaining validated profile fields first; the explicit
+        // keys below take precedence over anything with the same name.
+        ...profileFields,
         email,
         user_id,
         name: name || email || phone_number,

--- a/packages/authhero/test/routes/management-api/users.spec.ts
+++ b/packages/authhero/test/routes/management-api/users.spec.ts
@@ -151,6 +151,102 @@ describe("users management API endpoint", () => {
       ]);
     });
 
+    it("should persist the full profile on create instead of dropping fields", async () => {
+      const token = await getAdminToken();
+
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+
+      const createUserResponse = await managementClient.users.$post(
+        {
+          json: {
+            email: "full-profile@example.com",
+            connection: "email",
+            given_name: "Ada",
+            family_name: "Lovelace",
+            nickname: "ada",
+            picture: "https://example.com/ada.png",
+            locale: "en-GB",
+            gender: "female",
+            birthdate: "1815-12-10",
+            zoneinfo: "Europe/London",
+            website: "https://example.com/ada",
+            middle_name: "Augusta",
+            preferred_username: "countess",
+            app_metadata: { plan: "pro" },
+            user_metadata: { favouriteColor: "green" },
+            address: {
+              country: "United Kingdom",
+              locality: "London",
+            },
+          },
+          header: {
+            "tenant-id": "tenantId",
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      expect(createUserResponse.status).toBe(201);
+
+      const newUser = await createUserResponse.json();
+
+      // The create response should echo back every profile field, not just
+      // the previously-whitelisted subset.
+      expect(newUser.given_name).toBe("Ada");
+      expect(newUser.family_name).toBe("Lovelace");
+      expect(newUser.nickname).toBe("ada");
+      expect(newUser.picture).toBe("https://example.com/ada.png");
+      expect(newUser.locale).toBe("en-GB");
+      expect(newUser.gender).toBe("female");
+      expect(newUser.birthdate).toBe("1815-12-10");
+      expect(newUser.zoneinfo).toBe("Europe/London");
+      expect(newUser.website).toBe("https://example.com/ada");
+      expect(newUser.middle_name).toBe("Augusta");
+      expect(newUser.preferred_username).toBe("countess");
+      expect(newUser.app_metadata).toEqual({ plan: "pro" });
+      expect(newUser.user_metadata).toEqual({ favouriteColor: "green" });
+      expect(newUser.address).toEqual({
+        country: "United Kingdom",
+        locality: "London",
+      });
+
+      // And the fields should actually be persisted, not just reflected.
+      const getUserResponse = await managementClient.users[":user_id"].$get(
+        {
+          param: { user_id: newUser.user_id },
+          header: {
+            "tenant-id": "tenantId",
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      expect(getUserResponse.status).toBe(200);
+
+      const fetchedUser = await getUserResponse.json();
+      if (Array.isArray(fetchedUser)) {
+        throw new Error("Expected a single user");
+      }
+
+      expect(fetchedUser.given_name).toBe("Ada");
+      expect(fetchedUser.family_name).toBe("Lovelace");
+      expect(fetchedUser.app_metadata).toEqual({ plan: "pro" });
+      expect(fetchedUser.user_metadata).toEqual({ favouriteColor: "green" });
+      expect(fetchedUser.address).toEqual({
+        country: "United Kingdom",
+        locality: "London",
+      });
+    });
+
     it("should handle provider-prefixed user_id without double-prefixing", async () => {
       const token = await getAdminToken();
       const { managementApp, env } = await getTestServer();

--- a/packages/kysely/src/users/create.ts
+++ b/packages/kysely/src/users/create.ts
@@ -168,7 +168,12 @@ export function create(db: Kysely<Database>) {
           ? sqlUser.phone_verified === 1
           : undefined,
       is_social: sqlUser.is_social === 1,
-      address: user.address, // Return original address object, not serialized string
+      // Return the original object values, not the serialized strings written
+      // to the row — so the create response matches what get()/list() return
+      // (and Auth0) instead of leaking JSON strings.
+      app_metadata: user.app_metadata,
+      user_metadata: user.user_metadata,
+      address: user.address,
     };
   };
 }


### PR DESCRIPTION
## Summary

`POST /users` silently dropped most of the user profile fields it received. The body was validated against `userInsertSchema` (which accepts them) and the adapter's `create` persists whatever it's given, but the `postRoot` handler in between hand-copied only a whitelist into the record it wrote — so the rest were accepted with a `201` and then lost. The workaround was to create a user and immediately `PATCH` it (which does *not* whitelist), i.e. two calls for what should be one.

Fixes #1067.

## Changes

- **`packages/authhero/src/routes/management-api/users.ts`** — the `postRoot` handler now forwards all validated profile fields (`...profileFields`) into `userToCreate`, pulling out only the server-derived / non-persisted ones (`user_id`, `provider`, `verify_email`, `last_ip`, `is_social`, `last_login`, `registration_completed_at`) so they can't leak through or be spoofed. The explicit keys still take precedence. This mirrors how `PATCH /users` already forwards `...userFields`, and matches Auth0's `POST /api/v2/users`.
- **`packages/kysely/src/users/create.ts`** — a latent bug this change surfaced: `create()` returned the serialized JSON strings for `app_metadata` / `user_metadata` (only `address` was deserialized), so the create response leaked JSON strings while `get()`/`list()` returned objects. Now all three return objects. (Drizzle already did this correctly via `sqlToUser`.)
- New test asserting the full profile round-trips both in the `201` response and via a follow-up `GET`.
- Changeset (`authhero` + `@authhero/kysely-adapter`, patch).

## Testing

- `users.spec.ts` — 42/42 pass (incl. new test)
- kysely `test/users/` — 9/9 pass
- `tsc --noEmit` clean on both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a user now saves the full validated profile, including extra profile details and metadata.
  * User creation responses now return metadata and address fields in the same format as other user lookups.
  * Server-controlled fields are protected during user creation, preventing unexpected overrides.
* **Tests**
  * Added coverage to confirm user creation persists and returns the complete profile data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->