### PR TITLE
feat(admin): add birthdate and address fields to user forms

### DIFF
--- a/apps/admin/src/resources/users/create.tsx
+++ b/apps/admin/src/resources/users/create.tsx
@@ -59,6 +59,7 @@ export function UserCreate() {
         <TextInput source="name" />
         <TextInput source="given_name" />
         <TextInput source="family_name" />
+        <TextInput source="birthdate" type="date" label="Birthdate" />
         <TextInput source="picture" />
         <BooleanInput source="email_verified" />
         <BooleanInput source="phone_verified" />

--- a/apps/admin/src/resources/users/tabs/details-tab.tsx
+++ b/apps/admin/src/resources/users/tabs/details-tab.tsx
@@ -714,7 +714,31 @@ export function DetailsTab() {
             <TextInput source="nickname" />
           </div>
           <TextInput source="name" />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <TextInput source="birthdate" type="date" label="Birthdate" />
+          </div>
           <TextInput source="picture" />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Address</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <TextInput source="address.street_address" label="Street address" />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <TextInput source="address.locality" label="City / locality" />
+            <TextInput
+              source="address.region"
+              label="State / region"
+            />
+            <TextInput source="address.postal_code" label="Postal code" />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <TextInput source="address.country" label="Country" />
+            <TextInput source="address.formatted" label="Formatted address" />
+          </div>
         </CardContent>
       </Card>
 

--- a/apps/admin/src/resources/users/tabs/types.ts
+++ b/apps/admin/src/resources/users/tabs/types.ts
@@ -18,6 +18,15 @@ export interface UserRecord extends RaRecord {
   family_name?: string;
   nickname?: string;
   picture?: string;
+  birthdate?: string;
+  address?: {
+    formatted?: string;
+    street_address?: string;
+    locality?: string;
+    region?: string;
+    postal_code?: string;
+    country?: string;
+  };
   connection?: string;
   user_id?: string;
   last_login?: string;


### PR DESCRIPTION
## What

Surface the OIDC/Auth0 standard `birthdate` and `address` claims in the admin Users UI so they can be viewed and edited.

- **User edit form** ([details-tab.tsx](apps/admin/src/resources/users/tabs/details-tab.tsx)):
  - `birthdate` (date input) added to the **User profile** card.
  - New **Address** card with structured inputs for the OIDC address sub-fields (`street_address`, `locality`, `region`, `postal_code`, `country`, `formatted`), bound via dot-notation sources (`address.locality`, …) so they read/write the nested `address` object directly instead of raw JSON.
- **User create form** ([create.tsx](apps/admin/src/resources/users/create.tsx)): `birthdate` input added.
- **Type** ([types.ts](apps/admin/src/resources/users/tabs/types.ts)): `UserRecord` extended with `birthdate` and the structured `address` shape.

## Why

These are part of Auth0's normalized profile / OIDC Core 5.1 standard claims and were already accepted by the API but not editable in the UI.

## Notes

- Both fields flow through the management API create (`userInsertSchema`) and update (`.partial()`) schemas, which include `birthdate` and `address` via the base user schema, so edits persist.
- `address` at signup is unusual, so it's only on the edit form, not create.
- No changeset — `apps/admin` is not a versioned/published package.
- `tsc --noEmit` passes for the admin app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)