### PR TITLE
feat: forward tenant to user-registration hook events

### DIFF
--- a/.changeset/forward-tenant-registration-hook.md
+++ b/.changeset/forward-tenant-registration-hook.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Forward `tenant: { id }` to the pre- and post-user-registration hook events, matching the update and deletion hooks. Consumers no longer need to fall back to `event.ctx.var.tenant_id`.

--- a/packages/authhero/src/hooks/user-registration.ts
+++ b/packages/authhero/src/hooks/user-registration.ts
@@ -69,6 +69,7 @@ export function createUserHooks(
             ctx,
             user,
             request,
+            tenant: { id: tenant_id },
           },
           {
             user: {
@@ -241,6 +242,7 @@ export function createUserHooks(
               ctx,
               user,
               request,
+              tenant: { id: tenant_id },
             },
             {
               user: {},

--- a/packages/authhero/test/hooks/on-post-user-registration.spec.ts
+++ b/packages/authhero/test/hooks/on-post-user-registration.spec.ts
@@ -45,6 +45,8 @@ describe("on-post-user-registration-hook", () => {
     // The hook should fire once when the user is created
     expect(events.length).toBe(1);
     expect(events[0]?.user.email).toBe("foo2@example.com");
+    // The event should carry the tenant, matching update/deletion hooks
+    expect(events[0]?.tenant).toEqual({ id: "tenantId" });
   });
 
   it("should fire only once when two creates race for the same user_id", async () => {

--- a/packages/authhero/test/hooks/on-pre-user-registration.spec.ts
+++ b/packages/authhero/test/hooks/on-pre-user-registration.spec.ts
@@ -11,13 +11,15 @@ import { UserResponse, Strategy } from "@authhero/adapter-interfaces";
 describe("on-pre-user-registration-hook", () => {
   it("should link user to primary via setLinkedTo", async () => {
     let primaryUserId: string | undefined;
+    const events: HookEvent[] = [];
 
     const { env, managementApp } = await getTestServer({
       hooks: {
         onExecutePreUserRegistration: async (
-          _: HookEvent,
+          event: HookEvent,
           api: OnExecutePreUserRegistrationAPI,
         ) => {
+          events.push(event);
           // Link to the primary user when creating a new user
           if (primaryUserId) {
             api.user.setLinkedTo(primaryUserId);
@@ -50,6 +52,9 @@ describe("on-pre-user-registration-hook", () => {
     expect(primaryResponse.status).toBe(201);
     const primaryUser = (await primaryResponse.json()) as UserResponse;
     primaryUserId = primaryUser.user_id;
+
+    // The event should carry the tenant, matching update/deletion hooks
+    expect(events[0]?.tenant).toEqual({ id: "tenantId" });
 
     // Create a secondary user that will be linked to the primary
     const secondaryResponse = await client.users.$post(


### PR DESCRIPTION
## Problem

`onExecutePostUserRegistration` was the only user-lifecycle hook whose event did **not** carry `tenant`. The update and deletion hooks both pass `tenant: { id: tenant_id }`, forcing post-registration consumers to fall back to reading `event.ctx.var.tenant_id`.

Fixes #1069.

## Changes

- Add `tenant: { id: tenant_id }` to both the `onExecutePreUserRegistration` and `onExecutePostUserRegistration` events in `user-registration.ts`, matching the update hooks (which set it on both pre and post).
- No type change needed — `HookEvent` already declares `tenant?: { id: string }`.
- Tests assert the event now carries `tenant: { id: "tenantId" }` for both pre and post registration.
- Changeset (patch bump for `authhero`).

## Note

This covers the `onExecute*` decorator hooks that consumers wire up. The in-file code/template hooks (`handleCodeHook`) still pass `{ ctx, user, request }` without `tenant` — out of scope for the reported issue, happy to align them in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)