### PR TITLE
fix(admin): add search/filter/columns toolbar to permissions tabs

### DIFF
--- a/apps/admin/src/resources/roles/tabs/permissions-tab.tsx
+++ b/apps/admin/src/resources/roles/tabs/permissions-tab.tsx
@@ -1,13 +1,15 @@
+import type { FormHTMLAttributes } from "react";
 import { useEffect, useState } from "react";
 import type { RaRecord } from "ra-core";
 import {
+  FilterLiveForm,
   useDataProvider,
   useNotify,
   useRecordContext,
   useRefresh,
 } from "ra-core";
 import { useParams } from "react-router-dom";
-import { Plus, Trash2 } from "lucide-react";
+import { Filter, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -26,9 +28,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  ColumnsButton,
   DataTable,
   ListPagination,
   ReferenceManyField,
+  SearchInput,
   TextField,
 } from "@/components/admin";
 import { DateAgo } from "@/common/DateAgo";
@@ -370,6 +374,40 @@ function AssignedCell() {
   return <DateAgo date={record.created_at} />;
 }
 
+const SearchFormComponent = (props: FormHTMLAttributes<HTMLFormElement>) => (
+  <form {...props} className="flex w-full" />
+);
+
+/**
+ * Mirrors the toolbar rendered by <List> (search + filters + columns), which a
+ * bare <ReferenceManyField> does not provide. Rendered inside the field so it
+ * shares its ListContext (search) and resource context (columns store key).
+ */
+function PermissionsToolbar() {
+  return (
+    <div className="flex items-center gap-2 my-2">
+      <div className="flex w-full max-w-sm">
+        <FilterLiveForm formComponent={SearchFormComponent}>
+          <SearchInput source="q" className="flex-grow" />
+        </FilterLiveForm>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        disabled
+        className="cursor-not-allowed opacity-60"
+        title="No filters configured"
+      >
+        <Filter className="h-4 w-4" />
+        Add filter
+      </Button>
+      <div className="ml-auto">
+        <ColumnsButton />
+      </div>
+    </div>
+  );
+}
+
 export function PermissionsTab() {
   const record = useRecordContext<{ id?: string }>();
   if (!record?.id) return null;
@@ -390,6 +428,7 @@ export function PermissionsTab() {
           </p>
         }
       >
+        <PermissionsToolbar />
         <DataTable rowClick={false} bulkActionButtons={false}>
           <DataTable.Col
             source="resource_server_identifier"

--- a/apps/admin/src/resources/users/tabs/permissions-tab.tsx
+++ b/apps/admin/src/resources/users/tabs/permissions-tab.tsx
@@ -1,6 +1,8 @@
+import type { FormHTMLAttributes } from "react";
 import { useEffect, useState } from "react";
 import type { RaRecord } from "ra-core";
 import {
+  FilterLiveForm,
   useDataProvider,
   useGetOne,
   useNotify,
@@ -8,7 +10,7 @@ import {
   useRefresh,
 } from "ra-core";
 import { useParams } from "react-router-dom";
-import { Plus, Trash2 } from "lucide-react";
+import { Filter, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -27,9 +29,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  ColumnsButton,
   DataTable,
   ListPagination,
   ReferenceManyField,
+  SearchInput,
   TextField,
 } from "@/components/admin";
 import { DateAgo } from "@/common/DateAgo";
@@ -453,6 +457,40 @@ function OrganizationCell() {
   return <>{data?.display_name || data?.name || orgId}</>;
 }
 
+const SearchFormComponent = (props: FormHTMLAttributes<HTMLFormElement>) => (
+  <form {...props} className="flex w-full" />
+);
+
+/**
+ * Mirrors the toolbar rendered by <List> (search + filters + columns), which a
+ * bare <ReferenceManyField> does not provide. Rendered inside the field so it
+ * shares its ListContext (search) and resource context (columns store key).
+ */
+function PermissionsToolbar() {
+  return (
+    <div className="flex items-center gap-2 my-2">
+      <div className="flex w-full max-w-sm">
+        <FilterLiveForm formComponent={SearchFormComponent}>
+          <SearchInput source="q" className="flex-grow" />
+        </FilterLiveForm>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        disabled
+        className="cursor-not-allowed opacity-60"
+        title="No filters configured"
+      >
+        <Filter className="h-4 w-4" />
+        Add filter
+      </Button>
+      <div className="ml-auto">
+        <ColumnsButton />
+      </div>
+    </div>
+  );
+}
+
 export function PermissionsTab() {
   return (
     <div className="flex flex-col gap-4">
@@ -470,6 +508,7 @@ export function PermissionsTab() {
           </p>
         }
       >
+        <PermissionsToolbar />
         <DataTable rowClick={false} bulkActionButtons={false}>
           <DataTable.Col
             source="resource_server_identifier"


### PR DESCRIPTION
## Problem

The **Permissions** tab on both the Role show page and the User show page was missing the search box, **Add filter** button, and **Columns** button that every standard list view displays.

Root cause: these tabs render a bare `ReferenceManyField` + `DataTable` and bypass the `<List>` wrapper. The toolbar (search / filters / columns) is drawn by `<List>`'s `ListToolbar`, so skipping `<List>` means no toolbar.

## Fix

Add a `PermissionsToolbar` inside each `ReferenceManyField`, mirroring the vendored `ListToolbar` markup:

- **Search** — `SearchInput source="q"` in a `FilterLiveForm` (works via the field's `ListContext`)
- **Add filter** — the disabled placeholder shown by standard lists when no toggleable filters are configured
- **Columns** — `ColumnsButton`, whose store key (`permissions.datatable`) matches the `DataTable`'s, so show/hide/reorder works

The toolbar lives in the app-side tab files, not the vendored `components/admin/list.tsx`, per the admin `CLAUDE.md` convention. Follows the existing precedent in `resource-servers/tabs/scopes-tab.tsx` (which added search the same way).

## Files
- `apps/admin/src/resources/roles/tabs/permissions-tab.tsx`
- `apps/admin/src/resources/users/tabs/permissions-tab.tsx`

No changeset — `apps/admin` is not a versioned/published package. `pnpm --filter admin exec tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search and column visibility controls to permissions tables in the admin interface.
  * Added an “Add filter” control placeholder to align permissions tables with the standard list toolbar experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->