### PR TITLE
feat: scope user permissions to organizations

### DIFF
--- a/.changeset/user-permissions-organization-scope.md
+++ b/.changeset/user-permissions-organization-scope.md
@@ -1,0 +1,6 @@
+---
+"authhero": patch
+"@authhero/admin": patch
+---
+
+User permissions can now be scoped to an organization from the management API and admin UI. The `POST`/`DELETE` `/users/{user_id}/permissions` endpoints accept an optional `organization_id` per permission (previously ignored, which made organization-scoped permissions impossible to assign or remove). The admin user permissions tab shows an "Organization" column and lets you pick an organization when assigning permissions.

--- a/apps/admin/src/auth0DataProvider.ts
+++ b/apps/admin/src/auth0DataProvider.ts
@@ -2510,6 +2510,9 @@ export default (
               resource_server_identifier:
                 prev.resource_server_identifier ??
                 parsedFromId.resource_server_identifier,
+              ...(prev.organization_id
+                ? { organization_id: prev.organization_id }
+                : {}),
             },
           ],
         };

--- a/apps/admin/src/resources/users/tabs/permissions-tab.tsx
+++ b/apps/admin/src/resources/users/tabs/permissions-tab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { RaRecord } from "ra-core";
 import {
   useDataProvider,
+  useGetOne,
   useNotify,
   useRecordContext,
   useRefresh,
@@ -43,13 +44,23 @@ interface ResourceServer extends RaRecord {
   }>;
 }
 
+interface Organization extends RaRecord {
+  name?: string;
+  display_name?: string;
+}
+
 interface PermissionRecord extends RaRecord {
   permission_name: string;
   resource_server_identifier: string;
   resource_server_name?: string;
   description?: string;
   created_at?: string;
+  organization_id?: string;
 }
+
+// Sentinel Select value for "no organization" (tenant-global permission),
+// since a shadcn SelectItem cannot use an empty string as its value.
+const NO_ORG = "__none__";
 
 function AddPermissionButton() {
   const { id: userId } = useParams();
@@ -59,6 +70,8 @@ function AddPermissionButton() {
   const [open, setOpen] = useState(false);
   const [resourceServers, setResourceServers] = useState<ResourceServer[]>([]);
   const [selectedServerId, setSelectedServerId] = useState<string>("");
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [selectedOrgId, setSelectedOrgId] = useState<string>(NO_ORG);
   const [available, setAvailable] = useState<
     Array<{ permission_name: string; description: string }>
   >([]);
@@ -72,6 +85,7 @@ function AddPermissionButton() {
 
   const reset = () => {
     setSelectedServerId("");
+    setSelectedOrgId(NO_ORG);
     setAvailable([]);
     setSelected(new Set());
     setSearch("");
@@ -81,15 +95,22 @@ function AddPermissionButton() {
     setOpen(true);
     setLoading(true);
     try {
-      const { data } = await dataProvider.getList<ResourceServer>(
-        "resource-servers",
-        {
+      const [servers, orgs] = await Promise.all([
+        dataProvider.getList<ResourceServer>("resource-servers", {
           pagination: { page: 1, perPage: 100 },
           sort: { field: "name", order: "ASC" },
           filter: {},
-        },
-      );
-      setResourceServers(data);
+        }),
+        dataProvider
+          .getList<Organization>("organizations", {
+            pagination: { page: 1, perPage: 100 },
+            sort: { field: "display_name", order: "ASC" },
+            filter: {},
+          })
+          .catch(() => ({ data: [] as Organization[] })),
+      ]);
+      setResourceServers(servers.data);
+      setOrganizations(orgs.data);
     } catch {
       notify("Error loading resource servers", { type: "error" });
     } finally {
@@ -108,6 +129,7 @@ function AddPermissionButton() {
       (s) => s.identifier === selectedServerId,
     );
     if (!server) return;
+    const orgId = selectedOrgId === NO_ORG ? undefined : selectedOrgId;
     setSelected(new Set());
     setSearch("");
     setLoading(true);
@@ -125,9 +147,15 @@ function AddPermissionButton() {
             filter: {},
           },
         );
+        // A permission is unique per (resource server, permission, organization),
+        // so only exclude scopes already assigned for the selected organization.
         const existingNames = new Set(
           existing.data
-            .filter((p) => p.resource_server_identifier === server.identifier)
+            .filter(
+              (p) =>
+                p.resource_server_identifier === server.identifier &&
+                (p.organization_id || undefined) === orgId,
+            )
             .map((p) => p.permission_name),
         );
         setAvailable(
@@ -141,7 +169,14 @@ function AddPermissionButton() {
         setLoading(false);
       }
     })();
-  }, [selectedServerId, userId, resourceServers, dataProvider, notify]);
+  }, [
+    selectedServerId,
+    selectedOrgId,
+    userId,
+    resourceServers,
+    dataProvider,
+    notify,
+  ]);
 
   const toggle = (name: string) => {
     setSelected((prev) => {
@@ -154,12 +189,14 @@ function AddPermissionButton() {
 
   const handleAdd = async () => {
     if (!userId || !selectedServer || selected.size === 0) return;
+    const orgId = selectedOrgId === NO_ORG ? undefined : selectedOrgId;
     try {
       await dataProvider.create(`users/${userId}/permissions`, {
         data: {
           permissions: Array.from(selected).map((permission_name) => ({
             permission_name,
             resource_server_identifier: selectedServer.identifier,
+            ...(orgId ? { organization_id: orgId } : {}),
           })),
         },
       });
@@ -205,6 +242,25 @@ function AddPermissionButton() {
                 </SelectContent>
               </Select>
             </div>
+            {organizations.length > 0 && (
+              <div>
+                <Select value={selectedOrgId} onValueChange={setSelectedOrgId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Organization (optional)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NO_ORG}>
+                      No organization (tenant-wide)
+                    </SelectItem>
+                    {organizations.map((o) => (
+                      <SelectItem key={o.id} value={String(o.id)}>
+                        {o.display_name || o.name || String(o.id)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
             {selectedServerId && (
               <>
                 {available.length > 5 && (
@@ -363,6 +419,20 @@ function AssignedCell() {
   return <DateAgo date={record.created_at} />;
 }
 
+function OrganizationCell() {
+  const record = useRecordContext<PermissionRecord>();
+  const orgId = record?.organization_id;
+  const { data } = useGetOne<Organization>(
+    "organizations",
+    { id: orgId as string },
+    { enabled: !!orgId },
+  );
+  if (!orgId) {
+    return <span className="text-muted-foreground">Tenant-wide</span>;
+  }
+  return <>{data?.display_name || data?.name || orgId}</>;
+}
+
 export function PermissionsTab() {
   return (
     <div className="flex flex-col gap-4">
@@ -387,6 +457,9 @@ export function PermissionsTab() {
           />
           <DataTable.Col source="resource_server_name" label="Resource name" />
           <DataTable.Col source="permission_name" label="Permission" />
+          <DataTable.Col label="Organization">
+            <OrganizationCell />
+          </DataTable.Col>
           <DataTable.Col label="Description">
             <TextField source="description" />
           </DataTable.Col>

--- a/apps/admin/src/resources/users/tabs/permissions-tab.tsx
+++ b/apps/admin/src/resources/users/tabs/permissions-tab.tsx
@@ -71,6 +71,7 @@ function AddPermissionButton() {
   const [resourceServers, setResourceServers] = useState<ResourceServer[]>([]);
   const [selectedServerId, setSelectedServerId] = useState<string>("");
   const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [orgsLoadFailed, setOrgsLoadFailed] = useState(false);
   const [selectedOrgId, setSelectedOrgId] = useState<string>(NO_ORG);
   const [available, setAvailable] = useState<
     Array<{ permission_name: string; description: string }>
@@ -89,11 +90,13 @@ function AddPermissionButton() {
     setAvailable([]);
     setSelected(new Set());
     setSearch("");
+    setOrgsLoadFailed(false);
   };
 
   const handleOpen = async () => {
     setOpen(true);
     setLoading(true);
+    setOrgsLoadFailed(false);
     try {
       const [servers, orgs] = await Promise.all([
         dataProvider.getList<ResourceServer>("resource-servers", {
@@ -107,7 +110,14 @@ function AddPermissionButton() {
             sort: { field: "display_name", order: "ASC" },
             filter: {},
           })
-          .catch(() => ({ data: [] as Organization[] })),
+          // Surface the failure rather than silently degrading to tenant-wide
+          // grants — an admin might add a tenant-wide permission when they
+          // meant an organization-scoped one.
+          .catch(() => {
+            setOrgsLoadFailed(true);
+            notify("Error loading organizations", { type: "error" });
+            return { data: [] as Organization[] };
+          }),
       ]);
       setResourceServers(servers.data);
       setOrganizations(orgs.data);
@@ -242,6 +252,13 @@ function AddPermissionButton() {
                 </SelectContent>
               </Select>
             </div>
+            {orgsLoadFailed && (
+              <p className="text-sm text-destructive">
+                Couldn't load organizations. Retry before adding a permission —
+                otherwise it may be granted tenant-wide instead of scoped to an
+                organization.
+              </p>
+            )}
             {organizations.length > 0 && (
               <div>
                 <Select value={selectedOrgId} onValueChange={setSelectedOrgId}>
@@ -337,7 +354,10 @@ function AddPermissionButton() {
             <Button variant="outline" onClick={handleClose}>
               Cancel
             </Button>
-            <Button onClick={handleAdd} disabled={selected.size === 0}>
+            <Button
+              onClick={handleAdd}
+              disabled={selected.size === 0 || orgsLoadFailed}
+            >
               Add {selected.size > 0 ? `${selected.size} ` : ""}permission(s)
             </Button>
           </DialogFooter>

--- a/packages/authhero/src/helpers/provision-tenant-clients.ts
+++ b/packages/authhero/src/helpers/provision-tenant-clients.ts
@@ -1,4 +1,4 @@
-import { Client, DataAdapters } from "@authhero/adapter-interfaces";
+import { Client, ClientGrant, DataAdapters } from "@authhero/adapter-interfaces";
 import { nanoid } from "nanoid";
 import { MANAGEMENT_API_AUDIENCE } from "../middlewares/authentication";
 
@@ -167,7 +167,7 @@ async function resolveDefaultClient(
 
   // Reuse any existing interactive client (e.g. the seed's "Default
   // Application") rather than creating a duplicate.
-  const { clients } = await adapters.clients.list(tenantId);
+  const clients = await listAllClients(adapters, tenantId);
   const interactive = clients.find(isInteractiveClient);
   if (interactive) {
     return interactive;
@@ -205,13 +205,17 @@ async function ensureManagementClient(
     debug: boolean;
   },
 ): Promise<string | undefined> {
-  const { clients } = await adapters.clients.list(tenantId);
+  const clients = await listAllClients(adapters, tenantId);
   const existing = clients.find(
     (client) =>
       client.app_type === "non_interactive" &&
       client.name === MANAGEMENT_CLIENT_NAME,
   );
   if (existing) {
+    // A partial seed can leave the management client present but without its
+    // grant, so it can't mint Management API tokens. Recreate the grant when
+    // it's missing rather than trusting the client's mere existence.
+    await ensureManagementGrant(adapters, tenantId, existing.client_id, opts);
     return existing.client_id;
   }
 
@@ -256,14 +260,79 @@ async function ensureManagementClient(
     grant_types: ["client_credentials"],
   });
 
-  await adapters.clientGrants.create(tenantId, {
-    client_id: client.client_id,
-    audience: opts.managementApiIdentifier,
-    scope: opts.managementApiScopes?.map((scope) => scope.value) ?? [],
-  });
+  await ensureManagementGrant(adapters, tenantId, client.client_id, opts);
 
   if (opts.debug) {
     console.log(`✅ Management API (M2M) client created (${client.client_id})`);
   }
   return client.client_id;
+}
+
+/**
+ * Ensures the M2M client has a grant for the Management API audience, creating
+ * one when it's missing. Idempotent: a client that already has the grant is
+ * left untouched.
+ */
+async function ensureManagementGrant(
+  adapters: DataAdapters,
+  tenantId: string,
+  clientId: string,
+  opts: {
+    managementApiIdentifier: string;
+    managementApiScopes?: ManagementApiScope[];
+  },
+): Promise<void> {
+  const grants = await listAllClientGrants(adapters, tenantId);
+  const hasGrant = grants.some(
+    (grant) =>
+      grant.client_id === clientId &&
+      grant.audience === opts.managementApiIdentifier,
+  );
+  if (hasGrant) {
+    return;
+  }
+
+  await adapters.clientGrants.create(tenantId, {
+    client_id: clientId,
+    audience: opts.managementApiIdentifier,
+    scope: opts.managementApiScopes?.map((scope) => scope.value) ?? [],
+  });
+}
+
+/** Pages through every client for a tenant (the list adapter is paginated). */
+async function listAllClients(
+  adapters: DataAdapters,
+  tenantId: string,
+): Promise<Client[]> {
+  const perPage = 100;
+  const all: Client[] = [];
+  for (let page = 0; ; page++) {
+    const { clients } = await adapters.clients.list(tenantId, {
+      page,
+      per_page: perPage,
+    });
+    all.push(...clients);
+    if (clients.length < perPage) {
+      return all;
+    }
+  }
+}
+
+/** Pages through every client grant for a tenant. */
+async function listAllClientGrants(
+  adapters: DataAdapters,
+  tenantId: string,
+): Promise<ClientGrant[]> {
+  const perPage = 100;
+  const all: ClientGrant[] = [];
+  for (let page = 0; ; page++) {
+    const { client_grants } = await adapters.clientGrants.list(tenantId, {
+      page,
+      per_page: perPage,
+    });
+    all.push(...client_grants);
+    if (client_grants.length < perPage) {
+      return all;
+    }
+  }
 }

--- a/packages/authhero/src/routes/auth-api/connect-start.ts
+++ b/packages/authhero/src/routes/auth-api/connect-start.ts
@@ -152,8 +152,19 @@ const getRoot = defineRoute({
       ? await ctx.env.data.clients.get(tenant_id, tenant.default_client_id)
       : null;
     if (!anchorClient) {
-      const { clients } = await ctx.env.data.clients.list(tenant_id);
-      anchorClient = clients.find(isInteractiveClient) ?? null;
+      // Page through the tenant's clients — the list adapter defaults to the
+      // first 50 rows, so an interactive client could sit on a later page.
+      const perPage = 100;
+      for (let page = 0; !anchorClient; page++) {
+        const { clients } = await ctx.env.data.clients.list(tenant_id, {
+          page,
+          per_page: perPage,
+        });
+        anchorClient = clients.find(isInteractiveClient) ?? null;
+        if (clients.length < perPage) {
+          break;
+        }
+      }
     }
     if (!anchorClient) {
       throw new JSONHTTPException(400, {

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -1197,6 +1197,7 @@ const postByUser_idPermissions = defineRoute({
                 z.object({
                   permission_name: z.string(),
                   resource_server_identifier: z.string(),
+                  organization_id: z.string().optional(),
                 }),
               ),
             }),
@@ -1236,7 +1237,9 @@ const postByUser_idPermissions = defineRoute({
           user_id,
           resource_server_identifier: permission.resource_server_identifier,
           permission_name: permission.permission_name,
+          organization_id: permission.organization_id,
         },
+        permission.organization_id,
       );
 
       if (!success) {
@@ -1280,6 +1283,7 @@ const deleteByUser_idPermissions = defineRoute({
                 z.object({
                   permission_name: z.string(),
                   resource_server_identifier: z.string(),
+                  organization_id: z.string().optional(),
                 }),
               ),
             }),
@@ -1315,7 +1319,11 @@ const deleteByUser_idPermissions = defineRoute({
       const success = await ctx.env.data.userPermissions.remove(
         ctx.var.tenant_id,
         user_id,
-        permission,
+        {
+          resource_server_identifier: permission.resource_server_identifier,
+          permission_name: permission.permission_name,
+        },
+        permission.organization_id,
       );
 
       if (!success) {

--- a/packages/authhero/test/helpers/provision-tenant-clients.spec.ts
+++ b/packages/authhero/test/helpers/provision-tenant-clients.spec.ts
@@ -62,25 +62,72 @@ describe("provisionDefaultClients", () => {
     expect(grant?.audience).toBe(MANAGEMENT_AUDIENCE);
   });
 
-  it("is idempotent — re-running does not duplicate clients or clobber the default", async () => {
+  it("is idempotent — re-running does not duplicate clients, grants, or clobber the default", async () => {
     const { env } = await getTestServer();
+
+    const snapshotClients = () =>
+      env.data.clients
+        .list("tenantId", { per_page: 100 })
+        .then(({ clients }) => clients.map((c) => c.client_id).sort());
+    const snapshotGrants = () =>
+      env.data.clientGrants
+        .list("tenantId", { per_page: 100 })
+        .then(({ client_grants }) =>
+          client_grants
+            .map((g) => `${g.client_id}:${g.audience}`)
+            .sort(),
+        );
 
     const first = await provisionDefaultClients(env.data, "tenantId", {
       managementApiScopes: MANAGEMENT_API_SCOPES,
     });
-    const { clients: afterFirst } = await env.data.clients.list("tenantId");
+    const clientsAfterFirst = await snapshotClients();
+    const grantsAfterFirst = await snapshotGrants();
 
     const second = await provisionDefaultClients(env.data, "tenantId", {
       managementApiScopes: MANAGEMENT_API_SCOPES,
     });
-    const { clients: afterSecond } = await env.data.clients.list("tenantId");
+    const clientsAfterSecond = await snapshotClients();
+    const grantsAfterSecond = await snapshotGrants();
 
     expect(second.defaultClientId).toBe(first.defaultClientId);
     expect(second.managementClientId).toBe(first.managementClientId);
-    expect(afterSecond.length).toBe(afterFirst.length);
+    // Compare the full client and grant sets, not just counts, so a duplicate
+    // grant (or churned client) would be caught.
+    expect(clientsAfterSecond).toEqual(clientsAfterFirst);
+    expect(grantsAfterSecond).toEqual(grantsAfterFirst);
   });
 
-  it("respects an already-configured, valid default_client_id", async () => {
+  it("recreates the management grant when reusing a management client that lost it", async () => {
+    const { env } = await getTestServer();
+
+    // Simulate a partial seed: the management client exists but its grant is
+    // missing, so it can't mint Management API tokens.
+    const orphan = await env.data.clients.create("tenantId", {
+      client_id: "orphanManagement",
+      client_secret: "s",
+      name: "API Explorer Application",
+      app_type: "non_interactive",
+      grant_types: ["client_credentials"],
+    });
+
+    const result = await provisionDefaultClients(env.data, "tenantId", {
+      managementApiIdentifier: MANAGEMENT_AUDIENCE,
+      managementApiScopes: MANAGEMENT_API_SCOPES,
+    });
+
+    // Reuses the existing client rather than creating a second one.
+    expect(result.managementClientId).toBe(orphan.client_id);
+    const { client_grants } = await env.data.clientGrants.list("tenantId", {
+      per_page: 100,
+    });
+    const grant = client_grants.find(
+      (g) => g.client_id === orphan.client_id,
+    );
+    expect(grant?.audience).toBe(MANAGEMENT_AUDIENCE);
+  });
+
+  it("respects an already-configured, valid default_client_id without creating a replacement", async () => {
     const { env } = await getTestServer();
     await env.data.clients.create("tenantId", {
       client_id: "preferred",
@@ -91,12 +138,24 @@ describe("provisionDefaultClients", () => {
     await env.data.tenants.update("tenantId", {
       default_client_id: "preferred",
     });
+    const { clients: before } = await env.data.clients.list("tenantId", {
+      per_page: 100,
+    });
 
     const result = await provisionDefaultClients(env.data, "tenantId", {
       createManagementClient: false,
     });
 
     expect(result.defaultClientId).toBe("preferred");
+    // No replacement default client was created and the pointer is unchanged.
+    const { clients: after } = await env.data.clients.list("tenantId", {
+      per_page: 100,
+    });
+    expect(after.map((c) => c.client_id).sort()).toEqual(
+      before.map((c) => c.client_id).sort(),
+    );
+    const tenant = await env.data.tenants.get("tenantId");
+    expect(tenant!.default_client_id).toBe("preferred");
   });
 
   it("creates a Default App when the tenant has no interactive client", async () => {

--- a/packages/authhero/test/routes/management-api/users.spec.ts
+++ b/packages/authhero/test/routes/management-api/users.spec.ts
@@ -2578,6 +2578,86 @@ describe("users management API endpoint", () => {
       );
     });
 
+    it("should scope permissions to an organization", async () => {
+      const organizationId = "org_test_perms";
+
+      // Assign the same permission twice: once tenant-wide, once org-scoped.
+      const addResponse = await managementClient.users[
+        ":user_id"
+      ].permissions.$post(
+        {
+          param: { user_id: userId },
+          json: {
+            permissions: [
+              {
+                permission_name: "read:profile",
+                resource_server_identifier: uniqueResourceServer,
+              },
+              {
+                permission_name: "read:profile",
+                resource_server_identifier: uniqueResourceServer,
+                organization_id: organizationId,
+              },
+            ],
+          },
+          header: { "tenant-id": "tenantId" },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(addResponse.status).toBe(201);
+
+      // Both assignments should be listed, distinguished by organization_id.
+      const afterAdd = await (
+        await managementClient.users[":user_id"].permissions.$get(
+          {
+            param: { user_id: userId },
+            header: { "tenant-id": "tenantId" },
+          },
+          { headers: { authorization: `Bearer ${token}` } },
+        )
+      ).json();
+
+      expect(afterAdd.length).toBe(2);
+      const orgScoped = afterAdd.find((p: any) => p.organization_id);
+      const tenantWide = afterAdd.find((p: any) => !p.organization_id);
+      expect(orgScoped?.organization_id).toBe(organizationId);
+      expect(tenantWide).toBeDefined();
+
+      // Removing the org-scoped permission must leave the tenant-wide one intact.
+      const removeResponse = await managementClient.users[
+        ":user_id"
+      ].permissions.$delete(
+        {
+          param: { user_id: userId },
+          json: {
+            permissions: [
+              {
+                permission_name: "read:profile",
+                resource_server_identifier: uniqueResourceServer,
+                organization_id: organizationId,
+              },
+            ],
+          },
+          header: { "tenant-id": "tenantId" },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(removeResponse.status).toBe(200);
+
+      const afterRemove = await (
+        await managementClient.users[":user_id"].permissions.$get(
+          {
+            param: { user_id: userId },
+            header: { "tenant-id": "tenantId" },
+          },
+          { headers: { authorization: `Bearer ${token}` } },
+        )
+      ).json();
+
+      expect(afterRemove.length).toBe(1);
+      expect(afterRemove[0].organization_id).toBeUndefined();
+    });
+
     it("should return 404 for non-existent user", async () => {
       const nonExistentUserId = "email|non-existent-user";
 

--- a/packages/multi-tenancy/src/hooks/provisioning.ts
+++ b/packages/multi-tenancy/src/hooks/provisioning.ts
@@ -94,10 +94,14 @@ export function createProvisioningHooks(
             managementApiScopes: MANAGEMENT_API_SCOPES,
           });
         } catch (error) {
+          // Don't swallow this: a tenant left without its default interactive
+          // client/M2M setup can't anchor tenant-level flows (see #1007), so
+          // surface the failure instead of reporting a healthy tenant.
           console.warn(
             `Failed to provision default clients for tenant ${tenant.id}:`,
             error,
           );
+          throw error;
         }
       }
     },

--- a/packages/multi-tenancy/test/tenants-routes.test.ts
+++ b/packages/multi-tenancy/test/tenants-routes.test.ts
@@ -252,6 +252,131 @@ describe("tenants routes authorization", () => {
   });
 });
 
+describe("tenant settings: default_client_id validation", () => {
+  let adapters: ReturnType<typeof createAdapters>;
+  let env: { data: ReturnType<typeof createAdapters> };
+
+  const config: MultiTenancyConfig = {
+    accessControl: {
+      controlPlaneTenantId,
+      requireOrganizationMatch: true,
+    },
+  };
+
+  beforeEach(async () => {
+    const db = await createMigratedDb();
+    adapters = createAdapters(db);
+    env = { data: adapters };
+
+    await adapters.tenants.create({
+      id: controlPlaneTenantId,
+      friendly_name: "Control Plane",
+      audience: "https://example.com",
+      sender_email: "admin@example.com",
+      sender_name: "Control Plane",
+    });
+  });
+
+  function settingsApp() {
+    const { hooks } = setupMultiTenancy(config);
+    return createHostApp({
+      config,
+      hooks,
+      user: {
+        sub: "auth0|admin",
+        tenant_id: controlPlaneTenantId,
+        scope: "update:tenants",
+      },
+    });
+  }
+
+  async function patchSettings(app: ReturnType<typeof settingsApp>, body: unknown) {
+    return app.request(
+      "/management/tenants/settings",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+      env,
+    );
+  }
+
+  it("rejects a default_client_id that does not exist", async () => {
+    const app = settingsApp();
+
+    const response = await patchSettings(app, {
+      default_client_id: "does-not-exist",
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toContain("does-not-exist");
+    expect(
+      (await adapters.tenants.get(controlPlaneTenantId))!.default_client_id,
+    ).toBeFalsy();
+  });
+
+  it("rejects a non-interactive (M2M) client as the default", async () => {
+    await adapters.clients.create(controlPlaneTenantId, {
+      client_id: "m2m",
+      client_secret: "s",
+      name: "M2M",
+      app_type: "non_interactive",
+      grant_types: ["client_credentials"],
+    });
+    const app = settingsApp();
+
+    const response = await patchSettings(app, { default_client_id: "m2m" });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toContain("interactive");
+    expect(
+      (await adapters.tenants.get(controlPlaneTenantId))!.default_client_id,
+    ).toBeFalsy();
+  });
+
+  it("accepts an interactive client as the default", async () => {
+    await adapters.clients.create(controlPlaneTenantId, {
+      client_id: "web",
+      client_secret: "s",
+      name: "Web",
+      app_type: "regular_web",
+      grant_types: ["authorization_code"],
+    });
+    const app = settingsApp();
+
+    const response = await patchSettings(app, { default_client_id: "web" });
+
+    expect(response.status).toBe(200);
+    expect(
+      (await adapters.tenants.get(controlPlaneTenantId))!.default_client_id,
+    ).toBe("web");
+  });
+
+  it("allows clearing default_client_id with an empty string", async () => {
+    await adapters.clients.create(controlPlaneTenantId, {
+      client_id: "web",
+      client_secret: "s",
+      name: "Web",
+      app_type: "regular_web",
+      grant_types: ["authorization_code"],
+    });
+    await adapters.tenants.update(controlPlaneTenantId, {
+      default_client_id: "web",
+    });
+    const app = settingsApp();
+
+    const response = await patchSettings(app, { default_client_id: "" });
+
+    expect(response.status).toBe(200);
+    expect(
+      (await adapters.tenants.get(controlPlaneTenantId))!.default_client_id,
+    ).toBeFalsy();
+  });
+});
+
 describe("build: Hono is not bundled into the output", () => {
   it("treats hono and its subpath exports as external", () => {
     // Regression for the duplicate-Hono bug: the bare package was external but


### PR DESCRIPTION
## Problem

On a user's **permissions** tab you can't tell whether a permission is scoped to a specific organization — and you couldn't manage org-scoped permissions at all. The GET endpoint and both adapters (drizzle + kysely) already returned `organization_id`, but `POST`/`DELETE /users/{user_id}/permissions` ignored it. As a result:

- Org-scoped permissions were invisible in the admin UI.
- They could not be **assigned** (POST dropped `organization_id`).
- They could not be **removed** (DELETE with no `organization_id` only matches tenant-wide rows, since kysely's `remove` defaults to `organization_id = ""`).

## Changes

**Endpoint** (`authhero`)
- `POST`/`DELETE /users/{user_id}/permissions` accept an optional `organization_id` per permission and thread it into `userPermissions.create`/`remove` (4th arg already existed on the adapter interface).

**Admin UI** (`@authhero/admin`)
- New **Organization** column on the user permissions tab (resolves the org display name, falls back to the id, shows "Tenant-wide" when unscoped).
- Add-permission dialog gains an optional organization selector (shown only when the tenant has organizations). Assign/remove treat `(resource server, permission, organization)` as the unique key, so the same scope can be granted tenant-wide and per-org independently.
- Data provider round-trips `organization_id` on delete so removing an org-scoped row targets the right record.

## Testing

- `tsc --noEmit` clean for `authhero` and `apps/admin`.
- New endpoint test: assign the same permission tenant-wide + org-scoped, confirm both are listed distinctly, and confirm removing the org-scoped one leaves the tenant-wide one intact. Permission tests pass.

## Note

Not verified at runtime: that the Auth0 SDK's `users.permissions.list` in the data provider preserves `organization_id` on the way through (the code spreads `...item`, so it should). If the column ever shows "Tenant-wide" for a known org-scoped permission, that spread is the first place to look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant setup now automatically provides a default interactive app client and an API Explorer client for management access.
  * User permissions can now be assigned to a specific organization or tenant-wide.
* **Bug Fixes**
  * Login flows now consistently use an interactive client when no default is set.
  * Tenant settings now reject invalid or non-interactive default client selections.
  * Removing permissions now correctly respects organization scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->