### PR TITLE
feat(outbox): emit hook.post-user-update event on user update (#1086)

### DIFF
--- a/.changeset/post-user-update-outbox-event.md
+++ b/.changeset/post-user-update-outbox-event.md
@@ -1,0 +1,9 @@
+---
+"authhero": minor
+---
+
+Emit a `hook.post-user-update` outbox event when a user is updated (#1086).
+
+Webhook and code-hook consumers previously received `post-user-registration` and `post-user-deletion` events but got no notification when a user was updated. `createUserUpdateHooks` now builds a `post-user-update` event and passes it into the `data.users.update(..., { outboxEvents })` call so it commits atomically with the update (using the `WriteOptions.outboxEvents` plumbing added in #1057), then relays it for durable delivery after the commit — falling back to inline webhook dispatch when the outbox isn't configured.
+
+The event describes the row this update commits (`{ ...user, ...updates }`, reflecting any pre-update hook mutations to `updates`), consistent with the #1057 payload decision. The recursion-avoiding `linked_to`-only fast path and post-update template-hook side effects do not emit this event; account-linking can emit its own.

--- a/packages/authhero/src/hooks/user-update.ts
+++ b/packages/authhero/src/hooks/user-update.ts
@@ -13,6 +13,11 @@ import { stripInternalUserFields } from "../helpers/hook-user-payload";
 import { isTemplateHook, handleTemplateHook } from "./templatehooks";
 import { builtInUserLinkingEnabled } from "../helpers/user-linking";
 import { compareUsersByAge, repointPrimary } from "../helpers/users";
+import {
+  buildPostHookEvent,
+  relayOutboxEvent,
+  dispatchPostHookInline,
+} from "../helpers/hook-events";
 
 /**
  * Decorator applied by `addDataHooks` to `users.update`. Fires pre-update
@@ -107,10 +112,29 @@ export function createUserUpdateHooks(
       ctx.var.client_id,
     );
 
+    // Build the post-user-update outbox event up front (with a fixed id) so it
+    // can be written atomically with the update inside the transaction below
+    // (issue #1086, building on the #1057 plumbing). Per the #1057 decision the
+    // event describes the row this update commits — `{ ...user, ...updates }`,
+    // which already reflects any `updates` mutations made by pre-update hooks —
+    // not the result of in-transaction account-linking or post-update template
+    // hooks (those repoint `linked_to` / run their own writes and can emit
+    // their own events). `undefined` when the outbox isn't configured; the
+    // inline fallback after the commit runs instead.
+    const updateEvent = buildPostHookEvent(ctx, tenant_id, "post-user-update", {
+      ...user,
+      ...updates,
+    });
+
     // Wrap the update and potential account linking in a transaction
     await data.transaction(async (trxData) => {
-      // If we get here, proceed with the update
-      const updated = await trxData.users.update(tenant_id, user_id, updates);
+      // If we get here, proceed with the update. The outbox event commits in
+      // the same atomic unit as the user row (drizzle appends it to the update
+      // `runAtomic` batch; kysely inserts it in the update transaction) so it
+      // can never be dropped on a crash between the two writes.
+      const updated = await trxData.users.update(tenant_id, user_id, updates, {
+        outboxEvents: updateEvent ? [updateEvent] : undefined,
+      });
       if (!updated) {
         throw new JSONHTTPException(404, {
           message: "User not found",
@@ -215,6 +239,20 @@ export function createUserUpdateHooks(
         }
       }
     });
+
+    // The update committed. Relay the post-user-update event so the outbox
+    // middleware delivers it (WebhookDestination + CodeHookDestination) with
+    // retries / dead-letter. The event row was already persisted atomically
+    // with the update above; here we only push its id. When the outbox isn't
+    // configured, fall back to inline webhook dispatch (no retries).
+    if (updateEvent) {
+      relayOutboxEvent(ctx, updateEvent.id);
+    } else {
+      dispatchPostHookInline(ctx, tenant_id, "post-user-update", {
+        ...user,
+        ...updates,
+      });
+    }
 
     // Template hooks at `post-user-update` run after the transaction commits.
     // The `account-linking` template uses ctx-bound adapters for its own

--- a/packages/authhero/test/hooks/post-user-update-webhook.spec.ts
+++ b/packages/authhero/test/hooks/post-user-update-webhook.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach } from "vitest";
+import http from "node:http";
+import { testClient } from "hono/testing";
+import { Strategy, User } from "@authhero/adapter-interfaces";
+import { getTestServer } from "../helpers/test-server";
+import { getAdminToken } from "../helpers/token";
+
+/**
+ * End-to-end coverage for issue #1086: a user update must emit a
+ * `hook.post-user-update` outbox event and deliver it to webhooks registered
+ * for the `post-user-update` trigger — mirroring the existing
+ * post-user-registration / post-user-deletion webhook delivery.
+ */
+
+function createWebhookServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () => new Promise<void>((res) => server.close(() => res())),
+      });
+    });
+  });
+}
+
+describe("post-user-update webhook delivery", () => {
+  let closeServer: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (closeServer) {
+      await closeServer();
+      closeServer = undefined;
+    }
+  });
+
+  it("delivers a post-user-update webhook with the committed user when a user is updated", async () => {
+    const webhookCalls: Array<{ trigger_id: string; user: User }> = [];
+
+    const { url, close } = await createWebhookServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        try {
+          webhookCalls.push(JSON.parse(body));
+        } catch {
+          // ignore parse errors
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    closeServer = close;
+
+    const { env, managementApp } = await getTestServer({ outbox: true });
+    const client = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    await env.data.hooks.create("tenantId", {
+      url,
+      trigger_id: "post-user-update",
+      enabled: true,
+      synchronous: false,
+    });
+
+    const createUserResponse = await client.users.$post(
+      {
+        json: {
+          email: "post-update-webhook@example.com",
+          connection: Strategy.USERNAME_PASSWORD,
+        },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(createUserResponse.status).toBe(201);
+    const createdUser = await createUserResponse.json();
+
+    const updateUserResponse = await client.users[":user_id"].$patch(
+      {
+        json: { given_name: "Updated Name" },
+        header: { "tenant-id": "tenantId" },
+        param: { user_id: createdUser.user_id },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(updateUserResponse.status).toBe(200);
+
+    // The webhook received the update event with the persisted change.
+    const updateCall = webhookCalls.find(
+      (c) => c.trigger_id === "post-user-update",
+    );
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.user.user_id).toBe(createdUser.user_id);
+    expect(updateCall?.user.given_name).toBe("Updated Name");
+
+    // The event was delivered, not dead-lettered.
+    const failed = await env.data.outbox!.listFailed("tenantId");
+    const deadLettered = failed.events.find(
+      (e) => e.event_type === "hook.post-user-update",
+    );
+    expect(deadLettered).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1086.

Webhook and code-hook consumers received `post-user-registration` and `post-user-deletion` events but got **no** notification when a user was updated. Separately, the atomic `update` outbox plumbing added in #1057 (`WriteOptions.outboxEvents` threaded through `data.users.update`) was landed but **unexercised** — no call site passed events to `update`. This wires the emitter.

## Changes

- **`createUserUpdateHooks`** ([user-update.ts](packages/authhero/src/hooks/user-update.ts)) now:
  - Builds a `hook.post-user-update` event (via the existing `buildPostHookEvent`) from the committed row — `{ ...user, ...updates }`, which already reflects any `updates` mutations made by pre-update hooks.
  - Passes it into `trxData.users.update(..., { outboxEvents })` inside the transaction, so the user row and its event commit in a **single atomic unit** (drizzle appends to its `runAtomic` batch; kysely inserts inside the update transaction).
  - Relays the event after the commit via `relayOutboxEvent` for durable, retryable delivery — falling back to `dispatchPostHookInline` when the outbox isn't configured.

## Design decisions (raised in the issue)

- **Payload semantics:** the event describes the row this update commits, consistent with the #1057 decision for registration/deletion — not the result of in-transaction account-linking or post-update template hooks.
- **`linked_to`-only fast path:** does **not** emit an event (the recursion-avoiding early `return` runs before the event is built).
- **Template-hook side effects:** do not emit this event; account-linking can emit its own.
- **Dispatch path:** verified `WebhookDestination` / `CodeHookDestination` already accept any `hook.*` event and filter by the derived `trigger_id`, so `post-user-update` dispatches generically — no changes needed there.

## Tests

- New e2e test [post-user-update-webhook.spec.ts](packages/authhero/test/hooks/post-user-update-webhook.spec.ts): create → PATCH user → a real HTTP webhook registered for `post-user-update` receives the event with the committed change, and the event is not dead-lettered.
- Full hooks + outbox suites pass (189 tests), clean `tsc`.

Adapter-level atomicity for `update` is already covered by #1057's tests; this PR wires the emitter in `authhero`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)