### PR TITLE
feat(authhero): deliver post-registration/deletion code hooks via the outbox (#950)

### DIFF
--- a/.changeset/code-hook-destination.md
+++ b/.changeset/code-hook-destination.md
@@ -1,0 +1,11 @@
+---
+"authhero": minor
+---
+
+Deliver `post-user-registration` and `post-user-deletion` **code hooks** through the outbox instead of inline (issue #950).
+
+A new `CodeHookDestination` runs tenant-authored code hooks for these triggers from the `hook.*` outbox event, alongside `WebhookDestination`. Code hooks now share the outbox's retry + dead-letter machinery instead of being best-effort inline — a failure is retried with backoff and surfaced via the failed-events endpoints rather than logged and dropped. `post-user-deletion` code hooks now run (they previously did not).
+
+**Behavior change:** code-hook delivery for these triggers is now **at-least-once** rather than at-most-once. A retried event re-runs every code hook for the trigger, so the outbox event id is exposed to user code as `event.idempotency_key` for dedupe. The token-mutating triggers (`post-user-login`, `credentials-exchange`) still run inline and are unaffected.
+
+The code executor was decoupled from the request context: a new `executeCodeHook(...)` core runs a code hook from explicit dependencies, and `handleCodeHook(ctx, …)` is now a thin wrapper over it. `createDefaultDestinations` / `runOutboxRelay` accept an optional `codeExecutor` so the cron-drain safety net also runs code hooks. `CodeHookDestination` is exported from the package root.

--- a/apps/docs/architecture/hooks-pipeline.md
+++ b/apps/docs/architecture/hooks-pipeline.md
@@ -191,7 +191,7 @@ packages/authhero/src/helpers/outbox-destinations/
 
 ## Code hooks: from inline to outbox-backed
 
-Post-user-registration **code hooks** (tenant-authored actions bound by `code_id`) used to run inline inside `createUserHooks` — best-effort and at-most-once, so a throw was logged and dropped. Post-user-deletion code hooks are new here and have no inline predecessor; they were only ever delivered through the outbox. Both now run through `CodeHookDestination` from the `hook.*` event, sharing the relay's retry + dead-letter machinery ([#950](https://github.com/markusahlstrand/authhero/issues/950)).
+Post-user-registration **code hooks** (tenant-authored actions bound by `code_id`) had an inline predecessor: they used to run inside `createUserHooks` — best-effort and at-most-once, so a throw was logged and dropped. Post-user-deletion code hooks are newly introduced here and have no inline predecessor — this is the first time they execute at all, and they run only through the relay. Both now run through `CodeHookDestination` from the `hook.*` event, sharing the relay's retry + dead-letter machinery ([#950](https://github.com/markusahlstrand/authhero/issues/950)).
 
 The core executor was decoupled from the request `ctx`: `codehooks.ts::executeCodeHook({ codeExecutor, data, tenantId, hook, event, triggerId, api })` runs the code given explicit dependencies, and the inline `handleCodeHook(ctx, …)` is now a thin wrapper that resolves them from `ctx`. This works because the serialized event never carries `ctx` (it is stripped before reaching user code) and post-registration/deletion expose an empty `api` (there is no token to mutate), so no synthetic request needs to be reconstructed.
 

--- a/apps/docs/architecture/hooks-pipeline.md
+++ b/apps/docs/architecture/hooks-pipeline.md
@@ -100,7 +100,7 @@ Four destinations ship today:
 | `CodeHookDestination` | `event.event_type.startsWith("hook.")` | runs each enabled **code hook** whose `trigger_id` matches through the `codeExecutor`, persists an `action_executions` record, and throws if any hook failed so the event is retried. No-op when no executor is configured. Listed **after** `WebhookDestination` |
 | `RegistrationFinalizerDestination` | `event.event_type === "hook.post-user-registration"` | sets `user.registration_completed_at` (listed **after** the delivery destinations so the flag only flips when webhook **and** code-hook delivery succeeded) |
 
-`WebhookDestination` and `CodeHookDestination` both accept `hook.*` events, so a single `hook.post-user-registration` / `hook.post-user-deletion` event fans out to webhooks **and** code hooks, each retried independently by the relay.
+`WebhookDestination` and `CodeHookDestination` both accept `hook.*` events, so a single `hook.post-user-registration` / `hook.post-user-deletion` event fans out to webhooks **and** code hooks. The fan-out is not independent per destination: the relay runs an event's destinations in order and stops the loop at the first failure (step 2 above), so a webhook failure short-circuits the code-hook destination on that pass. The whole event is retried later, re-running every destination — which is why each destination must be idempotent.
 
 Destinations are constructed per request in `getDestinations(ctx)` so they can close over ctx-scoped dependencies — notably the service-token minter used for webhook `Authorization` headers.
 
@@ -191,7 +191,7 @@ packages/authhero/src/helpers/outbox-destinations/
 
 ## Code hooks: from inline to outbox-backed
 
-Post-user-registration and post-user-deletion **code hooks** (tenant-authored actions bound by `code_id`) used to run inline inside `createUserHooks` — best-effort and at-most-once, so a throw was logged and dropped. They now run through `CodeHookDestination` from the `hook.*` event, sharing the relay's retry + dead-letter machinery ([#950](https://github.com/markusahlstrand/authhero/issues/950)).
+Post-user-registration **code hooks** (tenant-authored actions bound by `code_id`) used to run inline inside `createUserHooks` — best-effort and at-most-once, so a throw was logged and dropped. Post-user-deletion code hooks are new here and have no inline predecessor; they were only ever delivered through the outbox. Both now run through `CodeHookDestination` from the `hook.*` event, sharing the relay's retry + dead-letter machinery ([#950](https://github.com/markusahlstrand/authhero/issues/950)).
 
 The core executor was decoupled from the request `ctx`: `codehooks.ts::executeCodeHook({ codeExecutor, data, tenantId, hook, event, triggerId, api })` runs the code given explicit dependencies, and the inline `handleCodeHook(ctx, …)` is now a thin wrapper that resolves them from `ctx`. This works because the serialized event never carries `ctx` (it is stripped before reaching user code) and post-registration/deletion expose an empty `api` (there is no token to mutate), so no synthetic request needs to be reconstructed.
 

--- a/apps/docs/architecture/hooks-pipeline.md
+++ b/apps/docs/architecture/hooks-pipeline.md
@@ -91,13 +91,16 @@ After the request handler returns, the `outboxMiddleware` flushes the synchronou
 
 ### Destination registry
 
-Three destinations ship today:
+Four destinations ship today:
 
 | Destination | `accepts()` | `deliver()` |
 |---|---|---|
 | `LogsDestination` | `!event.event_type.startsWith("hook.")` | writes an `AuditEvent` to the `logs` table |
 | `WebhookDestination` | `event.event_type.startsWith("hook.")` | POSTs to each enabled webhook whose `trigger_id` matches, with `Idempotency-Key: {event.id}` and a 10s `AbortController` timeout |
-| `RegistrationFinalizerDestination` | `event.event_type === "hook.post-user-registration"` | sets `user.registration_completed_at` (listed **after** `WebhookDestination` so the flag only flips when delivery succeeded) |
+| `CodeHookDestination` | `event.event_type.startsWith("hook.")` | runs each enabled **code hook** whose `trigger_id` matches through the `codeExecutor`, persists an `action_executions` record, and throws if any hook failed so the event is retried. No-op when no executor is configured. Listed **after** `WebhookDestination` |
+| `RegistrationFinalizerDestination` | `event.event_type === "hook.post-user-registration"` | sets `user.registration_completed_at` (listed **after** the delivery destinations so the flag only flips when webhook **and** code-hook delivery succeeded) |
+
+`WebhookDestination` and `CodeHookDestination` both accept `hook.*` events, so a single `hook.post-user-registration` / `hook.post-user-deletion` event fans out to webhooks **and** code hooks, each retried independently by the relay.
 
 Destinations are constructed per request in `getDestinations(ctx)` so they can close over ctx-scoped dependencies — notably the service-token minter used for webhook `Authorization` headers.
 
@@ -107,7 +110,7 @@ Destinations are constructed per request in `getDestinations(ctx)` so they can c
 2. Return `true` from `accepts` only for the `event_type` values you handle — destinations must not cross-write.
 3. Make `deliver` idempotent. The relay can retry after a partial success if the worker dies between `deliver` and `markProcessed`. Webhooks rely on `Idempotency-Key`; in-DB destinations should dedupe on a unique constraint (see `LogsDestination.deliver` which swallows `UNIQUE constraint failed` on the `logs.log_id` column).
 4. Throw on failure — the relay will `markRetry` with exponential backoff automatically.
-5. Register it in both `management-api/index.ts` and `auth-api/index.ts` `outboxMiddleware` calls.
+5. Register it in every `outboxMiddleware` call — `auth-api/index.ts`, `management-api/index.ts`, and both universal-login apps (`universal-login/index.ts`, `universal-login/u2-index.ts`) — and in `createDefaultDestinations` (the cron-drain safety net) so retries on the cron path aren't silently skipped.
 
 ## Dead-letter & replay
 
@@ -176,18 +179,25 @@ packages/authhero/src/hooks/
                                 #   and post-user-update
 ```
 
-Three sibling modules under `helpers/outbox-destinations/` own the publish phase:
+The sibling modules under `helpers/outbox-destinations/` own the publish phase:
 
 ```text
 packages/authhero/src/helpers/outbox-destinations/
 ├── logs.ts                    # LogsDestination (rejects hook.* events)
 ├── webhooks.ts                # WebhookDestination (hook.* events → HTTP POST)
+├── code-hooks.ts              # CodeHookDestination (hook.* events → codeExecutor)
 └── registration-finalizer.ts  # flips registration_completed_at
 ```
 
-## What still runs inline (known gap)
+## Code hooks: from inline to outbox-backed
 
-Post-user-registration **code hooks** currently execute inside `createUserHooks` runPostHooks, not through the outbox. The relay-time path would need to reconstruct a synthetic `ctx` to invoke `handleCodeHook` without the original request — that design is not yet in place. See [#950](https://github.com/markusahlstrand/authhero/issues/950) for the plan.
+Post-user-registration and post-user-deletion **code hooks** (tenant-authored actions bound by `code_id`) used to run inline inside `createUserHooks` — best-effort and at-most-once, so a throw was logged and dropped. They now run through `CodeHookDestination` from the `hook.*` event, sharing the relay's retry + dead-letter machinery ([#950](https://github.com/markusahlstrand/authhero/issues/950)).
+
+The core executor was decoupled from the request `ctx`: `codehooks.ts::executeCodeHook({ codeExecutor, data, tenantId, hook, event, triggerId, api })` runs the code given explicit dependencies, and the inline `handleCodeHook(ctx, …)` is now a thin wrapper that resolves them from `ctx`. This works because the serialized event never carries `ctx` (it is stripped before reaching user code) and post-registration/deletion expose an empty `api` (there is no token to mutate), so no synthetic request needs to be reconstructed.
+
+**This changes the delivery guarantee from at-most-once to at-least-once.** A retried event re-runs every code hook for the trigger, so the outbox event id is passed to user code as `event.idempotency_key` for dedupe. Authors of non-idempotent side effects should key on it (or check `app_metadata`) — the same contract already required for self-healing.
+
+> Code hooks that mutate tokens (`post-user-login`, `credentials-exchange`) still run inline — they must observe/alter the live token in the request, so they cannot be deferred to the outbox.
 
 ## Further reading
 

--- a/apps/docs/deployment/outbox-cron.md
+++ b/apps/docs/deployment/outbox-cron.md
@@ -30,6 +30,7 @@ export default {
       dataAdapter,
       issuer: env.ISSUER,
       webhookInvoker, // same function passed to init()
+      codeExecutor, // same executor passed to init() — see below
       retentionDays: 7,
     });
   },
@@ -43,6 +44,7 @@ export default {
 | `dataAdapter` | yes | Same `DataAdapters` you pass to `init()`. Must include `outbox` — the call is a no-op if it doesn't. |
 | `issuer` | yes | Issuer URL used when minting `auth-service` tokens. Typically `env.ISSUER`. Webhook receivers that validate `iss` will accept tokens from both the inline and cron paths. |
 | `webhookInvoker` | no | Same shape as the `webhookInvoker` option on `init()`. **Pass the same function** — see below. |
+| `codeExecutor` | no | Same executor passed to `init({ codeExecutor })`. Pass it so cron-drained `hook.*` events also run `post-user-registration` / `post-user-deletion` code hooks — otherwise a code hook that failed per-request delivery is silently skipped on retry. |
 | `retentionDays` | no | Days to keep processed events before cleanup. Default `7`. |
 | `batchSize` | no | Max events per drain pass. Forwarded to `drainOutbox`. |
 | `maxRetries` | no | Max delivery attempts before an event is dead-lettered. Forwarded to `drainOutbox`. |

--- a/apps/docs/features/hooks.md
+++ b/apps/docs/features/hooks.md
@@ -1185,12 +1185,25 @@ exports.onExecutePostLogin = async (event, api) => {
 
 Supported triggers and their export names:
 
-| Trigger | Export Function |
-|---------|----------------|
-| `post-user-login` | `exports.onExecutePostLogin` |
-| `credentials-exchange` | `exports.onExecuteCredentialsExchange` |
-| `pre-user-registration` | `exports.onExecutePreUserRegistration` |
-| `post-user-registration` | `exports.onExecutePostUserRegistration` |
+| Trigger | Export Function | Execution |
+|---------|----------------|-----------|
+| `post-user-login` | `exports.onExecutePostLogin` | Inline (mutates the token) |
+| `credentials-exchange` | `exports.onExecuteCredentialsExchange` | Inline (mutates the token) |
+| `pre-user-registration` | `exports.onExecutePreUserRegistration` | Inline (blocks / mutates the user before creation) |
+| `post-user-registration` | `exports.onExecutePostUserRegistration` | Outbox-backed (retried) |
+| `post-user-deletion` | `exports.onExecutePostUserDeletion` | Outbox-backed (retried) |
+
+### Outbox-backed delivery for post-registration / post-deletion code hooks
+
+`post-user-registration` and `post-user-deletion` code hooks are delivered through the [outbox pipeline](../architecture/hooks-pipeline.md), the same durable path as webhooks — via `CodeHookDestination`. They are **not** run inline in the request:
+
+- **Retries + dead-letter**: a failing code hook is retried with exponential backoff and dead-lettered after `maxRetries`, then surfaced via the [Failed events](/customization/failed-events) endpoints. Previously a failure was only logged and dropped.
+- **At-least-once**: because the event can be retried (and re-enqueued by [self-healing](../architecture/hooks-pipeline.md#self-healing-post-user-registration) on the user's next login), a code hook may run more than once. The outbox event id is passed to your code as `event.idempotency_key` — key non-idempotent side effects on it, or check `app_metadata`, so re-delivery is safe.
+- **Ordering**: they run after the user row is committed and after any `account-linking` template hook, so `event.user` reflects the linked/primary user.
+
+The token-mutating triggers (`post-user-login`, `credentials-exchange`) still run inline — they must alter the live token in the request and cannot be deferred.
+
+When running the [outbox as a cron drain](/deployment/outbox-cron), pass the same `codeExecutor` to `runOutboxRelay` / `createDefaultDestinations` so code hooks that failed per-request delivery are actually retried rather than skipped.
 
 ### Management API
 

--- a/apps/docs/features/user-creation-flow.md
+++ b/apps/docs/features/user-creation-flow.md
@@ -122,19 +122,24 @@ PHASE 2 — Commit (single short DB transaction)
 
 PHASE 3 — Publish (runs after the commit, never blocks it)
 
-6. onExecutePostUserRegistration (programmatic, inline for now)
-7. post-user-registration code hooks (inline for now — see [#950](https://github.com/markusahlstrand/authhero/issues/950))
-8. post-user-registration template hooks (e.g. account-linking)
+6. onExecutePostUserRegistration (programmatic SDK hook, inline)
+7. post-user-registration template hooks (e.g. account-linking)
    └── pre-defined function dispatched by template_id; not user code
-9. enqueuePostHookEvent("post-user-registration")
-   └── outbox relay → WebhookDestination + RegistrationFinalizerDestination
-       ├── POSTs to enabled webhooks with Idempotency-Key = event.id
+8. enqueuePostHookEvent("post-user-registration")
+   └── outbox relay → WebhookDestination + CodeHookDestination
+       │                + RegistrationFinalizerDestination
+       ├── WebhookDestination: POSTs to enabled webhooks with
+       │   Idempotency-Key = event.id
+       ├── CodeHookDestination: runs enabled post-user-registration
+       │   code hooks via the codeExecutor (idempotency_key = event.id)
        ├── retries with exponential backoff on failure (max 5)
        ├── moves to dead-letter after retry exhaustion
        └── on success → sets user.registration_completed_at
 ```
 
-Self-healing: if `registration_completed_at` is still `null` on the user's next login, `postUserLoginHook` re-enqueues the `post-user-registration` event so a dead-lettered or lost delivery recovers automatically. Webhook consumers must be idempotent (enforced by the `Idempotency-Key` header).
+Post-user-registration **code hooks** run from the outbox event (step 8) via `CodeHookDestination`, not inline — so they get retries + dead-letter. Because template hooks (step 7) mutate the user before the event is enqueued, code hooks observe the linked/primary user. See [#950](https://github.com/markusahlstrand/authhero/issues/950) and the [Hooks & Outbox Pipeline](../architecture/hooks-pipeline.md#code-hooks-from-inline-to-outbox-backed) doc.
+
+Self-healing: if `registration_completed_at` is still `null` on the user's next login, `postUserLoginHook` re-enqueues the `post-user-registration` event so a dead-lettered or lost delivery recovers automatically. Consumers must be idempotent — webhooks via the `Idempotency-Key` header, code hooks via `event.idempotency_key`.
 
 ## Signup Blocking with `disable_sign_ups`
 

--- a/packages/authhero/src/helpers/default-destinations.ts
+++ b/packages/authhero/src/helpers/default-destinations.ts
@@ -120,11 +120,25 @@ export function createDefaultDestinations(
     destinations.push(new LogStreamDestination(dataAdapter.logStreams));
   }
 
+  if (getServiceToken) {
+    destinations.push(
+      new WebhookDestination(dataAdapter.hooks, getServiceToken, {
+        timeoutMs: webhookTimeoutMs,
+        webhookInvoker,
+      }),
+    );
+  }
+
   // Run tenant code hooks on the cron path too, so a code hook that failed
   // per-request delivery is actually retried rather than skipped. Requires the
   // code-hook adapters alongside the executor. Independent of `getServiceToken`
   // — code hooks are invoked directly (via `executeCodeHook`), not over HTTP —
   // so a consumer that only configures `codeExecutor` still drains code hooks.
+  //
+  // Must be pushed AFTER `WebhookDestination`: `drainOutbox` / `processOutboxEvents`
+  // stop an event's destination loop on the first failure, so placing code hooks
+  // first would let a failing code hook block webhook delivery on cron retries.
+  // This also matches the per-request destination order in the route middleware.
   if (
     codeExecutor &&
     dataAdapter.actions &&
@@ -146,12 +160,6 @@ export function createDefaultDestinations(
   }
 
   if (getServiceToken) {
-    destinations.push(
-      new WebhookDestination(dataAdapter.hooks, getServiceToken, {
-        timeoutMs: webhookTimeoutMs,
-        webhookInvoker,
-      }),
-    );
     if (controlPlaneSync) {
       destinations.push(
         new ControlPlaneSyncDestination({

--- a/packages/authhero/src/helpers/default-destinations.ts
+++ b/packages/authhero/src/helpers/default-destinations.ts
@@ -1,4 +1,4 @@
-import { DataAdapters } from "@authhero/adapter-interfaces";
+import { CodeExecutor, DataAdapters } from "@authhero/adapter-interfaces";
 import { EventDestination } from "./outbox-relay";
 import { LogsDestination } from "./outbox-destinations/logs";
 import { LogStreamDestination } from "./outbox-destinations/log-streams";
@@ -6,16 +6,25 @@ import {
   WebhookDestination,
   type GetServiceToken,
 } from "./outbox-destinations/webhooks";
+import { CodeHookDestination } from "./outbox-destinations/code-hooks";
 import { RegistrationFinalizerDestination } from "./outbox-destinations/registration-finalizer";
 import { ControlPlaneSyncDestination } from "./outbox-destinations/control-plane-sync";
 import type { WebhookInvoker } from "../types/AuthHeroConfig";
 
 export interface CreateDefaultDestinationsConfig {
   /**
-   * Data adapter — only the `logs`, `hooks`, `users`, and `logStreams`
-   * adapters are used by the built-in destinations.
+   * Data adapter — the `logs`, `hooks`, `users`, and `logStreams` adapters are
+   * used by the built-in destinations. When `codeExecutor` is set, the
+   * `actions`, `hookCode`, and `actionExecutions` adapters are also required so
+   * `CodeHookDestination` can resolve and run tenant code hooks.
    */
-  dataAdapter: Pick<DataAdapters, "logs" | "hooks" | "users" | "logStreams">;
+  dataAdapter: Pick<DataAdapters, "logs" | "hooks" | "users" | "logStreams"> &
+    Partial<
+      Pick<
+        DataAdapters,
+        "actions" | "hookCode" | "actionExecutions" | "multiTenancyConfig"
+      >
+    >;
 
   /**
    * Produces a Bearer access token for the given tenant, used when POSTing
@@ -49,6 +58,15 @@ export interface CreateDefaultDestinationsConfig {
    * deliveries don't diverge from inline per-request ones.
    */
   webhookInvoker?: WebhookInvoker;
+
+  /**
+   * Code executor — same instance passed to `init({ codeExecutor })`. When
+   * provided (and `dataAdapter` carries `actions`, `hookCode`, and
+   * `actionExecutions`), a `CodeHookDestination` is added so cron-drained
+   * `hook.*` events also run tenant code hooks. Without it, code hooks that
+   * failed per-request delivery would be silently skipped on retry.
+   */
+  codeExecutor?: CodeExecutor;
 }
 
 /**
@@ -85,6 +103,7 @@ export function createDefaultDestinations(
     webhookTimeoutMs,
     webhookInvoker,
     controlPlaneSync,
+    codeExecutor,
   } = config;
 
   if (controlPlaneSync && !getServiceToken) {
@@ -117,8 +136,30 @@ export function createDefaultDestinations(
         }),
       );
     }
-    // Must come AFTER WebhookDestination so the registration-completed flag
-    // only flips once webhook delivery has actually succeeded.
+    // Run tenant code hooks on the cron path too, so a code hook that failed
+    // per-request delivery is actually retried rather than skipped. Requires
+    // the code-hook adapters alongside the executor.
+    if (
+      codeExecutor &&
+      dataAdapter.actions &&
+      dataAdapter.hookCode &&
+      dataAdapter.actionExecutions
+    ) {
+      destinations.push(
+        new CodeHookDestination(
+          {
+            hooks: dataAdapter.hooks,
+            actions: dataAdapter.actions,
+            hookCode: dataAdapter.hookCode,
+            actionExecutions: dataAdapter.actionExecutions,
+            multiTenancyConfig: dataAdapter.multiTenancyConfig,
+          },
+          codeExecutor,
+        ),
+      );
+    }
+    // Must come AFTER the delivery destinations so the registration-completed
+    // flag only flips once webhook and code-hook delivery have succeeded.
     destinations.push(new RegistrationFinalizerDestination(dataAdapter.users));
   }
 

--- a/packages/authhero/src/helpers/default-destinations.ts
+++ b/packages/authhero/src/helpers/default-destinations.ts
@@ -120,6 +120,31 @@ export function createDefaultDestinations(
     destinations.push(new LogStreamDestination(dataAdapter.logStreams));
   }
 
+  // Run tenant code hooks on the cron path too, so a code hook that failed
+  // per-request delivery is actually retried rather than skipped. Requires the
+  // code-hook adapters alongside the executor. Independent of `getServiceToken`
+  // — code hooks are invoked directly (via `executeCodeHook`), not over HTTP —
+  // so a consumer that only configures `codeExecutor` still drains code hooks.
+  if (
+    codeExecutor &&
+    dataAdapter.actions &&
+    dataAdapter.hookCode &&
+    dataAdapter.actionExecutions
+  ) {
+    destinations.push(
+      new CodeHookDestination(
+        {
+          hooks: dataAdapter.hooks,
+          actions: dataAdapter.actions,
+          hookCode: dataAdapter.hookCode,
+          actionExecutions: dataAdapter.actionExecutions,
+          multiTenancyConfig: dataAdapter.multiTenancyConfig,
+        },
+        codeExecutor,
+      ),
+    );
+  }
+
   if (getServiceToken) {
     destinations.push(
       new WebhookDestination(dataAdapter.hooks, getServiceToken, {
@@ -136,30 +161,8 @@ export function createDefaultDestinations(
         }),
       );
     }
-    // Run tenant code hooks on the cron path too, so a code hook that failed
-    // per-request delivery is actually retried rather than skipped. Requires
-    // the code-hook adapters alongside the executor.
-    if (
-      codeExecutor &&
-      dataAdapter.actions &&
-      dataAdapter.hookCode &&
-      dataAdapter.actionExecutions
-    ) {
-      destinations.push(
-        new CodeHookDestination(
-          {
-            hooks: dataAdapter.hooks,
-            actions: dataAdapter.actions,
-            hookCode: dataAdapter.hookCode,
-            actionExecutions: dataAdapter.actionExecutions,
-            multiTenancyConfig: dataAdapter.multiTenancyConfig,
-          },
-          codeExecutor,
-        ),
-      );
-    }
-    // Must come AFTER the delivery destinations so the registration-completed
-    // flag only flips once webhook and code-hook delivery have succeeded.
+    // Must come AFTER the delivery destinations (webhook + code hook) so the
+    // registration-completed flag only flips once delivery has succeeded.
     destinations.push(new RegistrationFinalizerDestination(dataAdapter.users));
   }
 

--- a/packages/authhero/src/helpers/outbox-destinations/code-hooks.ts
+++ b/packages/authhero/src/helpers/outbox-destinations/code-hooks.ts
@@ -1,0 +1,149 @@
+import { AuditEvent, CodeExecutor } from "@authhero/adapter-interfaces";
+import { EventDestination } from "../outbox-relay";
+import {
+  CodeHookData,
+  CodeHookEventInput,
+  executeCodeHook,
+  HandleCodeHookOutcome,
+  isCodeHook,
+  persistActionExecution,
+} from "../../hooks/codehooks";
+
+const HOOK_EVENT_PREFIX = "hook.";
+
+interface CodeHookInvocation {
+  eventId: string;
+  tenantId: string;
+  triggerId: string;
+  /** Serialized user snapshot from the audit event (`target.after`). */
+  user?: unknown;
+  /** Serialized request context from the audit event. */
+  request?: unknown;
+}
+
+/**
+ * Delivers `hook.*` outbox events to tenant-authored **code hooks** (actions)
+ * for the matching `trigger_id`. Runs alongside `WebhookDestination` — both
+ * accept the same `hook.*` events — so a single registration/deletion event
+ * fans out to webhooks *and* code hooks, each retried independently by the
+ * outbox relay.
+ *
+ * Reliability model: unlike the previous inline execution (best-effort,
+ * at-most-once, failures logged and dropped), code hooks delivered here are
+ * **at-least-once**. If any code hook for the trigger fails, `deliver` throws
+ * so the relay retries the whole event with backoff and, after `maxRetries`,
+ * dead-letters it. A retry re-runs every code hook for the trigger, so the
+ * event id is passed to user code as `event.idempotency_key` for dedupe.
+ *
+ * Must be listed AFTER `WebhookDestination` and BEFORE
+ * `RegistrationFinalizerDestination` so `registration_completed_at` is only
+ * flipped on a pass where every webhook *and* code hook succeeded.
+ *
+ * Constructed per-request (via `getDestinations(ctx)`) so it can close over
+ * `ctx.env.codeExecutor`. The same class is used by the cron `drainOutbox`
+ * safety net when a `codeExecutor` is supplied to `createDefaultDestinations`.
+ * When no executor is configured, code hooks cannot run (nor be deployed), so
+ * `deliver` is a no-op success — matching the inline `handleCodeHook` which
+ * returns `null` without an executor.
+ */
+export class CodeHookDestination implements EventDestination {
+  name = "code-hooks";
+  private data: CodeHookData;
+  private codeExecutor?: CodeExecutor;
+
+  constructor(data: CodeHookData, codeExecutor?: CodeExecutor) {
+    this.data = data;
+    this.codeExecutor = codeExecutor;
+  }
+
+  accepts(event: AuditEvent): boolean {
+    return event.event_type.startsWith(HOOK_EVENT_PREFIX);
+  }
+
+  transform(event: AuditEvent): CodeHookInvocation {
+    return {
+      eventId: event.id,
+      tenantId: event.tenant_id,
+      triggerId: event.event_type.slice(HOOK_EVENT_PREFIX.length),
+      user: event.target?.after,
+      request: event.request,
+    };
+  }
+
+  async deliver(invocations: CodeHookInvocation[]): Promise<void> {
+    const codeExecutor = this.codeExecutor;
+    // No executor configured: code hooks can't have been deployed, so there is
+    // nothing to run. Treat as delivered so the event isn't retried forever.
+    if (!codeExecutor) return;
+
+    for (const invocation of invocations) {
+      const { hooks } = await this.data.hooks.list(invocation.tenantId);
+      const codeHooks = hooks.filter(
+        (h) =>
+          h.enabled &&
+          h.trigger_id === invocation.triggerId &&
+          isCodeHook(h),
+      );
+      if (codeHooks.length === 0) continue;
+
+      const event: CodeHookEventInput = {
+        user: invocation.user,
+        request: invocation.request,
+        tenant: { id: invocation.tenantId },
+      };
+
+      const outcomes: HandleCodeHookOutcome[] = [];
+      for (const hook of codeHooks) {
+        // Re-narrow: `filter` above keeps the array typed as `Hook[]`.
+        if (!isCodeHook(hook)) continue;
+        try {
+          outcomes.push(
+            await executeCodeHook({
+              codeExecutor,
+              data: this.data,
+              tenantId: invocation.tenantId,
+              hook,
+              event,
+              triggerId: invocation.triggerId,
+              // Post-registration / post-deletion have no token to mutate, so
+              // the api surface is empty (matches the inline call sites).
+              api: { user: {} },
+              idempotencyKey: invocation.eventId,
+            }),
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          outcomes.push({
+            result: {
+              action_name: hook.code_id,
+              error: { id: "execution_threw", msg: message },
+              started_at: new Date().toISOString(),
+              ended_at: new Date().toISOString(),
+            },
+            logs: [],
+            denied: false,
+          });
+        }
+      }
+
+      // Persist the execution record for observability regardless of outcome,
+      // then fail the delivery if any hook errored so the relay retries.
+      await persistActionExecution(
+        this.data,
+        invocation.tenantId,
+        invocation.triggerId,
+        outcomes,
+      );
+
+      const failed = outcomes.filter((o) => o.result.error);
+      if (failed.length > 0) {
+        const summary = failed
+          .map((o) => `${o.result.action_name}: ${o.result.error?.msg}`)
+          .join("; ");
+        throw new Error(
+          `${failed.length} code hook(s) failed for ${invocation.triggerId}: ${summary}`,
+        );
+      }
+    }
+  }
+}

--- a/packages/authhero/src/helpers/outbox-destinations/code-hooks.ts
+++ b/packages/authhero/src/helpers/outbox-destinations/code-hooks.ts
@@ -25,8 +25,11 @@ interface CodeHookInvocation {
  * Delivers `hook.*` outbox events to tenant-authored **code hooks** (actions)
  * for the matching `trigger_id`. Runs alongside `WebhookDestination` — both
  * accept the same `hook.*` events — so a single registration/deletion event
- * fans out to webhooks *and* code hooks, each retried independently by the
- * outbox relay.
+ * fans out to webhooks *and* code hooks. The fan-out is not retried
+ * independently: the relay retries the whole outbox event, running its
+ * destinations in order and stopping at the first failure, so a code-hook
+ * failure here causes earlier destinations (e.g. webhooks) to run again on the
+ * retry. Every destination on the event must therefore be idempotent.
  *
  * Reliability model: unlike the previous inline execution (best-effort,
  * at-most-once, failures logged and dropped), code hooks delivered here are

--- a/packages/authhero/src/helpers/outbox-destinations/code-hooks.ts
+++ b/packages/authhero/src/helpers/outbox-destinations/code-hooks.ts
@@ -1,4 +1,4 @@
-import { AuditEvent, CodeExecutor } from "@authhero/adapter-interfaces";
+import { AuditEvent, CodeExecutor, Hook } from "@authhero/adapter-interfaces";
 import { EventDestination } from "../outbox-relay";
 import {
   CodeHookData,
@@ -77,7 +77,7 @@ export class CodeHookDestination implements EventDestination {
     if (!codeExecutor) return;
 
     for (const invocation of invocations) {
-      const { hooks } = await this.data.hooks.list(invocation.tenantId);
+      const hooks = await this.listAllHooks(invocation.tenantId);
       const codeHooks = hooks.filter(
         (h) =>
           h.enabled &&
@@ -145,5 +145,24 @@ export class CodeHookDestination implements EventDestination {
         );
       }
     }
+  }
+
+  /**
+   * Fetch every hook for the tenant, paging past the adapter's default page
+   * size. `hooks.list` returns only the first page by default, so a tenant with
+   * more enabled code hooks than one page would silently skip the rest.
+   */
+  private async listAllHooks(tenantId: string): Promise<Hook[]> {
+    const perPage = 100;
+    const all: Hook[] = [];
+    for (let page = 0; ; page++) {
+      const { hooks } = await this.data.hooks.list(tenantId, {
+        page,
+        per_page: perPage,
+      });
+      all.push(...hooks);
+      if (hooks.length < perPage) break;
+    }
+    return all;
   }
 }

--- a/packages/authhero/src/helpers/run-outbox-relay.ts
+++ b/packages/authhero/src/helpers/run-outbox-relay.ts
@@ -1,4 +1,4 @@
-import { DataAdapters } from "@authhero/adapter-interfaces";
+import { CodeExecutor, DataAdapters } from "@authhero/adapter-interfaces";
 import type { WebhookInvoker } from "../types/AuthHeroConfig";
 import { drainOutbox } from "./outbox-relay";
 import { cleanupOutbox } from "./outbox-cleanup";
@@ -35,6 +35,14 @@ export interface RunOutboxRelayConfig {
 
   /** Webhook HTTP timeout (ms), when the default invoker is used. */
   webhookTimeoutMs?: number;
+
+  /**
+   * Optional code executor — same instance passed to `init({ codeExecutor })`.
+   * When provided, cron-drained `hook.*` events also run tenant code hooks, so
+   * a code hook that failed per-request delivery is retried rather than
+   * silently skipped.
+   */
+  codeExecutor?: CodeExecutor;
 }
 
 /**
@@ -78,6 +86,7 @@ export async function runOutboxRelay(
     batchSize,
     maxRetries,
     webhookTimeoutMs,
+    codeExecutor,
   } = config;
 
   if (!dataAdapter.outbox) {
@@ -95,6 +104,7 @@ export async function runOutboxRelay(
     getServiceToken,
     webhookTimeoutMs,
     webhookInvoker,
+    codeExecutor,
   });
 
   let drainError: unknown;

--- a/packages/authhero/src/hooks/codehooks.ts
+++ b/packages/authhero/src/hooks/codehooks.ts
@@ -4,11 +4,13 @@ import {
   ActionExecutionResult,
   ActionExecutionStatus,
   CodeExecutionLog,
+  CodeExecutor,
   DataAdapters,
   Hook,
 } from "@authhero/adapter-interfaces";
 import { Bindings, Variables } from "../types";
 import { HookEvent, OnExecuteCredentialsExchangeAPI } from "../types/Hooks";
+import { EnrichedClient } from "../helpers/client";
 
 /**
  * Auth0 uses `post-login` for what we internally call `post-user-login`.
@@ -19,6 +21,17 @@ export function toAuth0TriggerId(internal: string): string {
   return internal;
 }
 
+/**
+ * The subset of `DataAdapters` needed to resolve and run a code hook and to
+ * persist its execution record. Narrowed so `CodeHookDestination` and the cron
+ * `createDefaultDestinations` helper can construct it without depending on the
+ * full adapter surface.
+ */
+export type CodeHookData = Pick<
+  DataAdapters,
+  "hooks" | "actions" | "hookCode" | "actionExecutions" | "multiTenancyConfig"
+>;
+
 // Type guard for code hooks
 type CodeHook = Extract<Hook, { code_id: string }>;
 
@@ -27,12 +40,29 @@ export function isCodeHook(hook: Hook): hook is CodeHook {
 }
 
 /**
+ * Loosened event shape accepted by `buildSerializableEvent` / `executeCodeHook`.
+ *
+ * The inline hook call sites pass a full `HookEvent`. The `CodeHookDestination`
+ * (which runs from the outbox relay, after the request has closed) has no live
+ * `ctx` and reconstructs the event from the persisted audit event, so `user`
+ * and `request` arrive as already-serialized `unknown` values. Both are
+ * assignable to this type.
+ */
+export type CodeHookEventInput = {
+  ctx?: unknown;
+  client?: Pick<
+    EnrichedClient,
+    "client_id" | "name" | "client_metadata"
+  > | null;
+} & Record<string, unknown>;
+
+/**
  * Build a serializable event object from a HookEvent.
  * Strips the `ctx` property (Hono context) which cannot be serialized,
  * and returns a plain JSON-compatible object.
  */
 export function buildSerializableEvent(
-  event: HookEvent,
+  event: CodeHookEventInput,
   secrets?: Record<string, string>,
 ): Record<string, unknown> {
   const { ctx, client, ...rest } = event;
@@ -87,7 +117,7 @@ function secretsToMap(
 }
 
 async function loadCodeForHook(
-  data: DataAdapters,
+  data: Pick<DataAdapters, "actions" | "hookCode" | "multiTenancyConfig">,
   tenant_id: string,
   code_id: string,
 ): Promise<ResolvedCode | null> {
@@ -160,34 +190,35 @@ export type HandleCodeHookOutcome = {
 };
 
 /**
- * Execute a code hook by fetching the code from the database, running it
- * through the code executor, and replaying API calls against the real api
- * object.
+ * Core code-hook execution, decoupled from the Hono request `ctx`.
  *
- * Returns the per-action result (Auth0 shape) so the caller can aggregate
- * results across all actions on a trigger into a single `action_executions`
- * record. Returns `null` when the code cannot be located or the executor is
- * unavailable — the caller decides whether to surface that.
+ * Given an explicit executor, data adapter, and tenant, fetches the code,
+ * runs it, and replays the recorded API calls against `api`. Shared by the
+ * inline `handleCodeHook` wrapper (request-time) and by `CodeHookDestination`
+ * (outbox relay, after the request has closed).
+ *
+ * Always returns an outcome — including a `code_not_found` / `execution_failed`
+ * outcome — so the caller can persist an `action_executions` record. It only
+ * throws for `api.access.deny`, which surfaces as a thrown `HTTPException` from
+ * the replayed API call; callers that must abort the flow catch it.
+ *
+ * `idempotencyKey`, when set, is exposed to user code as `event.idempotency_key`.
+ * The outbox is at-least-once, so a retried hook event re-runs the code; authors
+ * performing non-idempotent side effects can dedupe on this key.
  */
-export async function handleCodeHook(
-  ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
-  data: DataAdapters,
-  hook: { code_id: string; hook_id: string },
-  event: HookEvent,
-  triggerId: string,
-  api: Record<string, any>,
-): Promise<HandleCodeHookOutcome | null> {
-  const codeExecutor = ctx.env.codeExecutor;
-  if (!codeExecutor) {
-    return null;
-  }
+export async function executeCodeHook(params: {
+  codeExecutor: CodeExecutor;
+  data: CodeHookData;
+  tenantId: string;
+  hook: { code_id: string; hook_id?: string };
+  event: CodeHookEventInput;
+  triggerId: string;
+  api: Record<string, any>;
+  idempotencyKey?: string;
+}): Promise<HandleCodeHookOutcome> {
+  const { codeExecutor, data, tenantId, hook, event, triggerId, api } = params;
 
-  const tenant_id = ctx.var.tenant_id || ctx.req.header("tenant-id");
-  if (!tenant_id) {
-    return null;
-  }
-
-  const codeRecord = await loadCodeForHook(data, tenant_id, hook.code_id);
+  const codeRecord = await loadCodeForHook(data, tenantId, hook.code_id);
   const started_at = new Date().toISOString();
 
   if (!codeRecord) {
@@ -207,6 +238,9 @@ export async function handleCodeHook(
   }
 
   const serializableEvent = buildSerializableEvent(event, codeRecord.secrets);
+  if (params.idempotencyKey) {
+    serializableEvent.idempotency_key = params.idempotencyKey;
+  }
 
   const execResult = await codeExecutor.execute({
     code: codeRecord.code,
@@ -254,12 +288,50 @@ export async function handleCodeHook(
 }
 
 /**
+ * Execute a code hook by fetching the code from the database, running it
+ * through the code executor, and replaying API calls against the real api
+ * object.
+ *
+ * Thin request-time wrapper over `executeCodeHook` that resolves the executor
+ * and tenant from `ctx`. Returns `null` when the code executor is unavailable
+ * or the tenant can't be resolved — the caller decides whether to surface that.
+ */
+export async function handleCodeHook(
+  ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
+  data: DataAdapters,
+  hook: { code_id: string; hook_id: string },
+  event: HookEvent,
+  triggerId: string,
+  api: Record<string, any>,
+): Promise<HandleCodeHookOutcome | null> {
+  const codeExecutor = ctx.env.codeExecutor;
+  if (!codeExecutor) {
+    return null;
+  }
+
+  const tenant_id = ctx.var.tenant_id || ctx.req.header("tenant-id");
+  if (!tenant_id) {
+    return null;
+  }
+
+  return executeCodeHook({
+    codeExecutor,
+    data,
+    tenantId: tenant_id,
+    hook,
+    event,
+    triggerId,
+    api,
+  });
+}
+
+/**
  * Aggregate per-action outcomes into an Auth0-shape execution record and
  * persist it via the adapter. Returns the generated execution_id (uuid)
  * so the caller can embed it in the surrounding tenant log.
  */
 export async function persistActionExecution(
-  data: DataAdapters,
+  data: Pick<DataAdapters, "actionExecutions">,
   tenant_id: string,
   triggerId: string,
   outcomes: HandleCodeHookOutcome[],

--- a/packages/authhero/src/hooks/codehooks.ts
+++ b/packages/authhero/src/hooks/codehooks.ts
@@ -81,12 +81,32 @@ export function buildSerializableEvent(
 }
 
 /**
+ * The namespaced API surface exposed to code hooks. User code records calls of
+ * the form `<namespace>.<method>(...)` (e.g. `accessToken.setCustomClaim`,
+ * `access.deny`), which {@link replayApiCalls} replays against the real
+ * namespace objects. Each top-level key is a namespace whose members are the
+ * callable methods for that namespace — so the shape is nested (namespace →
+ * method → function) rather than a flat `any` surface. Concrete per-trigger API
+ * types (`OnExecute*API`) structurally satisfy this.
+ *
+ * The method args stay permissive (`any[]`): this surface is a dynamic
+ * dispatcher — {@link replayApiCalls} looks methods up by string and applies
+ * the recorded `unknown[]` args, while call sites register concretely-typed
+ * methods (`(key: string, value: unknown) => void`, …). A stricter `unknown[]`
+ * args tuple would reject those concrete registrations (parameter
+ * contravariance). The return type is still narrowed to `unknown`.
+ */
+export type CodeHookApiMethod = (...args: any[]) => unknown;
+export type CodeHookApiNamespace = Record<string, CodeHookApiMethod>;
+export type CodeHookApi = Record<string, CodeHookApiNamespace>;
+
+/**
  * Replay recorded API calls from code hook execution against real API objects.
  * Handles calls like "accessToken.setCustomClaim" by navigating the api object.
  */
 export function replayApiCalls(
   apiCalls: Array<{ method: string; args: unknown[] }>,
-  api: Record<string, any>,
+  api: CodeHookApi,
 ): void {
   for (const call of apiCalls) {
     const parts = call.method.split(".");
@@ -213,7 +233,7 @@ export async function executeCodeHook(params: {
   hook: { code_id: string; hook_id?: string };
   event: CodeHookEventInput;
   triggerId: string;
-  api: Record<string, any>;
+  api: CodeHookApi;
   idempotencyKey?: string;
 }): Promise<HandleCodeHookOutcome> {
   const { codeExecutor, data, tenantId, hook, event, triggerId, api } = params;
@@ -302,7 +322,7 @@ export async function handleCodeHook(
   hook: { code_id: string; hook_id: string },
   event: HookEvent,
   triggerId: string,
-  api: Record<string, any>,
+  api: CodeHookApi,
 ): Promise<HandleCodeHookOutcome | null> {
   const codeExecutor = ctx.env.codeExecutor;
   if (!codeExecutor) {
@@ -391,7 +411,7 @@ export async function handleCredentialsExchangeCodeHooks(
         hook,
         event,
         "credentials-exchange",
-        api as unknown as Record<string, any>,
+        api as unknown as CodeHookApi,
       );
       if (outcome) outcomes.push(outcome);
     } catch (err) {

--- a/packages/authhero/src/hooks/user-registration.ts
+++ b/packages/authhero/src/hooks/user-registration.ts
@@ -271,58 +271,23 @@ export function createUserHooks(
         }
       }
 
-      // Execute post-user-registration code and template hooks.
+      // Execute post-user-registration template hooks.
+      //
+      // Post-registration *code* hooks are no longer run inline: they are
+      // delivered by `CodeHookDestination` from the outbox event enqueued
+      // below, so they get retries + dead-letter instead of best-effort
+      // inline execution. See `enqueuePostHookEvent`.
+      //
       // Bundle-friendly: fetch the full tenant hooks list and filter in JS
       // instead of passing a `q:` param.
       {
         const { hooks: allHooks } = await ctx.env.data.hooks.list(tenant_id);
-        const postRegCodeHooks = allHooks.filter(
-          (h: any) =>
-            h.trigger_id === "post-user-registration" &&
-            h.enabled &&
-            isCodeHook(h),
-        );
-        const postRegOutcomes: HandleCodeHookOutcome[] = [];
-        for (const hook of postRegCodeHooks) {
-          if (!isCodeHook(hook)) continue;
-          try {
-            const outcome = await handleCodeHook(
-              ctx,
-              ctx.env.data,
-              hook,
-              { ctx, user: result, request },
-              "post-user-registration",
-              { user: {} },
-            );
-            if (outcome) postRegOutcomes.push(outcome);
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            postRegOutcomes.push({
-              result: {
-                action_name: hook.code_id,
-                error: { id: "execution_threw", msg: message },
-                started_at: new Date().toISOString(),
-                ended_at: new Date().toISOString(),
-              },
-              logs: [],
-              denied: false,
-            });
-          }
-        }
-        const postRegExecutionId = await persistActionExecution(
-          ctx.env.data,
-          tenant_id,
-          "post-user-registration",
-          postRegOutcomes,
-        );
-        if (postRegExecutionId) {
-          ctx.set("action_execution_id", postRegExecutionId);
-        }
 
-        // Template hooks (e.g. `account-linking`) run after code hooks so
-        // they observe any user-metadata or linked_to updates the code
-        // hooks performed. Failures are logged but do not abort signup —
-        // the post-registration phase is best-effort, mirroring code hooks.
+        // Template hooks (e.g. `account-linking`) mutate `result` before the
+        // post-registration event is enqueued, so code hooks (delivered async
+        // from that event) observe the linked/primary user. Failures are
+        // logged but do not abort signup — the post-registration phase is
+        // best-effort for template hooks.
         const postRegTemplateHooks = allHooks.filter(
           (h: any) =>
             h.trigger_id === "post-user-registration" &&

--- a/packages/authhero/src/index.ts
+++ b/packages/authhero/src/index.ts
@@ -54,6 +54,7 @@ export {
   type WebhookDestinationOptions,
   type GetServiceToken,
 } from "./helpers/outbox-destinations/webhooks";
+export { CodeHookDestination } from "./helpers/outbox-destinations/code-hooks";
 export { RegistrationFinalizerDestination } from "./helpers/outbox-destinations/registration-finalizer";
 export {
   ControlPlaneSyncDestination,

--- a/packages/authhero/src/routes/auth-api/index.ts
+++ b/packages/authhero/src/routes/auth-api/index.ts
@@ -28,6 +28,7 @@ import { serverTimingMiddleware } from "../../helpers/server-timing";
 import { LogsDestination } from "../../helpers/outbox-destinations/logs";
 import { LogStreamDestination } from "../../helpers/outbox-destinations/log-streams";
 import { WebhookDestination } from "../../helpers/outbox-destinations/webhooks";
+import { CodeHookDestination } from "../../helpers/outbox-destinations/code-hooks";
 import { RegistrationFinalizerDestination } from "../../helpers/outbox-destinations/registration-finalizer";
 import { makeOutboxServiceTokenFactory } from "../../helpers/service-token";
 import { getIssuer } from "../../variables";
@@ -58,6 +59,7 @@ export default function create(config: AuthHeroConfig) {
           }),
           { webhookInvoker: ctx.env.webhookInvoker },
         ),
+        new CodeHookDestination(ctx.env.data, ctx.env.codeExecutor),
         // Must come after delivery destinations so the flag only flips when
         // the upstream hook destinations actually succeeded.
         new RegistrationFinalizerDestination(config.dataAdapter.users),

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -69,6 +69,7 @@ import { outboxMiddleware } from "../../middlewares/outbox";
 import { LogsDestination } from "../../helpers/outbox-destinations/logs";
 import { LogStreamDestination } from "../../helpers/outbox-destinations/log-streams";
 import { WebhookDestination } from "../../helpers/outbox-destinations/webhooks";
+import { CodeHookDestination } from "../../helpers/outbox-destinations/code-hooks";
 import { RegistrationFinalizerDestination } from "../../helpers/outbox-destinations/registration-finalizer";
 import { ControlPlaneSyncDestination } from "../../helpers/outbox-destinations/control-plane-sync";
 import { createServiceToken } from "../../helpers/service-token";
@@ -409,6 +410,7 @@ export default function create(config: AuthHeroConfig) {
           const token = await createServiceToken(ctx, tenantId, "webhook");
           return token.access_token;
         }),
+        new CodeHookDestination(managementAdapter, ctx.env.codeExecutor),
         ...(config.controlPlaneSync
           ? [
               new ControlPlaneSyncDestination({

--- a/packages/authhero/src/routes/universal-login/index.ts
+++ b/packages/authhero/src/routes/universal-login/index.ts
@@ -26,6 +26,7 @@ import { outboxMiddleware } from "../../middlewares/outbox";
 import { LogsDestination } from "../../helpers/outbox-destinations/logs";
 import { LogStreamDestination } from "../../helpers/outbox-destinations/log-streams";
 import { WebhookDestination } from "../../helpers/outbox-destinations/webhooks";
+import { CodeHookDestination } from "../../helpers/outbox-destinations/code-hooks";
 import { RegistrationFinalizerDestination } from "../../helpers/outbox-destinations/registration-finalizer";
 import { createServiceToken } from "../../helpers/service-token";
 import { tailwindCss } from "../../styles";
@@ -99,6 +100,7 @@ export default function create(config: AuthHeroConfig) {
             const token = await createServiceToken(ctx, tenantId, "webhook");
             return token.access_token;
           }),
+          new CodeHookDestination(ctx.env.data, ctx.env.codeExecutor),
           new RegistrationFinalizerDestination(config.dataAdapter.users),
         ],
       }),

--- a/packages/authhero/src/routes/universal-login/u2-index.ts
+++ b/packages/authhero/src/routes/universal-login/u2-index.ts
@@ -29,6 +29,7 @@ import { outboxMiddleware } from "../../middlewares/outbox";
 import { LogsDestination } from "../../helpers/outbox-destinations/logs";
 import { LogStreamDestination } from "../../helpers/outbox-destinations/log-streams";
 import { WebhookDestination } from "../../helpers/outbox-destinations/webhooks";
+import { CodeHookDestination } from "../../helpers/outbox-destinations/code-hooks";
 import { RegistrationFinalizerDestination } from "../../helpers/outbox-destinations/registration-finalizer";
 import { createServiceToken } from "../../helpers/service-token";
 import { screenApiRoutes } from "./screen-api";
@@ -74,6 +75,7 @@ export default function createU2App(config: AuthHeroConfig) {
             const token = await createServiceToken(ctx, tenantId, "webhook");
             return token.access_token;
           }),
+          new CodeHookDestination(ctx.env.data, ctx.env.codeExecutor),
           new RegistrationFinalizerDestination(config.dataAdapter.users),
         ],
       }),

--- a/packages/authhero/test/helpers/outbox-destinations/code-hooks.spec.ts
+++ b/packages/authhero/test/helpers/outbox-destinations/code-hooks.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from "vitest";
+import type { AuditEvent } from "@authhero/adapter-interfaces";
+import { CodeHookDestination } from "../../../src/helpers/outbox-destinations/code-hooks";
+
+function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    id: "evt-1",
+    tenant_id: "tenant-1",
+    event_type: "hook.post-user-registration",
+    log_type: "sapi",
+    category: "system",
+    actor: { type: "system" },
+    target: {
+      type: "user",
+      id: "user-1",
+      after: { user_id: "user-1", email: "a@b.test" },
+    },
+    request: { method: "POST", path: "/users", ip: "127.0.0.1" },
+    hostname: "localhost",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/**
+ * Build a data adapter mock where `hooks.list` returns `hooks`, code is
+ * resolved from `hookCode.get`, and action executions are captured.
+ */
+function makeData(hooks: any[], code = "module.exports = async () => {};") {
+  const created: any[] = [];
+  return {
+    data: {
+      hooks: { list: vi.fn().mockResolvedValue({ hooks }) },
+      actions: { get: vi.fn().mockResolvedValue(null), list: vi.fn() },
+      hookCode: { get: vi.fn().mockResolvedValue({ code, secrets: {} }) },
+      actionExecutions: {
+        create: vi.fn(async (_tenantId: string, rec: any) => {
+          created.push(rec);
+        }),
+      },
+    } as any,
+    created,
+  };
+}
+
+function makeExecutor(
+  result: Partial<{
+    success: boolean;
+    error: string;
+    apiCalls: Array<{ method: string; args: unknown[] }>;
+    logs: unknown[];
+  }> = {},
+) {
+  return {
+    execute: vi.fn().mockResolvedValue({
+      success: result.success ?? true,
+      error: result.error,
+      durationMs: 1,
+      apiCalls: result.apiCalls ?? [],
+      logs: result.logs ?? [],
+    }),
+  } as any;
+}
+
+const codeHook = {
+  hook_id: "h1",
+  code_id: "code-1",
+  enabled: true,
+  trigger_id: "post-user-registration",
+};
+
+describe("CodeHookDestination", () => {
+  it("accepts hook.* events and rejects the rest", () => {
+    const { data } = makeData([]);
+    const dest = new CodeHookDestination(data, makeExecutor());
+
+    expect(dest.accepts(makeEvent())).toBe(true);
+    expect(dest.accepts(makeEvent({ event_type: "hook.post-user-deletion" }))).toBe(
+      true,
+    );
+    expect(dest.accepts(makeEvent({ event_type: "user.created" }))).toBe(false);
+  });
+
+  it("is a no-op when no code executor is configured", async () => {
+    const { data } = makeData([codeHook]);
+    const dest = new CodeHookDestination(data, undefined);
+
+    await dest.deliver([dest.transform(makeEvent())]);
+
+    expect(data.hooks.list).not.toHaveBeenCalled();
+    expect(data.actionExecutions.create).not.toHaveBeenCalled();
+  });
+
+  it("runs matching enabled code hooks and persists the execution", async () => {
+    const { data, created } = makeData([codeHook]);
+    const executor = makeExecutor({ success: true });
+    const dest = new CodeHookDestination(data, executor);
+
+    await dest.deliver([dest.transform(makeEvent())]);
+
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+    const execArg = executor.execute.mock.calls[0][0];
+    expect(execArg.triggerId).toBe("post-user-registration");
+    // The serialized user snapshot comes from the audit event's target.after.
+    expect(execArg.event.user).toEqual({ user_id: "user-1", email: "a@b.test" });
+    // The outbox event id is exposed for at-least-once dedupe.
+    expect(execArg.event.idempotency_key).toBe("evt-1");
+
+    expect(created).toHaveLength(1);
+    expect(created[0].trigger_id).toBe("post-user-registration");
+    expect(created[0].status).toBe("final");
+  });
+
+  it("skips webhook (url) hooks and hooks for other triggers", async () => {
+    const { data } = makeData([
+      { hook_id: "w1", url: "https://x.test", enabled: true, trigger_id: "post-user-registration" },
+      { ...codeHook, trigger_id: "post-user-login" },
+      { ...codeHook, hook_id: "h2", code_id: "code-2", enabled: false },
+    ]);
+    const executor = makeExecutor();
+    const dest = new CodeHookDestination(data, executor);
+
+    await dest.deliver([dest.transform(makeEvent())]);
+
+    expect(executor.execute).not.toHaveBeenCalled();
+    expect(data.actionExecutions.create).not.toHaveBeenCalled();
+  });
+
+  it("throws when a code hook fails so the relay retries, but still persists the record", async () => {
+    const { data, created } = makeData([codeHook]);
+    const executor = makeExecutor({ success: false, error: "boom" });
+    const dest = new CodeHookDestination(data, executor);
+
+    await expect(dest.deliver([dest.transform(makeEvent())])).rejects.toThrow(
+      /code hook\(s\) failed for post-user-registration/,
+    );
+
+    // The execution record is written before the throw so failures are visible.
+    expect(created).toHaveLength(1);
+    expect(created[0].status).toBe("partial");
+  });
+
+  it("records a thrown executor as execution_threw and retries", async () => {
+    const { data, created } = makeData([codeHook]);
+    const executor = {
+      execute: vi.fn().mockRejectedValue(new Error("executor exploded")),
+    } as any;
+    const dest = new CodeHookDestination(data, executor);
+
+    await expect(dest.deliver([dest.transform(makeEvent())])).rejects.toThrow(
+      /executor exploded/,
+    );
+    expect(created).toHaveLength(1);
+    expect(created[0].results[0].error.id).toBe("execution_threw");
+  });
+});

--- a/packages/authhero/test/helpers/outbox-destinations/code-hooks.spec.ts
+++ b/packages/authhero/test/helpers/outbox-destinations/code-hooks.spec.ts
@@ -1,6 +1,28 @@
-import { describe, it, expect, vi } from "vitest";
-import type { AuditEvent } from "@authhero/adapter-interfaces";
+import { describe, it, expect, vi, type Mock } from "vitest";
+import type {
+  ActionExecutionResult,
+  AuditEvent,
+  CodeExecutionResult,
+  CodeExecutor,
+} from "@authhero/adapter-interfaces";
 import { CodeHookDestination } from "../../../src/helpers/outbox-destinations/code-hooks";
+import type { CodeHookData } from "../../../src/hooks/codehooks";
+
+/** Minimal hook shape the destination reads (enabled + trigger + code/url). */
+type MockHook = {
+  hook_id?: string;
+  code_id?: string;
+  url?: string;
+  enabled: boolean;
+  trigger_id: string;
+};
+
+/** Captured `action_executions.create` record. */
+type CreatedExecution = {
+  trigger_id: string;
+  status: string;
+  results: ActionExecutionResult[];
+};
 
 function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
   return {
@@ -26,40 +48,37 @@ function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
  * Build a data adapter mock where `hooks.list` returns `hooks`, code is
  * resolved from `hookCode.get`, and action executions are captured.
  */
-function makeData(hooks: any[], code = "module.exports = async () => {};") {
-  const created: any[] = [];
-  return {
-    data: {
-      hooks: { list: vi.fn().mockResolvedValue({ hooks }) },
-      actions: { get: vi.fn().mockResolvedValue(null), list: vi.fn() },
-      hookCode: { get: vi.fn().mockResolvedValue({ code, secrets: {} }) },
-      actionExecutions: {
-        create: vi.fn(async (_tenantId: string, rec: any) => {
-          created.push(rec);
-        }),
-      },
-    } as any,
-    created,
-  };
+function makeData(
+  hooks: MockHook[],
+  code = "module.exports = async () => {};",
+) {
+  const created: CreatedExecution[] = [];
+  const data = {
+    hooks: { list: vi.fn().mockResolvedValue({ hooks }) },
+    actions: { get: vi.fn().mockResolvedValue(null), list: vi.fn() },
+    hookCode: { get: vi.fn().mockResolvedValue({ code, secrets: {} }) },
+    actionExecutions: {
+      create: vi.fn(async (_tenantId: string, rec: CreatedExecution) => {
+        created.push(rec);
+      }),
+    },
+  } as unknown as CodeHookData;
+  return { data, created };
 }
 
 function makeExecutor(
-  result: Partial<{
-    success: boolean;
-    error: string;
-    apiCalls: Array<{ method: string; args: unknown[] }>;
-    logs: unknown[];
-  }> = {},
-) {
-  return {
-    execute: vi.fn().mockResolvedValue({
-      success: result.success ?? true,
-      error: result.error,
-      durationMs: 1,
-      apiCalls: result.apiCalls ?? [],
-      logs: result.logs ?? [],
-    }),
-  } as any;
+  result: Partial<
+    Pick<CodeExecutionResult, "success" | "error" | "apiCalls" | "logs">
+  > = {},
+): CodeExecutor & { execute: Mock<CodeExecutor["execute"]> } {
+  const execute = vi.fn<CodeExecutor["execute"]>().mockResolvedValue({
+    success: result.success ?? true,
+    error: result.error,
+    durationMs: 1,
+    apiCalls: result.apiCalls ?? [],
+    logs: result.logs ?? [],
+  });
+  return { execute };
 }
 
 const codeHook = {
@@ -142,15 +161,17 @@ describe("CodeHookDestination", () => {
 
   it("records a thrown executor as execution_threw and retries", async () => {
     const { data, created } = makeData([codeHook]);
-    const executor = {
-      execute: vi.fn().mockRejectedValue(new Error("executor exploded")),
-    } as any;
+    const executor: CodeExecutor = {
+      execute: vi
+        .fn<CodeExecutor["execute"]>()
+        .mockRejectedValue(new Error("executor exploded")),
+    };
     const dest = new CodeHookDestination(data, executor);
 
     await expect(dest.deliver([dest.transform(makeEvent())])).rejects.toThrow(
       /executor exploded/,
     );
     expect(created).toHaveLength(1);
-    expect(created[0].results[0].error.id).toBe("execution_threw");
+    expect(created[0].results[0].error?.id).toBe("execution_threw");
   });
 });

--- a/packages/authhero/test/routes/universal-login/post-user-registration-code-hook.spec.ts
+++ b/packages/authhero/test/routes/universal-login/post-user-registration-code-hook.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { testClient } from "hono/testing";
+import {
+  AuthorizationResponseType,
+  AuthorizationResponseMode,
+  CodeExecutor,
+} from "@authhero/adapter-interfaces";
+import { getTestServer } from "../../helpers/test-server";
+
+/**
+ * End-to-end wiring test for `CodeHookDestination` (issue #950).
+ *
+ * A `post-user-registration` **code hook** must run when a user registers via
+ * universal-login. Unlike the previous inline execution, it now runs from the
+ * outbox `hook.post-user-registration` event via `CodeHookDestination`, so it
+ * gets retries + dead-letter. This proves the destination is wired into the
+ * universal-login outbox middleware and driven by the relay.
+ */
+describe("universal-login post-user-registration code hook delivery", () => {
+  it("runs the post-user-registration code hook from the outbox on universal-login signup", async () => {
+    const executorCalls: Array<{
+      triggerId: string;
+      event: Record<string, unknown>;
+    }> = [];
+
+    const codeExecutor: CodeExecutor = {
+      async execute(params) {
+        executorCalls.push({
+          triggerId: params.triggerId,
+          event: params.event,
+        });
+        return { success: true, durationMs: 1, apiCalls: [], logs: [] };
+      },
+    };
+
+    const { universalApp, oauthApp, env, getSentEmails } = await getTestServer({
+      mockEmail: true,
+      outbox: true,
+      codeExecutor,
+    });
+
+    // Provision an action holding code + a hook binding it to the trigger.
+    const action = await env.data.actions.create("tenantId", {
+      name: "post-reg-action",
+      code: "exports.onExecutePostUserRegistration = async () => {};",
+    });
+    await env.data.hooks.create("tenantId", {
+      trigger_id: "post-user-registration",
+      enabled: true,
+      code_id: action.id,
+      synchronous: false,
+    });
+
+    const oauthClient = testClient(oauthApp, env);
+    const universalClient = testClient(universalApp, env);
+
+    const authorizeResponse = await oauthClient.authorize.$get({
+      query: {
+        client_id: "clientId",
+        redirect_uri: "https://example.com/callback",
+        state: "state",
+        nonce: "nonce",
+        scope: "openid email profile",
+        response_type: AuthorizationResponseType.CODE,
+        response_mode: AuthorizationResponseMode.QUERY,
+      },
+    });
+    expect(authorizeResponse.status).toBe(302);
+
+    const location = authorizeResponse.headers.get("location");
+    if (!location) throw new Error("No location header from /authorize");
+    const state = new URL(`https://example.com${location}`).searchParams.get(
+      "state",
+    );
+    if (!state) throw new Error("No state in universal-login redirect");
+
+    const newEmail = "code-hook-registrant@example.com";
+
+    const identifierPost = await universalClient.login.identifier.$post({
+      query: { state },
+      form: { username: newEmail },
+    });
+    expect(identifierPost.status).toBe(302);
+
+    const codeGet = await universalClient.login["email-otp-challenge"].$get({
+      query: { state },
+    });
+    expect(codeGet.status).toBe(200);
+
+    const otpEmail = getSentEmails().find((e) => e.to === newEmail);
+    if (!otpEmail?.data?.code) {
+      throw new Error(`No OTP email sent to ${newEmail}`);
+    }
+
+    const codePost = await universalClient.login["email-otp-challenge"].$post({
+      query: { state },
+      form: { code: otpEmail.data.code },
+    });
+    expect(codePost.status).toBe(302);
+
+    // The code hook ran via the outbox relay for the registration trigger.
+    const regCall = executorCalls.find(
+      (c) => c.triggerId === "post-user-registration",
+    );
+    expect(regCall).toBeDefined();
+    // The outbox event id is surfaced for at-least-once dedupe.
+    expect(typeof regCall!.event.idempotency_key).toBe("string");
+    // The registered user's email is carried in the event payload.
+    expect((regCall!.event.user as { email?: string })?.email).toBe(newEmail);
+
+    // The event must not have been dead-lettered.
+    const failed = await env.data.outbox!.listFailed("tenantId");
+    expect(
+      failed.events.find(
+        (e) => e.event_type === "hook.post-user-registration",
+      ),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #950.

## What

Post-user-registration and post-user-deletion **code hooks** (tenant-authored actions bound by `code_id`) used to run inline in the request — best-effort and at-most-once, so a throw was logged and dropped. They now run through a new `CodeHookDestination` from the `hook.*` outbox event, sharing the same retry + dead-letter machinery as webhooks. `post-user-deletion` code hooks now run at all (they previously didn't).

## How

- **Decouple the executor from `ctx`** — extract `executeCodeHook({ codeExecutor, data, tenantId, hook, event, triggerId, api, idempotencyKey })` in `codehooks.ts`; `handleCodeHook(ctx, …)` is now a thin wrapper. No synthetic `ctx` is needed: the serialized event strips `ctx` before it reaches user code, and post-* triggers expose an empty `api` (no token to mutate).
- **`CodeHookDestination`** — accepts `hook.*` events, runs each enabled matching code hook, persists the `action_executions` record, and throws if any hook failed so the relay retries. No-op when no `codeExecutor` is configured.
- **Wiring** — added after `WebhookDestination` and before `RegistrationFinalizerDestination` in all four `getDestinations(ctx)` sites (auth-api, both universal-login apps, management-api) **and** in `createDefaultDestinations` / `runOutboxRelay` (the cron drain — otherwise retries would silently skip code hooks). Removed the inline post-registration code-hook loop.
- Exported `CodeHookDestination` from the package root.

## Behavior change (see changeset)

Delivery for these two triggers is now **at-least-once** rather than at-most-once. A retried event re-runs every code hook for the trigger, so the outbox event id is passed to user code as `event.idempotency_key` for dedupe — matching Auth0 Actions and the existing self-healing contract. Two secondary effects: code hooks now observe the post-`account-linking` user, and the synchronous signup log no longer carries the `action_execution_id` (the record is created async). Token-mutating triggers (`post-user-login`, `credentials-exchange`) are unaffected — they still run inline.

## Tests

- 6 unit tests for `CodeHookDestination` (accepts/skip filtering, no-op without executor, success + persistence, failure→retry-with-persistence, thrown executor).
- 1 end-to-end universal-login signup test proving the executor is driven via the relay with `idempotency_key` and no dead-letter.
- Full package suite: **1748 passed, 1 skipped**; `tsc --noEmit` clean.

## Docs

Updated `architecture/hooks-pipeline.md`, `features/hooks.md`, `features/user-creation-flow.md`, and `deployment/outbox-cron.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `post-user-registration` and `post-user-deletion` code hooks now run through the outbox, with retry and dead-letter handling.
  * Outbox-driven code hook delivery now supports idempotency keys for safer replays.
  * `post-user-deletion` code hooks are now executed.

* **Bug Fixes**
  * Failed code-hook deliveries are now surfaced through failure endpoints instead of being silently dropped.
  * Cron-based outbox draining now includes code-hook execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->