### PR TITLE
fix(org): match admin:organizations bypass against Management API audience

### DIFF
--- a/.changeset/org-admin-bypass-management-audience.md
+++ b/.changeset/org-admin-bypass-management-audience.md
@@ -1,0 +1,13 @@
+---
+"authhero": patch
+---
+
+Fix organization token issuance for global admins. The `admin:organizations`
+membership bypass now matches the permission against the Management API audience
+(`urn:authhero:management`) instead of the requested token's audience. Previously
+a user with a global `admin:organizations` role was rejected with `403 access_denied`
+("User is not a member of the specified organization") whenever the requested token
+targeted an app resource server (e.g. `urn:sesamy`), because the permission was only
+recognised when it happened to be registered on that same app audience. Applies to
+the refresh_token grant, the token-exchange grant, and the shared scope/permission
+calculation used across token flows.

--- a/.changeset/refresh-token-failure-log-enrichment.md
+++ b/.changeset/refresh-token-failure-log-enrichment.md
@@ -1,0 +1,11 @@
+---
+"authhero": patch
+---
+
+Enrich failed `refresh_token` exchange logs (`fertft`) with the same identifying
+fields the successful exchange records. When a refresh token is rejected because
+it was revoked, expired, reused, or presented to the wrong client, the log now
+carries `audience` and `scope` (from the token's resource server) plus
+`connection`, `connection_id`, `strategy`, and `strategy_type` (from the login
+session it was minted against), instead of leaving them blank. The extra
+login-session read only happens on the error path.

--- a/packages/authhero/src/authentication-flows/refresh-token.ts
+++ b/packages/authhero/src/authentication-flows/refresh-token.ts
@@ -10,6 +10,7 @@ import { z } from "@hono/zod-openapi";
 import { safeCompare } from "../utils/safe-compare";
 import { appendLog } from "../utils/append-log";
 import { getEnrichedClient } from "../helpers/client";
+import { MANAGEMENT_API_AUDIENCE } from "../middlewares/authentication";
 import { ssrfFetchOptionsFromEnv } from "../utils/ssrf-fetch";
 import { logMessage } from "../helpers/logging";
 import {
@@ -86,6 +87,32 @@ export async function refreshTokenGrant(
     );
   }
 
+  // The failure logs below fire before the login-session/user lookup further
+  // down, so on their own they'd omit the audience/scope/connection/strategy
+  // that the success log (token.ts) records — leaving a failed exchange less
+  // traceable than a successful one. Resolve those same fields from the token
+  // row (audience/scope) and the login session it was minted against
+  // (connection/strategy). Only the single failing branch runs, so this costs
+  // at most one extra keyed read, and only on the error path.
+  const resolveFailureLogFields = async () => {
+    if (!refreshToken) return {};
+    const resourceServer = refreshToken.resource_servers[0];
+    const loginSession = refreshToken.login_id
+      ? await ctx.env.data.loginSessions.get(
+          client.tenant.id,
+          refreshToken.login_id,
+        )
+      : undefined;
+    return {
+      userId: refreshToken.user_id,
+      audience: resourceServer?.audience,
+      scope: resourceServer?.scopes,
+      connection: loginSession?.auth_connection,
+      strategy: loginSession?.auth_strategy?.strategy,
+      strategy_type: loginSession?.auth_strategy?.strategy_type,
+    };
+  };
+
   if (!refreshToken) {
     // No local row matches the presented token. Try the tenant's configured
     // migration sources (#833): redeem the RT upstream, learn the user via
@@ -112,7 +139,7 @@ export async function refreshTokenGrant(
     logMessage(ctx, client.tenant.id, {
       type: LogTypes.FAILED_EXCHANGE_REFRESH_TOKEN_FOR_ACCESS_TOKEN,
       description: "Refresh token was not issued to this client",
-      userId: refreshToken.user_id,
+      ...(await resolveFailureLogFields()),
     });
     throw new JSONHTTPException(invalidGrantStatus, {
       error: "invalid_grant",
@@ -123,7 +150,7 @@ export async function refreshTokenGrant(
     logMessage(ctx, client.tenant.id, {
       type: LogTypes.FAILED_EXCHANGE_REFRESH_TOKEN_FOR_ACCESS_TOKEN,
       description: "Refresh token has been revoked",
-      userId: refreshToken.user_id,
+      ...(await resolveFailureLogFields()),
     });
     throw new JSONHTTPException(invalidGrantStatus, {
       error: "invalid_grant",
@@ -139,7 +166,7 @@ export async function refreshTokenGrant(
     logMessage(ctx, client.tenant.id, {
       type: LogTypes.FAILED_EXCHANGE_REFRESH_TOKEN_FOR_ACCESS_TOKEN,
       description: "Refresh token has expired",
-      userId: refreshToken.user_id,
+      ...(await resolveFailureLogFields()),
     });
     throw new JSONHTTPException(invalidGrantStatus, {
       error: "invalid_grant",
@@ -166,7 +193,7 @@ export async function refreshTokenGrant(
       logMessage(ctx, client.tenant.id, {
         type: LogTypes.FAILED_EXCHANGE_REFRESH_TOKEN_FOR_ACCESS_TOKEN,
         description: "Refresh token reuse detected; family revoked",
-        userId: refreshToken.user_id,
+        ...(await resolveFailureLogFields()),
       });
       throw new JSONHTTPException(invalidGrantStatus, {
         error: "invalid_grant",
@@ -222,14 +249,14 @@ export async function refreshTokenGrant(
       });
     }
 
-    // Check if user has global admin:organizations permission (bypasses membership check)
+    // Check if user has the global `admin:organizations` permission, which
+    // bypasses the membership check. This is a management-plane permission, so
+    // it is always matched against the Management API audience — never against
+    // the requested token's audience (which may be an app resource server).
     let hasGlobalOrgAdminPermission = false;
     const currentTenant = await ctx.env.data.tenants.get(client.tenant.id);
 
-    if (
-      currentTenant?.flags?.inherit_global_permissions_in_organizations &&
-      resourceServer?.audience
-    ) {
+    if (currentTenant?.flags?.inherit_global_permissions_in_organizations) {
       // Check direct user permissions at tenant level
       const globalUserPermissions = await ctx.env.data.userPermissions.list(
         client.tenant.id,
@@ -241,7 +268,7 @@ export async function refreshTokenGrant(
       hasGlobalOrgAdminPermission = globalUserPermissions.some(
         (permission) =>
           permission.permission_name === "admin:organizations" &&
-          permission.resource_server_identifier === resourceServer.audience,
+          permission.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
       );
 
       // Check role-derived permissions at tenant level
@@ -263,7 +290,7 @@ export async function refreshTokenGrant(
           const hasAdminOrg = rolePermissions.some(
             (permission) =>
               permission.permission_name === "admin:organizations" &&
-              permission.resource_server_identifier === resourceServer.audience,
+              permission.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
           );
 
           if (hasAdminOrg) {

--- a/packages/authhero/src/authentication-flows/token-exchange.ts
+++ b/packages/authhero/src/authentication-flows/token-exchange.ts
@@ -5,6 +5,7 @@ import { JSONHTTPException } from "../errors/json-http-exception";
 import { Bindings, Variables, GrantFlowUserResult } from "../types";
 import { safeCompare } from "../utils/safe-compare";
 import { getEnrichedClient } from "../helpers/client";
+import { MANAGEMENT_API_AUDIENCE } from "../middlewares/authentication";
 import { logMessage } from "../helpers/logging";
 import { JwtExpiredError, validateJwtToken, type JwtPayload } from "../utils/jwt";
 import { getIssuer } from "../variables";
@@ -235,8 +236,10 @@ export async function tokenExchangeGrant(
   }
 
   // Authorize the org switch. Mirrors the refresh-token grant: bypass when
-  // the user has the global `admin:organizations` permission on this
-  // resource server (gated by tenant flag); otherwise require membership.
+  // the user has the global `admin:organizations` permission on the Management
+  // API (gated by tenant flag); otherwise require membership. This is a
+  // management-plane permission, so it is matched against the Management API
+  // audience, never the requested token's audience.
   let hasGlobalOrgAdminPermission = false;
   const tenant = await ctx.env.data.tenants.get(client.tenant.id);
   if (tenant?.flags?.inherit_global_permissions_in_organizations) {
@@ -249,7 +252,7 @@ export async function tokenExchangeGrant(
     hasGlobalOrgAdminPermission = globalUserPermissions.some(
       (p) =>
         p.permission_name === "admin:organizations" &&
-        p.resource_server_identifier === resourceServer.identifier,
+        p.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
     );
 
     if (!hasGlobalOrgAdminPermission) {
@@ -268,7 +271,7 @@ export async function tokenExchangeGrant(
         const hasAdminOrg = rolePermissions.some(
           (p) =>
             p.permission_name === "admin:organizations" &&
-            p.resource_server_identifier === resourceServer.identifier,
+            p.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
         );
         if (hasAdminOrg) {
           hasGlobalOrgAdminPermission = true;

--- a/packages/authhero/src/helpers/scopes-permissions.ts
+++ b/packages/authhero/src/helpers/scopes-permissions.ts
@@ -2,6 +2,7 @@ import { Context } from "hono";
 import { ResourceServer, GrantType } from "@authhero/adapter-interfaces";
 import { Bindings, Variables } from "../types";
 import { JSONHTTPException } from "../errors/json-http-exception";
+import { MANAGEMENT_API_AUDIENCE } from "../middlewares/authentication";
 
 // Base interface with common properties
 interface BaseScopesAndPermissionsParams {
@@ -333,10 +334,12 @@ export async function calculateScopesAndPermissions(
           { per_page: 1000 },
         );
 
+        // admin:organizations is a management-plane permission: match it against
+        // the Management API audience, never the requested token's audience.
         const hasAdminOrg = rolePermissions.some(
           (permission) =>
             permission.permission_name === "admin:organizations" &&
-            permission.resource_server_identifier === audience,
+            permission.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
         );
 
         if (hasAdminOrg) {

--- a/packages/authhero/test/helpers/scopes-permissions.spec.ts
+++ b/packages/authhero/test/helpers/scopes-permissions.spec.ts
@@ -1165,11 +1165,13 @@ describe("scopes-permissions helper", () => {
           description: "Can manage all organizations",
         });
 
-        // Assign the admin:organizations and read:users permissions to the role
+        // admin:organizations is a management-plane permission and drives the
+        // membership bypass, so it lives on the Management API audience. The
+        // app permission (read:users) is what actually lands in the app token.
         await env.data.rolePermissions.assign("tenantId", adminRole.id, [
           {
             role_id: adminRole.id,
-            resource_server_identifier: "https://admin-test-api.example.com",
+            resource_server_identifier: "urn:authhero:management",
             permission_name: "admin:organizations",
           },
           {
@@ -1205,15 +1207,11 @@ describe("scopes-permissions helper", () => {
           organizationId: organization.id,
         });
 
-        expect(result).toEqual(
-          expect.objectContaining({
-            scopes: [],
-            permissions: expect.arrayContaining([
-              "admin:organizations",
-              "read:users",
-            ]),
-          }),
-        );
+        // Membership is bypassed and the inherited app permission is granted.
+        // admin:organizations is a Management API permission and must NOT leak
+        // into the app-audience token.
+        expect(result.permissions).toContain("read:users");
+        expect(result.permissions).not.toContain("admin:organizations");
 
         // Clean up
         await env.data.resourceServers.remove("tenantId", resourceServer.id!);
@@ -1270,12 +1268,13 @@ describe("scopes-permissions helper", () => {
           description: "Can admin orgs but only read users",
         });
 
-        // Only assign read:users and admin:organizations (NOT write:users or delete:users)
+        // admin:organizations (management-plane) drives the bypass and lives on
+        // the Management API. Only read:users is a held app permission — NOT
+        // write:users or delete:users.
         await env.data.rolePermissions.assign("tenantId", limitedRole.id, [
           {
             role_id: limitedRole.id,
-            resource_server_identifier:
-              "https://permission-check-api.example.com",
+            resource_server_identifier: "urn:authhero:management",
             permission_name: "admin:organizations",
           },
           {
@@ -1316,9 +1315,10 @@ describe("scopes-permissions helper", () => {
           organizationId: organization.id,
         });
 
-        // Should only get the permissions they actually have
+        // Should only get the app permissions they actually have. The
+        // management-plane admin:organizations must NOT leak into the app token.
         expect(result.permissions).toContain("read:users");
-        expect(result.permissions).toContain("admin:organizations");
+        expect(result.permissions).not.toContain("admin:organizations");
         expect(result.permissions).not.toContain("write:users");
         expect(result.permissions).not.toContain("delete:users");
 

--- a/packages/authhero/test/routes/auth-api/token.spec.ts
+++ b/packages/authhero/test/routes/auth-api/token.spec.ts
@@ -2566,10 +2566,13 @@ describe("token", () => {
         description: "Can manage all organizations",
       });
 
+      // admin:organizations is a management-plane permission: the membership
+      // bypass matches it against the Management API audience, never the
+      // requested token's (app) audience.
       await env.data.rolePermissions.assign("tenantId", adminRole.id, [
         {
           role_id: adminRole.id,
-          resource_server_identifier: audience,
+          resource_server_identifier: "urn:authhero:management",
           permission_name: "admin:organizations",
         },
       ]);
@@ -2647,6 +2650,133 @@ describe("token", () => {
       // Verify the token has the correct org_id
       const payload = parseJWT(body.access_token)?.payload as any;
       expect(payload.org_id).toBe(organization.id);
+
+      // Clean up
+      await env.data.tenants.update("tenantId", { flags: {} });
+      await env.data.resourceServers.remove("tenantId", resourceServer.id!);
+      await env.data.users.remove("tenantId", user.user_id);
+      await env.data.organizations.remove("tenantId", organization.id);
+    });
+
+    it("should NOT bypass membership when admin:organizations is on an app audience instead of the Management API", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const client = testClient(oauthApp, env);
+
+      const audience = "https://app-scoped-admin-api.example.com";
+
+      const resourceServer = await env.data.resourceServers.create("tenantId", {
+        name: "App Scoped Admin API",
+        identifier: audience,
+        scopes: [
+          { value: "admin:organizations", description: "Manage organizations" },
+          { value: "read:users", description: "Read users" },
+        ],
+        options: {
+          enforce_policies: true,
+          token_dialect: "access_token_authz",
+        },
+      });
+
+      const organization = await env.data.organizations.create("tenantId", {
+        name: "app-scoped-org",
+        display_name: "App Scoped Org",
+      });
+
+      const user = await env.data.users.create("tenantId", {
+        user_id: "email|app-scoped-admin-user",
+        email: "app-scoped-admin@example.com",
+        provider: "email",
+        connection: "email",
+        email_verified: true,
+        is_social: false,
+      });
+
+      const adminRole = await env.data.roles.create("tenantId", {
+        name: "App Scoped Org Admin",
+        description: "admin:organizations on an app audience only",
+      });
+
+      // admin:organizations granted on the APP audience — not the Management
+      // API. This must NOT authorize the org switch.
+      await env.data.rolePermissions.assign("tenantId", adminRole.id, [
+        {
+          role_id: adminRole.id,
+          resource_server_identifier: audience,
+          permission_name: "admin:organizations",
+        },
+      ]);
+
+      await env.data.userRoles.create(
+        "tenantId",
+        user.user_id,
+        adminRole.id,
+        "", // Global role (no organization)
+      );
+
+      await env.data.tenants.update("tenantId", {
+        flags: {
+          inherit_global_permissions_in_organizations: true,
+        },
+      });
+
+      const loginSession = await env.data.loginSessions.create("tenantId", {
+        expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+        csrf_token: "csrfToken",
+        authParams: {
+          client_id: "clientId",
+          redirect_uri: "https://example.com/callback",
+        },
+      });
+
+      const idle_expires_at = new Date(
+        Date.now() + 1000 * 60 * 60,
+      ).toISOString();
+
+      await env.data.refreshTokens.create("tenantId", {
+        id: "refreshTokenAppScopedAdmin",
+        login_id: loginSession.id,
+        user_id: user.user_id,
+        client_id: "clientId",
+        resource_servers: [
+          {
+            audience,
+            scopes: "admin:organizations read:users",
+          },
+        ],
+        device: {
+          last_ip: "",
+          initial_ip: "",
+          last_user_agent: "",
+          initial_user_agent: "",
+          initial_asn: "",
+          last_asn: "",
+        },
+        rotating: false,
+        idle_expires_at,
+        expires_at: idle_expires_at,
+      });
+
+      const response = await client.oauth.token.$post(
+        // @ts-expect-error - testClient type requires both form and json
+        {
+          form: {
+            grant_type: "refresh_token",
+            refresh_token: "refreshTokenAppScopedAdmin",
+            client_id: "clientId",
+            organization: organization.id,
+          },
+        },
+        { headers: { "tenant-id": "tenantId" } },
+      );
+
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as {
+        error: string;
+        error_description: string;
+      };
+      expect(body.error_description).toBe(
+        "User is not a member of the specified organization",
+      );
 
       // Clean up
       await env.data.tenants.update("tenantId", { flags: {} });


### PR DESCRIPTION
Fixes #1090.

## Problem

A user with a **global** (tenant-level) role granting `admin:organizations` was denied when requesting an organization-scoped token for an **app audience** (e.g. `urn:sesamy`), even with `inherit_global_permissions_in_organizations` enabled:

```
403 access_denied — "User is not a member of the specified organization"
```

`admin:organizations` is an authhero-reserved, management-plane permission, always seeded onto the Management API resource server (`urn:authhero:management`). But the membership bypass matched it against the **requested token's** audience. When the token targets an app resource server, `permission.resource_server_identifier === <requested audience>` can never be true, so the bypass never fired and membership was required. "Is this user a global org admin?" is a question about the Management API and is independent of which app audience the token is for.

## Fix

Match the `admin:organizations` permission against `MANAGEMENT_API_AUDIENCE` (`urn:authhero:management`) instead of the requested token's audience, in all three places that implement the bypass:

- `authentication-flows/refresh-token.ts` (also simplifies the outer guard to gate on the tenant flag only, matching token-exchange)
- `authentication-flows/token-exchange.ts`
- `helpers/scopes-permissions.ts` — the shared `calculateScopesAndPermissions`, reached during token minting; this is why fixing the grant handler alone wasn't enough end-to-end

## Notes

- General authhero fix, not deployment-specific — affects any install using the global-org-admin feature with app-audience org tokens.
- No adapter/DB changes; purely the authorization gate.
- Permission **inheritance** into the app token stays filtered by the requested audience, so management permissions still never leak into an app-audience token.
- Behavior change: deployments that worked around this by registering `admin:organizations` on an *app* resource server must instead have it on `urn:authhero:management` — which is how authhero seeds it by default.
- The interactive-login membership checks in `common.ts` (`completeLogin`) and the no-audience branch in `silent.ts` have **no** bypass at all (pre-existing); left as-is to avoid changing interactive-flow behavior. Worth a follow-up if global admins should also bypass there.

## Tests

- Updated the refresh_token positive test to register `admin:organizations` on the Management API.
- Added a negative test: an app-audience `admin:organizations` no longer bypasses membership (403).
- Updated the two `scopes-permissions` inheritance tests to the corrected model and assert the management permission does not leak into the app token.
- `tsc --noEmit` clean; token, token-exchange, scopes-permissions, org-membership-bypass, connect-consent, and silent specs all pass.

---

## Also in this PR: refresh-token failure-log enrichment

Failed `refresh_token` exchange logs (`fertft`) were missing the identifying fields that the *successful* exchange records — a revoked/expired/reused token produced a log with empty `connection`, `connection_id`, `audience`, `scope`, `strategy`, and `strategy_type`.

**Fix** (`authentication-flows/refresh-token.ts`): a `resolveFailureLogFields()` helper populates those fields from data already implied by the token — `audience`/`scope` from the token's resource server, and `connection`/`strategy`/`strategy_type` from the login session it was minted against (`connection_id` is then auto-resolved by `logMessage`). Applied to all four failure branches (client mismatch, revoked, expired, reuse-detected). The extra login-session read only happens on the error path, and exactly one branch throws, so it's at most one extra keyed read.

- `tsc --noEmit` clean; legacy `token.spec.ts` passes (66/66).
- Separate changeset (`refresh-token-failure-log-enrichment.md`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)