### PR TITLE
feat: auto-provision a default/anchor client at tenant creation (#1007)

### DIFF
--- a/.changeset/auto-provision-default-client.md
+++ b/.changeset/auto-provision-default-client.md
@@ -11,3 +11,4 @@ New tenants now come with a designated interactive default client by constructio
 - Wired into both tenant-creation paths: the `seed`/bootstrap script and the multi-tenancy `afterCreate` provisioning hook (pooled tenants; isolated tenants are seeded via their own database provisioning).
 - `/connect/start` now falls back to the first *interactive* client (via the new `isInteractiveClient` helper) instead of `clients[0]`, so it never anchors on an M2M client.
 - `PATCH /tenants/settings` now rejects a `default_client_id` that doesn't reference an existing, interactive client (both the management-api and multi-tenancy handlers).
+- Provisioning now recovers from a partial prior run: if the M2M "API Explorer" client exists but its Management API grant is missing (e.g. a run that failed between creating the client and its grant), a re-run restores the grant instead of returning early.

--- a/.changeset/auto-provision-default-client.md
+++ b/.changeset/auto-provision-default-client.md
@@ -1,0 +1,13 @@
+---
+"authhero": minor
+"@authhero/multi-tenancy": minor
+---
+
+Auto-provision a default/anchor client at tenant creation (issue #1007).
+
+New tenants now come with a designated interactive default client by construction, so tenant-level flows that need an anchor (e.g. the DCR `/connect/start` consent flow) no longer silently fall back to an arbitrary — possibly M2M — client.
+
+- New shared `provisionDefaultClients()` helper (exported from `authhero`) creates an interactive first-party "Default App", sets `tenant.default_client_id` to it, and provisions an M2M "API Explorer" client authorized against the Management API. It is idempotent and import-safe: it respects an already-set `default_client_id`, reuses an existing interactive client instead of duplicating, and skips the M2M client when one already exists. The Default App is created with no connections, so all of the tenant's connections are offered at login.
+- Wired into both tenant-creation paths: the `seed`/bootstrap script and the multi-tenancy `afterCreate` provisioning hook (pooled tenants; isolated tenants are seeded via their own database provisioning).
+- `/connect/start` now falls back to the first *interactive* client (via the new `isInteractiveClient` helper) instead of `clients[0]`, so it never anchors on an M2M client.
+- `PATCH /tenants/settings` now rejects a `default_client_id` that doesn't reference an existing, interactive client (both the management-api and multi-tenancy handlers).

--- a/packages/authhero/src/helpers/provision-tenant-clients.ts
+++ b/packages/authhero/src/helpers/provision-tenant-clients.ts
@@ -1,0 +1,269 @@
+import { Client, DataAdapters } from "@authhero/adapter-interfaces";
+import { nanoid } from "nanoid";
+import { MANAGEMENT_API_AUDIENCE } from "../middlewares/authentication";
+
+/**
+ * Whether a client can anchor interactive, user-facing flows (universal login,
+ * the DCR `/connect/start` consent bounce, etc.).
+ *
+ * A client is considered interactive unless it is explicitly machine-to-machine:
+ * `non_interactive`/`resource_server` app types, or a grant list that only
+ * allows `client_credentials`. Clients with no explicit `grant_types` are
+ * treated as interactive — that matches how a freshly created "Default App"
+ * (which relies on the authorize flow) behaves in AuthHero and Auth0.
+ */
+export function isInteractiveClient(
+  client: Pick<Client, "app_type" | "grant_types">,
+): boolean {
+  if (
+    client.app_type === "non_interactive" ||
+    client.app_type === "resource_server"
+  ) {
+    return false;
+  }
+
+  const grantTypes = client.grant_types ?? [];
+  if (grantTypes.length === 0) {
+    return true;
+  }
+
+  return grantTypes.some(
+    (grant) => grant === "authorization_code" || grant === "implicit",
+  );
+}
+
+/** A single Management API scope entry (`{ value, description }`). */
+export interface ManagementApiScope {
+  value: string;
+  description?: string;
+}
+
+export interface ProvisionDefaultClientsOptions {
+  /** Display name for an auto-created Default App. Defaults to "Default App". */
+  defaultAppName?: string;
+  /** Callback URLs for an auto-created Default App. */
+  callbacks?: string[];
+  /** Allowed logout URLs for an auto-created Default App. */
+  allowedLogoutUrls?: string[];
+  /** Allowed web origins for an auto-created Default App. */
+  webOrigins?: string[];
+  /**
+   * Also provision an M2M "API Explorer" client authorized against the
+   * Management API (Auth0 parity). Defaults to `true`. Requires
+   * `managementApiScopes` to seed the resource server when it is missing.
+   */
+  createManagementClient?: boolean;
+  /** Management API identifier. Defaults to `urn:authhero:management`. */
+  managementApiIdentifier?: string;
+  /**
+   * Scopes used to seed the Management API resource server when it does not
+   * yet exist, and to authorize the M2M client's grant. When omitted, the
+   * resource server is assumed to already exist and the grant is created with
+   * no explicit scope.
+   */
+  managementApiScopes?: ManagementApiScope[];
+  /** Emit progress logs (used by the seed script). */
+  debug?: boolean;
+}
+
+const MANAGEMENT_CLIENT_NAME = "API Explorer Application";
+
+export interface ProvisionDefaultClientsResult {
+  /** The client the tenant's `default_client_id` now points at. */
+  defaultClientId: string;
+  /** The auto-provisioned M2M Management API client, if one was created/found. */
+  managementClientId?: string;
+}
+
+/**
+ * Ensures a tenant has a designated interactive default client and (optionally)
+ * an M2M Management API client, then points `tenant.default_client_id` at the
+ * former.
+ *
+ * Idempotent and import-safe:
+ * - Respects an already-set, still-valid `default_client_id`.
+ * - Reuses an existing interactive client instead of creating a duplicate.
+ * - Skips the M2M client when one already exists.
+ *
+ * Shared by every tenant-creation path (the seed/bootstrap script and the
+ * multi-tenancy provisioning hook) so new tenants come with a sensible anchor
+ * client by construction — see issue #1007.
+ */
+export async function provisionDefaultClients(
+  adapters: DataAdapters,
+  tenantId: string,
+  options: ProvisionDefaultClientsOptions = {},
+): Promise<ProvisionDefaultClientsResult> {
+  const {
+    defaultAppName = "Default App",
+    callbacks = [],
+    allowedLogoutUrls = [],
+    webOrigins = [],
+    createManagementClient = true,
+    managementApiIdentifier = MANAGEMENT_API_AUDIENCE,
+    managementApiScopes,
+    debug = false,
+  } = options;
+
+  const tenant = await adapters.tenants.get(tenantId);
+  if (!tenant) {
+    throw new Error(`Cannot provision clients: tenant "${tenantId}" not found`);
+  }
+
+  // 1. Resolve the interactive default client.
+  const defaultClient = await resolveDefaultClient(adapters, tenantId, {
+    currentDefaultClientId: tenant.default_client_id,
+    defaultAppName,
+    callbacks,
+    allowedLogoutUrls,
+    webOrigins,
+    debug,
+  });
+
+  if (tenant.default_client_id !== defaultClient.client_id) {
+    await adapters.tenants.update(tenantId, {
+      default_client_id: defaultClient.client_id,
+    });
+    if (debug) {
+      console.log(`✅ default_client_id set to "${defaultClient.client_id}"`);
+    }
+  }
+
+  // 2. Optionally provision the M2M Management API client.
+  let managementClientId: string | undefined;
+  if (createManagementClient) {
+    managementClientId = await ensureManagementClient(adapters, tenantId, {
+      managementApiIdentifier,
+      managementApiScopes,
+      debug,
+    });
+  }
+
+  return { defaultClientId: defaultClient.client_id, managementClientId };
+}
+
+async function resolveDefaultClient(
+  adapters: DataAdapters,
+  tenantId: string,
+  opts: {
+    currentDefaultClientId?: string;
+    defaultAppName: string;
+    callbacks: string[];
+    allowedLogoutUrls: string[];
+    webOrigins: string[];
+    debug: boolean;
+  },
+): Promise<Client> {
+  // Respect an already-configured, still-valid interactive default client.
+  if (opts.currentDefaultClientId) {
+    const existing = await adapters.clients.get(
+      tenantId,
+      opts.currentDefaultClientId,
+    );
+    if (existing && isInteractiveClient(existing)) {
+      return existing;
+    }
+  }
+
+  // Reuse any existing interactive client (e.g. the seed's "Default
+  // Application") rather than creating a duplicate.
+  const { clients } = await adapters.clients.list(tenantId);
+  const interactive = clients.find(isInteractiveClient);
+  if (interactive) {
+    return interactive;
+  }
+
+  // No interactive client exists yet — create the Default App.
+  const created = await adapters.clients.create(tenantId, {
+    client_id: nanoid(),
+    client_secret: nanoid(),
+    name: opts.defaultAppName,
+    app_type: "regular_web",
+    is_first_party: true,
+    grant_types: ["authorization_code", "refresh_token"],
+    callbacks: opts.callbacks,
+    allowed_logout_urls: opts.allowedLogoutUrls,
+    web_origins: opts.webOrigins,
+    // Leave connections empty so all of the tenant's connections are offered
+    // at login (see helpers/client.ts). New connections become available
+    // automatically without touching the default client.
+    connections: [],
+    client_metadata: { universal_login_version: "2" },
+  });
+  if (opts.debug) {
+    console.log(`✅ Default App created (${created.client_id})`);
+  }
+  return created;
+}
+
+async function ensureManagementClient(
+  adapters: DataAdapters,
+  tenantId: string,
+  opts: {
+    managementApiIdentifier: string;
+    managementApiScopes?: ManagementApiScope[];
+    debug: boolean;
+  },
+): Promise<string | undefined> {
+  const { clients } = await adapters.clients.list(tenantId);
+  const existing = clients.find(
+    (client) =>
+      client.app_type === "non_interactive" &&
+      client.name === MANAGEMENT_CLIENT_NAME,
+  );
+  if (existing) {
+    return existing.client_id;
+  }
+
+  // The M2M client mints Management API tokens via client_credentials, so the
+  // resource server has to exist. Seed it when scopes were supplied and it is
+  // missing (mirrors the seed script's defaults).
+  if (opts.managementApiScopes) {
+    const { resource_servers } = await adapters.resourceServers.list(
+      tenantId,
+      {},
+    );
+    const hasManagementApi = resource_servers.some(
+      (rs) => rs.identifier === opts.managementApiIdentifier,
+    );
+    if (!hasManagementApi) {
+      await adapters.resourceServers.create(tenantId, {
+        name: "Authhero Management API",
+        identifier: opts.managementApiIdentifier,
+        allow_offline_access: true,
+        skip_consent_for_verifiable_first_party_clients: false,
+        token_lifetime: 86400,
+        token_lifetime_for_web: 7200,
+        signing_alg: "RS256",
+        scopes: opts.managementApiScopes,
+        options: {
+          enforce_policies: true,
+          token_dialect: "access_token_authz",
+        },
+      });
+      if (opts.debug) {
+        console.log("✅ Management API resource server created");
+      }
+    }
+  }
+
+  const client = await adapters.clients.create(tenantId, {
+    client_id: nanoid(),
+    client_secret: nanoid(),
+    name: MANAGEMENT_CLIENT_NAME,
+    app_type: "non_interactive",
+    is_first_party: true,
+    grant_types: ["client_credentials"],
+  });
+
+  await adapters.clientGrants.create(tenantId, {
+    client_id: client.client_id,
+    audience: opts.managementApiIdentifier,
+    scope: opts.managementApiScopes?.map((scope) => scope.value) ?? [],
+  });
+
+  if (opts.debug) {
+    console.log(`✅ Management API (M2M) client created (${client.client_id})`);
+  }
+  return client.client_id;
+}

--- a/packages/authhero/src/helpers/provision-tenant-clients.ts
+++ b/packages/authhero/src/helpers/provision-tenant-clients.ts
@@ -212,6 +212,10 @@ async function ensureManagementClient(
       client.name === MANAGEMENT_CLIENT_NAME,
   );
   if (existing) {
+    // The client may have been created by a prior run that failed before its
+    // Management API grant was written. Restore the grant if it is missing so
+    // re-runs recover from a partial failure.
+    await ensureManagementApiGrant(adapters, tenantId, existing.client_id, opts);
     return existing.client_id;
   }
 
@@ -256,14 +260,41 @@ async function ensureManagementClient(
     grant_types: ["client_credentials"],
   });
 
-  await adapters.clientGrants.create(tenantId, {
-    client_id: client.client_id,
-    audience: opts.managementApiIdentifier,
-    scope: opts.managementApiScopes?.map((scope) => scope.value) ?? [],
-  });
+  await ensureManagementApiGrant(adapters, tenantId, client.client_id, opts);
 
   if (opts.debug) {
     console.log(`✅ Management API (M2M) client created (${client.client_id})`);
   }
   return client.client_id;
+}
+
+/**
+ * Ensures the M2M client has a grant against the Management API, creating one
+ * only when it is missing. Idempotent so re-runs recover from a partial prior
+ * run that created the client but not its grant.
+ */
+async function ensureManagementApiGrant(
+  adapters: DataAdapters,
+  tenantId: string,
+  clientId: string,
+  opts: {
+    managementApiIdentifier: string;
+    managementApiScopes?: ManagementApiScope[];
+  },
+): Promise<void> {
+  const { client_grants } = await adapters.clientGrants.list(tenantId);
+  const hasGrant = client_grants.some(
+    (grant) =>
+      grant.client_id === clientId &&
+      grant.audience === opts.managementApiIdentifier,
+  );
+  if (hasGrant) {
+    return;
+  }
+
+  await adapters.clientGrants.create(tenantId, {
+    client_id: clientId,
+    audience: opts.managementApiIdentifier,
+    scope: opts.managementApiScopes?.map((scope) => scope.value) ?? [],
+  });
 }

--- a/packages/authhero/src/index.ts
+++ b/packages/authhero/src/index.ts
@@ -37,6 +37,15 @@ export { cleanupOutbox } from "./helpers/outbox-cleanup";
 export type { OutboxCleanupParams } from "./helpers/outbox-cleanup";
 export { createDefaultDestinations } from "./helpers/default-destinations";
 export type { CreateDefaultDestinationsConfig } from "./helpers/default-destinations";
+export {
+  provisionDefaultClients,
+  isInteractiveClient,
+} from "./helpers/provision-tenant-clients";
+export type {
+  ProvisionDefaultClientsOptions,
+  ProvisionDefaultClientsResult,
+  ManagementApiScope,
+} from "./helpers/provision-tenant-clients";
 export { runOutboxRelay } from "./helpers/run-outbox-relay";
 export type { RunOutboxRelayConfig } from "./helpers/run-outbox-relay";
 export { LogsDestination } from "./helpers/outbox-destinations/logs";

--- a/packages/authhero/src/routes/auth-api/connect-start.ts
+++ b/packages/authhero/src/routes/auth-api/connect-start.ts
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid";
 import { Bindings, Variables } from "../../types";
 import { JSONHTTPException } from "../../errors/json-http-exception";
 import { validateConnectOrigin } from "../../helpers/dcr/validate-connect-origin";
+import { isInteractiveClient } from "../../helpers/provision-tenant-clients";
 
 import { defineRoute } from "../../utils/define-route";
 const UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS = 60 * 30; // 30 min
@@ -144,14 +145,15 @@ const getRoot = defineRoute({
     // to carry consent state through the login bounce; the anchor client_id
     // is never traversed in an OAuth flow. Prefer the tenant's configured
     // `default_client_id` (analogous to Auth0's Default App) so branding
-    // stays deterministic, and fall back to the first available client so a
-    // brand-new tenant can still bootstrap its first DCR integration.
+    // stays deterministic, and fall back to the first *interactive* client so
+    // a brand-new tenant can still bootstrap its first DCR integration — never
+    // an M2M/client_credentials client, which can't render a login screen.
     let anchorClient = tenant.default_client_id
       ? await ctx.env.data.clients.get(tenant_id, tenant.default_client_id)
       : null;
     if (!anchorClient) {
       const { clients } = await ctx.env.data.clients.list(tenant_id);
-      anchorClient = clients[0] ?? null;
+      anchorClient = clients.find(isInteractiveClient) ?? null;
     }
     if (!anchorClient) {
       throw new JSONHTTPException(400, {

--- a/packages/authhero/src/routes/management-api/tenants.ts
+++ b/packages/authhero/src/routes/management-api/tenants.ts
@@ -9,6 +9,7 @@ import {
 import { deepMergePatch } from "../../utils/deep-merge";
 import { logMessage } from "../../helpers/logging";
 import { defineRoute } from "../../utils/define-route";
+import { isInteractiveClient } from "../../helpers/provision-tenant-clients";
 const getSettings = defineRoute({
   route: createRoute({
     tags: ["tenants", "settings"],
@@ -118,6 +119,26 @@ const patchSettings = defineRoute({
         if (!exists) {
           throw new HTTPException(400, {
             message: `Resource server with identifier '${next}' not found`,
+          });
+        }
+      }
+    }
+
+    // The default client anchors interactive tenant-level flows (e.g. the DCR
+    // /connect/start consent bounce), so it must reference an existing,
+    // interactive client — never an M2M/client_credentials client (#1007).
+    if ("default_client_id" in sanitizedUpdates) {
+      const next = sanitizedUpdates.default_client_id;
+      if (typeof next === "string" && next.length > 0) {
+        const client = await ctx.env.data.clients.get(ctx.var.tenant_id, next);
+        if (!client) {
+          throw new HTTPException(400, {
+            message: `Client with id '${next}' not found`,
+          });
+        }
+        if (!isInteractiveClient(client)) {
+          throw new HTTPException(400, {
+            message: `Client '${next}' is not an interactive client and cannot be used as the default client`,
           });
         }
       }

--- a/packages/authhero/src/seed.ts
+++ b/packages/authhero/src/seed.ts
@@ -7,6 +7,7 @@ import { createX509Certificate } from "./utils/encryption";
 import { userIdGenerate } from "./utils/user-id";
 import { nanoid } from "nanoid";
 import { hashPassword } from "./helpers/password-policy";
+import { provisionDefaultClients } from "./helpers/provision-tenant-clients";
 import { USERNAME_PASSWORD_PROVIDER } from "./constants";
 
 /**
@@ -889,6 +890,15 @@ export async function seed(
   } else if (debug) {
     console.log("Management API resource server already exists, skipping...");
   }
+
+  // Designate the interactive default client (reuses the "Default Application"
+  // created above) and provision an M2M Management API client. Idempotent, so
+  // re-seeding an existing tenant neither duplicates nor clobbers it (#1007).
+  await provisionDefaultClients(adapters, tenantId, {
+    managementApiIdentifier,
+    managementApiScopes: MANAGEMENT_API_SCOPES,
+    debug,
+  });
 
   // Create organization with tenant_id as the name (for org-scoped token support)
   // The ID is a generated random string like Auth0's org_xxx pattern

--- a/packages/authhero/test/helpers/provision-tenant-clients.spec.ts
+++ b/packages/authhero/test/helpers/provision-tenant-clients.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { getTestServer } from "./test-server";
+import {
+  provisionDefaultClients,
+  isInteractiveClient,
+} from "../../src/helpers/provision-tenant-clients";
+import { MANAGEMENT_API_SCOPES } from "../../src/seed";
+
+const MANAGEMENT_AUDIENCE = "urn:authhero:management";
+
+describe("isInteractiveClient", () => {
+  it("treats clients with no explicit grant_types as interactive", () => {
+    expect(isInteractiveClient({})).toBe(true);
+    expect(isInteractiveClient({ grant_types: [] })).toBe(true);
+  });
+
+  it("treats authorization_code / implicit clients as interactive", () => {
+    expect(isInteractiveClient({ grant_types: ["authorization_code"] })).toBe(
+      true,
+    );
+    expect(isInteractiveClient({ grant_types: ["implicit"] })).toBe(true);
+  });
+
+  it("treats client_credentials-only and non_interactive clients as M2M", () => {
+    expect(isInteractiveClient({ grant_types: ["client_credentials"] })).toBe(
+      false,
+    );
+    expect(
+      isInteractiveClient({
+        app_type: "non_interactive",
+        grant_types: ["authorization_code"],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("provisionDefaultClients", () => {
+  it("points default_client_id at the existing interactive client and provisions an M2M client", async () => {
+    const { env } = await getTestServer();
+
+    const result = await provisionDefaultClients(env.data, "tenantId", {
+      managementApiIdentifier: MANAGEMENT_AUDIENCE,
+      managementApiScopes: MANAGEMENT_API_SCOPES,
+    });
+
+    // Reuses the test server's interactive "clientId" rather than creating one.
+    expect(result.defaultClientId).toBe("clientId");
+    const tenant = await env.data.tenants.get("tenantId");
+    expect(tenant!.default_client_id).toBe("clientId");
+
+    // M2M client + grant were created.
+    expect(result.managementClientId).toBeDefined();
+    const m2m = await env.data.clients.get(
+      "tenantId",
+      result.managementClientId!,
+    );
+    expect(m2m!.app_type).toBe("non_interactive");
+    const { client_grants } = await env.data.clientGrants.list("tenantId", {});
+    const grant = client_grants.find(
+      (g) => g.client_id === result.managementClientId,
+    );
+    expect(grant?.audience).toBe(MANAGEMENT_AUDIENCE);
+  });
+
+  it("is idempotent — re-running does not duplicate clients or clobber the default", async () => {
+    const { env } = await getTestServer();
+
+    const first = await provisionDefaultClients(env.data, "tenantId", {
+      managementApiScopes: MANAGEMENT_API_SCOPES,
+    });
+    const { clients: afterFirst } = await env.data.clients.list("tenantId");
+
+    const second = await provisionDefaultClients(env.data, "tenantId", {
+      managementApiScopes: MANAGEMENT_API_SCOPES,
+    });
+    const { clients: afterSecond } = await env.data.clients.list("tenantId");
+
+    expect(second.defaultClientId).toBe(first.defaultClientId);
+    expect(second.managementClientId).toBe(first.managementClientId);
+    expect(afterSecond.length).toBe(afterFirst.length);
+  });
+
+  it("respects an already-configured, valid default_client_id", async () => {
+    const { env } = await getTestServer();
+    await env.data.clients.create("tenantId", {
+      client_id: "preferred",
+      client_secret: "s",
+      name: "Preferred",
+      grant_types: ["authorization_code"],
+    });
+    await env.data.tenants.update("tenantId", {
+      default_client_id: "preferred",
+    });
+
+    const result = await provisionDefaultClients(env.data, "tenantId", {
+      createManagementClient: false,
+    });
+
+    expect(result.defaultClientId).toBe("preferred");
+  });
+
+  it("creates a Default App when the tenant has no interactive client", async () => {
+    const { env } = await getTestServer();
+    await env.data.tenants.create({
+      id: "freshTenant",
+      friendly_name: "Fresh",
+      audience: "urn:authhero:tenant:freshTenant",
+      sender_email: "noreply@example.com",
+      sender_name: "AuthHero",
+    });
+    // Only an M2M client exists — must NOT be chosen as the default.
+    await env.data.clients.create("freshTenant", {
+      client_id: "onlyM2m",
+      client_secret: "s",
+      name: "Only M2M",
+      app_type: "non_interactive",
+      grant_types: ["client_credentials"],
+    });
+
+    const result = await provisionDefaultClients(env.data, "freshTenant", {
+      createManagementClient: false,
+    });
+
+    expect(result.defaultClientId).not.toBe("onlyM2m");
+    const created = await env.data.clients.get(
+      "freshTenant",
+      result.defaultClientId,
+    );
+    expect(created!.name).toBe("Default App");
+    expect(isInteractiveClient(created!)).toBe(true);
+    const tenant = await env.data.tenants.get("freshTenant");
+    expect(tenant!.default_client_id).toBe(result.defaultClientId);
+  });
+});

--- a/packages/authhero/test/helpers/provision-tenant-clients.spec.ts
+++ b/packages/authhero/test/helpers/provision-tenant-clients.spec.ts
@@ -80,6 +80,32 @@ describe("provisionDefaultClients", () => {
     expect(afterSecond.length).toBe(afterFirst.length);
   });
 
+  it("restores a missing Management API grant for an existing M2M client (partial-failure recovery)", async () => {
+    const { env } = await getTestServer();
+
+    // Simulate a prior run that created the M2M client but failed before its
+    // Management API grant was written.
+    await env.data.clients.create("tenantId", {
+      client_id: "orphanM2m",
+      client_secret: "s",
+      name: "API Explorer Application",
+      app_type: "non_interactive",
+      grant_types: ["client_credentials"],
+    });
+
+    const result = await provisionDefaultClients(env.data, "tenantId", {
+      managementApiIdentifier: MANAGEMENT_AUDIENCE,
+      managementApiScopes: MANAGEMENT_API_SCOPES,
+    });
+
+    // Reuses the orphaned client rather than creating a duplicate...
+    expect(result.managementClientId).toBe("orphanM2m");
+    // ...and restores the missing grant.
+    const { client_grants } = await env.data.clientGrants.list("tenantId", {});
+    const grant = client_grants.find((g) => g.client_id === "orphanM2m");
+    expect(grant?.audience).toBe(MANAGEMENT_AUDIENCE);
+  });
+
   it("respects an already-configured, valid default_client_id", async () => {
     const { env } = await getTestServer();
     await env.data.clients.create("tenantId", {

--- a/packages/authhero/test/routes/management-api/settings.spec.ts
+++ b/packages/authhero/test/routes/management-api/settings.spec.ts
@@ -559,4 +559,80 @@ describe("settings", () => {
       expect(updated.default_audience).toBe("https://orphaned.example.com");
     });
   });
+
+  describe("default_client_id validation", () => {
+    it("rejects a default_client_id that does not reference any client", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      const response = await managementClient.tenants.settings.$patch(
+        {
+          header: { "tenant-id": "tenantId" },
+          json: { default_client_id: "doesNotExist" },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects a default_client_id that references an M2M client", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      await env.data.clients.create("tenantId", {
+        client_id: "m2mClient",
+        client_secret: "s",
+        name: "M2M Client",
+        app_type: "non_interactive",
+        grant_types: ["client_credentials"],
+      });
+
+      const response = await managementClient.tenants.settings.$patch(
+        {
+          header: { "tenant-id": "tenantId" },
+          json: { default_client_id: "m2mClient" },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("accepts a default_client_id that references an interactive client", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      const response = await managementClient.tenants.settings.$patch(
+        {
+          header: { "tenant-id": "tenantId" },
+          json: { default_client_id: "clientId" },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+
+      expect(response.status).toBe(200);
+      const updated = await response.json();
+      expect(updated.default_client_id).toBe("clientId");
+    });
+
+    it("allows clearing default_client_id with an empty string", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      const response = await managementClient.tenants.settings.$patch(
+        {
+          header: { "tenant-id": "tenantId" },
+          json: { default_client_id: "" },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+
+      expect(response.status).toBe(200);
+    });
+  });
 });

--- a/packages/multi-tenancy/src/hooks/provisioning.ts
+++ b/packages/multi-tenancy/src/hooks/provisioning.ts
@@ -3,6 +3,7 @@ import {
   Tenant,
   MANAGEMENT_API_SCOPES,
   MANAGEMENT_API_AUDIENCE,
+  provisionDefaultClients,
 } from "authhero";
 
 /**
@@ -78,6 +79,24 @@ export function createProvisioningHooks(
               initiated_by: ctx.ctx?.var.user?.sub,
             },
             (report) => onProvision(tenant.id, report),
+          );
+        }
+      } else {
+        // 3. Provision a default interactive client (+ M2M Management API
+        // client) so the tenant has a working anchor for tenant-level flows
+        // by construction (#1007). Only for pooled tenants: when database
+        // isolation is on, the tenant's own DB is seeded via `onProvision`
+        // (which runs `seed`, itself calling `provisionDefaultClients`), so
+        // provisioning here would write to the wrong database.
+        try {
+          await provisionDefaultClients(ctx.adapters, tenant.id, {
+            managementApiIdentifier: MANAGEMENT_API_AUDIENCE,
+            managementApiScopes: MANAGEMENT_API_SCOPES,
+          });
+        } catch (error) {
+          console.warn(
+            `Failed to provision default clients for tenant ${tenant.id}:`,
+            error,
           );
         }
       }

--- a/packages/multi-tenancy/src/routes/tenants.ts
+++ b/packages/multi-tenancy/src/routes/tenants.ts
@@ -7,6 +7,7 @@ import {
   CreateTenantParams,
   fetchAll,
   deepMergePatch,
+  isInteractiveClient,
 } from "authhero";
 import {
   MultiTenancyBindings,
@@ -562,6 +563,28 @@ export function createTenantsOpenAPIRouter(
         throw new HTTPException(404, {
           message: "Tenant not found",
         });
+      }
+
+      // The default client anchors interactive tenant-level flows, so it must
+      // reference an existing, interactive client — never an M2M client (#1007).
+      if ("default_client_id" in sanitizedUpdates) {
+        const next = sanitizedUpdates.default_client_id;
+        if (typeof next === "string" && next.length > 0) {
+          const client = await ctx.env.data.clients.get(
+            ctx.var.tenant_id,
+            next,
+          );
+          if (!client) {
+            throw new HTTPException(400, {
+              message: `Client with id '${next}' not found`,
+            });
+          }
+          if (!isInteractiveClient(client)) {
+            throw new HTTPException(400, {
+              message: `Client '${next}' is not an interactive client and cannot be used as the default client`,
+            });
+          }
+        }
       }
 
       // Deep merge with updates to preserve nested object properties


### PR DESCRIPTION
Closes #1007.

New tenants now come with a designated **interactive default client** by construction, so tenant-level flows that need an anchor (e.g. the DCR `/connect/start` consent flow) no longer silently fall back to an arbitrary — possibly M2M — client. Previously `default_client_id` was only ever set by hand via `PATCH /tenants/settings`, so every new tenant started with it unset and `/connect/start` fell back to `clients[0]`, which could be a `client_credentials`-only client with no callbacks (the misleading "Redirect uri not found for this response mode." failure).

## What's in this PR

- **New shared `provisionDefaultClients()` helper** (`packages/authhero/src/helpers/provision-tenant-clients.ts`, exported from `authhero`):
  - Creates an interactive first-party **"Default App"** (`authorization_code` + `refresh_token`) and points `tenant.default_client_id` at it.
  - Provisions an M2M **"API Explorer"** client authorized against the Management API (Auth0 parity), seeding the Management API resource server if missing.
  - Default App is created with **no connections**, so all of the tenant's connections are offered at login and stay current as connections are added.
  - **Idempotent / import-safe**: respects an already-set `default_client_id`, reuses an existing interactive client instead of duplicating, and skips the M2M client when one already exists.
- **Wired into both tenant-creation paths** (single shared code path):
  - the `seed`/bootstrap script (reuses the existing "Default Application" rather than duplicating), and
  - the multi-tenancy `afterCreate` provisioning hook for **pooled** tenants. Isolated (WFP) tenants are seeded via their own database provisioning (`onProvision` → `seed`), which now calls the same helper — so provisioning here would write to the wrong DB and is intentionally skipped.
- **Hardened `/connect/start` fallback**: falls back to the first *interactive* client (new `isInteractiveClient` helper) instead of `clients[0]`, so it never anchors on an M2M client.
- **`PATCH /tenants/settings` validation**: rejects a `default_client_id` that's missing or non-interactive (both the management-api and multi-tenancy handlers), mirroring the existing `default_audience` validation.

## Acceptance criteria (#1007)

- [x] Creating a tenant yields `default_client_id` set to an auto-provisioned interactive client.
- [x] The DCR connect flow works on a freshly created tenant with no manual configuration.
- [x] `PATCH /tenants/settings` rejects a `default_client_id` that doesn't reference an interactive client.
- [x] Re-seeding / importing an existing tenant does not duplicate the default client or clobber an existing `default_client_id`.

## Testing

- New `provision-tenant-clients.spec.ts`: `isInteractiveClient` unit cases, reuse-existing / idempotency / respect-existing-default / create-Default-App-when-only-M2M-exists.
- Extended `settings.spec.ts` with a `default_client_id validation` block (missing → 400, M2M → 400, interactive → 200, clear → 200).
- `authhero` and `@authhero/multi-tenancy` full suites pass (both packages build clean, types + dts). The one failing test, `users.spec.ts › should persist the full profile on create`, **pre-exists on `main`** and is unrelated to this change.

Changeset: `minor` bump for `authhero` and `@authhero/multi-tenancy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New tenants now get a default interactive app automatically, and an API Explorer client may also be provisioned when needed.
  * Tenant setup now consistently uses an interactive client as the login/consent entry point.

* **Bug Fixes**
  * Tenant settings now reject invalid `default_client_id` values, including missing or non-interactive clients.
  * Tenant provisioning is now more reliable and avoids creating duplicate clients on repeated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->