### PR TITLE
feat(proxy): createServiceBindingFetch loop-fix for proxy-at-edge (#1079)

### DIFF
--- a/.changeset/proxy-service-binding-fetch.md
+++ b/.changeset/proxy-service-binding-fetch.md
@@ -1,0 +1,9 @@
+---
+"@authhero/proxy": minor
+---
+
+Add `createServiceBindingFetch` to route the HTTP proxy adapter's control-plane calls through a Cloudflare service binding instead of the public edge (#1079).
+
+When a proxy-at-edge deployment fronts the same wildcard zone its control plane resolves on (e.g. the proxy owns `*.token.example.com/*` while `CONTROL_PLANE_URL` points at a host under that wildcard), resolving the control plane over the public edge loops the adapter's `/oauth/token` and `resolveHost` calls back into the proxy — a self-DoS. `createServiceBindingFetch(env.AUTH2)` wraps a service binding as the `fetch` override on `createHttpProxyAdapter`, so those calls reach the control-plane Worker directly and the loop cannot form regardless of `baseUrl`.
+
+The `fetch` override already existed; this exports an ergonomic, documented helper for it and adds the proxy-at-edge cutover runbook to the deployment docs.

--- a/apps/docs/customization/proxy/deployment.md
+++ b/apps/docs/customization/proxy/deployment.md
@@ -355,6 +355,124 @@ HTTP fallback entirely (resolve straight from `kv`) and retire the
 
 This is the "proxy as dispatch worker" shape. See [Cloudflare Workers for Platforms](/deployment/cloudflare-wfp) for the full deploy guide. The proxy fronts a dispatch namespace and routes each request into the matching tenant's Worker. The data adapter is typically the same one AuthHero uses, but with a synthetic default route layered on (see [Quick start → WFP dispatcher](/customization/proxy/#wfp-dispatcher-workers-for-platforms)).
 
+## Shape 5 — Proxy-at-edge in front of a legacy control plane
+
+Use this when you already run a single "control-plane" AuthHero Worker that owns a
+wildcard auth zone (e.g. `*.token.example.com/*` → one Worker backed by a shared
+PlanetScale/MySQL database), and you want to migrate tenants onto their own
+per-tenant Workers **one at a time** without a big-bang cutover.
+
+The proxy takes over the wildcard route and does two things:
+
+- **Dispatches** hosts that have been migrated (a `custom_domains` + `proxy_routes`
+  row, or a KV blob) to the tenant's own Worker via the dispatch namespace.
+- **Default-forwards** everything else — legacy tenants still on the shared DB,
+  JWKS, M2M `POST /api/v2/*` — to the legacy control-plane Worker, unchanged.
+
+The default-forward is the router's fail-open `defaultHandlers` chain (see
+[router.ts](https://github.com/markusahlstrand/authhero/blob/main/packages/proxy/src/data-plane/router.ts)):
+an unresolved host, a resolve timeout, or a resolve error all fall through to the
+same catch-all instead of returning 404/502. Point that catch-all at the legacy
+control plane over a **service binding** so the hop never touches the public edge:
+
+```typescript
+import { createProxyApp } from "@authhero/proxy";
+
+export default {
+  fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    return createProxyApp({
+      data,                                   // KV or shared-DB adapter (Shape 2/3b)
+      bindings: { AUTH2: env.AUTH2 },         // service binding → legacy control plane
+      // Unmatched host / resolve failure → forward to the legacy Worker verbatim.
+      defaultHandlers: [
+        { type: "forwarded_headers" },
+        { type: "service_binding", options: { binding: "AUTH2", preserve_host: true } },
+      ],
+    }).fetch(req, env, ctx);
+  },
+};
+```
+
+`preserve_host: true` is required so the legacy Worker still resolves the tenant
+from the original `Host` (its subdomain-/custom-domain-based tenant resolution and
+`iss` claim depend on it). Verify this end-to-end for `POST /api/v2/*` with auth
+headers before cutover — a dropped Host silently reroutes the write to the wrong
+tenant.
+
+### The self-loop foot-gun (fix this first)
+
+If the proxy's control-plane resolution (`createHttpProxyAdapter`) targets a
+hostname **on the wildcard the proxy now owns** — e.g. `CONTROL_PLANE_URL` is
+`https://controlplane.token.example.com` while the proxy serves
+`*.token.example.com/*` — then the proxy's own `/oauth/token` and `resolveHost`
+calls loop back into the proxy. That is a self-DoS, and it triggers the moment you
+move the route.
+
+Two fixes, use at least one:
+
+1. **Point `CONTROL_PLANE_URL` off the wildcard** — e.g. `https://auth2.example.com`.
+2. **Resolve over a service binding** with `createServiceBindingFetch`, so the
+   control-plane calls never traverse the public edge regardless of `baseUrl`:
+
+```typescript
+import { createHttpProxyAdapter, createServiceBindingFetch } from "@authhero/proxy";
+
+const data = createHttpProxyAdapter({
+  baseUrl: env.CONTROL_PLANE_URL,           // may even stay on the wildcard
+  clientId: env.CONTROL_PLANE_CLIENT_ID,
+  clientSecret: env.CONTROL_PLANE_CLIENT_SECRET,
+  fetch: createServiceBindingFetch(env.AUTH2),
+});
+```
+
+The binding routes straight to the control-plane Worker, so the loop cannot form.
+Do this **before** moving the route.
+
+### Phased cutover runbook
+
+The route move and the per-tenant database migration are decoupled — Phase 1
+changes only topology, Phase 2 migrates tenants incrementally. Both are reversible.
+
+**Phase 0 — prepare (no traffic change)**
+
+- [ ] Deploy the proxy Worker with the `AUTH2` service binding to the legacy
+      control plane, the dispatch-namespace binding, and the loop-fix above.
+- [ ] Confirm the default-forward chain is active (`defaultHandlers` → `AUTH2`).
+- [ ] Smoke-test the proxy on a spare hostname: legacy host forwards (200), JWKS
+      returns the expected keys, `POST /api/v2/users` preserves Host + tenant.
+
+**Phase 1 — edge cutover (behaviorally transparent)**
+
+- [ ] Move the wildcard route (`*.token.example.dev/*` first, then `.com`) from
+      the legacy Worker to the proxy Worker. All tenants stay on the shared DB.
+- [ ] Every request now default-forwards to the legacy control plane over `AUTH2`
+      — one extra SWR-cached hop, no behavior change. Only topology moved.
+- [ ] **Rollback:** move the route back to the legacy Worker. Instant, total.
+- [ ] Verify in dev first — this both validates the topology and fixes the
+      "`403 Client not found` on a WFP host" symptom for any already-migrated tenant.
+
+**Phase 2 — per-tenant database migration (incremental)**
+
+For each tenant, in isolation:
+
+- [ ] Provision the tenant's per-tenant Worker + database (its client/connection
+      data now lives in the tenant DB, not the shared control-plane DB).
+- [ ] Add the routing row: a `custom_domains` + `proxy_routes` entry (or a KV blob,
+      Shape 3b) mapping `<tenant>.token.example.com` → `tenant-{id}-auth`.
+- [ ] The proxy now dispatches that host to the tenant Worker; all other hosts keep
+      default-forwarding to the legacy control plane.
+- [ ] **Rollback:** delete the routing row → the host falls back through
+      `defaultHandlers` to the legacy control plane again.
+
+### Verify before prod
+
+- **Host preservation** through the service binding for `POST /api/v2/*` with auth
+  headers — replay a real M2M call in dev, confirm the correct tenant/issuer.
+- **JWKS** resolves for both a forwarded legacy host and (Phase 2) a WFP host
+  served by the tenant Worker with projected shared signing keys.
+- **Loop fix live** before the route move — confirm control-plane resolution never
+  re-enters the wildcard (it should traverse the binding, not the public edge).
+
 ## Database setup
 
 The `proxy_routes` table is part of the standard AuthHero schema and is created by the regular adapter migrations (`migrateToLatest` for `@authhero/kysely-adapter`, the equivalent step for `@authhero/drizzle` and `@authhero/aws`). The proxy reads from the existing `custom_domains` table that AuthHero already manages — so when you share a database with AuthHero, no extra setup is needed at all.

--- a/packages/proxy/src/http-adapter/service-binding-fetch.test.ts
+++ b/packages/proxy/src/http-adapter/service-binding-fetch.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ResolvedHost } from "../adapter";
+import { createHttpProxyAdapter } from "./index";
+import {
+  createServiceBindingFetch,
+  type ServiceBindingFetcher,
+} from "./service-binding-fetch";
+
+const resolved: ResolvedHost = {
+  tenant_id: "wfp2",
+  custom_domain_id: "cd1",
+  domain: "wfp2.token.sesamy.com",
+  routes: [],
+};
+
+function fakeFetcher(
+  handler: (req: Request) => Response | Promise<Response>,
+): ServiceBindingFetcher & { requests: Request[] } {
+  const requests: Request[] = [];
+  return {
+    requests,
+    fetch(req: Request) {
+      requests.push(req);
+      return Promise.resolve(handler(req));
+    },
+  };
+}
+
+describe("createServiceBindingFetch", () => {
+  it("routes a (url, init) call through the binding as a Request", async () => {
+    const fetcher = fakeFetcher(() => new Response("ok", { status: 200 }));
+    const bindingFetch = createServiceBindingFetch(fetcher);
+
+    const res = await bindingFetch("https://ignored.example/oauth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ grant_type: "client_credentials" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetcher.requests).toHaveLength(1);
+    const [req] = fetcher.requests;
+    if (!req) throw new Error("no request captured");
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe("https://ignored.example/oauth/token");
+    expect(req.headers.get("content-type")).toBe("application/json");
+    expect(await req.text()).toBe(
+      JSON.stringify({ grant_type: "client_credentials" }),
+    );
+  });
+
+  it("passes an already-built Request through untouched", async () => {
+    const fetcher = fakeFetcher(() => new Response(null, { status: 204 }));
+    const bindingFetch = createServiceBindingFetch(fetcher);
+    const original = new Request("https://ignored.example/x");
+
+    await bindingFetch(original);
+
+    expect(fetcher.requests[0]).toBe(original);
+  });
+});
+
+describe("createHttpProxyAdapter with a service-binding fetch", () => {
+  it("resolves the control plane over the binding, never the public edge", async () => {
+    // A stand-in for `env.AUTH2`: answers the token + resolveHost calls and
+    // records every host it was asked for.
+    const seenHosts: string[] = [];
+    const fetcher = fakeFetcher((req) => {
+      const url = new URL(req.url);
+      seenHosts.push(url.host);
+      if (url.pathname === "/oauth/token") {
+        return Response.json({ access_token: "tok", expires_in: 3600 });
+      }
+      if (url.pathname.startsWith("/api/v2/proxy/control-plane/hosts/")) {
+        expect(req.headers.get("authorization")).toBe("Bearer tok");
+        return Response.json(resolved);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    // A global fetch that MUST never be called — its invocation would mean the
+    // control-plane call escaped to the public edge (the loop we prevent).
+    const globalFetch = vi.spyOn(globalThis, "fetch");
+
+    const adapter = createHttpProxyAdapter({
+      // Deliberately on the wildcard the proxy itself serves.
+      baseUrl: "https://controlplane.token.sesamy.com",
+      clientId: "proxy",
+      clientSecret: "secret",
+      fetch: createServiceBindingFetch(fetcher),
+    });
+
+    const out = await adapter.resolveHost("wfp2.token.sesamy.com");
+
+    expect(out).toEqual(resolved);
+    expect(globalFetch).not.toHaveBeenCalled();
+    // Every hop stayed on the binding, regardless of the wildcard baseUrl.
+    expect(seenHosts).toEqual([
+      "controlplane.token.sesamy.com",
+      "controlplane.token.sesamy.com",
+    ]);
+    globalFetch.mockRestore();
+  });
+});

--- a/packages/proxy/src/http-adapter/service-binding-fetch.ts
+++ b/packages/proxy/src/http-adapter/service-binding-fetch.ts
@@ -1,0 +1,46 @@
+/**
+ * Minimal shape of a Cloudflare service binding (a `Fetcher`). Declared
+ * locally so `@authhero/proxy` does not depend on `@cloudflare/workers-types`.
+ */
+export interface ServiceBindingFetcher {
+  fetch(request: Request): Promise<Response>;
+}
+
+/**
+ * Wrap a Cloudflare service binding as a `fetch`-compatible function, suitable
+ * for the `fetch` override on {@link HttpProxyAdapterOptions}.
+ *
+ * When the proxy's control plane lives on a hostname that the proxy itself
+ * serves (e.g. the proxy owns `*.token.example.com/*` and the control plane
+ * resolves at `https://controlplane.token.example.com`), resolving it over the
+ * public edge loops the proxy's `resolveHost`/`/oauth/token` calls straight
+ * back into itself — a self-DoS. Routing those calls through a service binding
+ * to the control-plane worker keeps them off the public edge entirely, so the
+ * loop cannot form regardless of the configured `baseUrl`.
+ *
+ * ```ts
+ * const data = createHttpProxyAdapter({
+ *   baseUrl: env.CONTROL_PLANE_URL,
+ *   clientId: env.CONTROL_PLANE_CLIENT_ID,
+ *   clientSecret: env.CONTROL_PLANE_CLIENT_SECRET,
+ *   fetch: createServiceBindingFetch(env.AUTH2),
+ * });
+ * ```
+ */
+export function createServiceBindingFetch(
+  fetcher: ServiceBindingFetcher,
+): typeof fetch {
+  const bindingFetch = (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    // Preserve an already-built Request untouched when there is no init to
+    // merge; otherwise normalize to a Request the binding's fetcher accepts.
+    const request =
+      input instanceof Request && init === undefined
+        ? input
+        : new Request(input, init);
+    return fetcher.fetch(request);
+  };
+  return bindingFetch as typeof fetch;
+}

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -57,6 +57,8 @@ export type {
 } from "./static";
 export { createHttpProxyAdapter } from "./http-adapter";
 export type { HttpProxyAdapterOptions } from "./http-adapter";
+export { createServiceBindingFetch } from "./http-adapter/service-binding-fetch";
+export type { ServiceBindingFetcher } from "./http-adapter/service-binding-fetch";
 export {
   createKvProxyAdapter,
   buildKvHostKey,


### PR DESCRIPTION
## What

Adds `createServiceBindingFetch` to `@authhero/proxy` and documents the proxy-at-edge topology + phased cutover runbook. This is the in-repo slice of #1079 — routing WFP tenant auth-flow traffic (`*.token.sesamy.*`) through the custom-domains proxy so requests reach the tenant's own D1-backed worker instead of `403 "Client not found"` from the shared control plane.

## Why

The chosen fix for #1079 is topological: front the wildcard zone with the proxy, dispatch migrated hosts to their tenant worker, and default-forward everything else to the legacy control plane. But if the proxy's control-plane resolution (`createHttpProxyAdapter`) targets a host **on the wildcard the proxy now owns**, its own `/oauth/token` and `resolveHost` calls loop back into the proxy — a self-DoS that triggers the moment you move the route.

`createServiceBindingFetch(env.AUTH2)` wraps a Cloudflare service binding as the `fetch` override on `createHttpProxyAdapter`, so control-plane calls reach the control-plane worker directly and never traverse the public edge — the loop cannot form regardless of `baseUrl`. The `fetch` override already existed; this exports an ergonomic, documented helper for it.

## Changes

- **`createServiceBindingFetch`** — new helper + `ServiceBindingFetcher` type, exported from the package root.
- **Tests** — request wrapping, pass-through of a pre-built `Request`, and an integration test proving `createHttpProxyAdapter` resolves the control plane over the binding with the global `fetch` never called, even when `baseUrl` is on the wildcard.
- **Docs** (`proxy/deployment.md`) — new **Shape 5 — Proxy-at-edge** section: default-forward via the `service_binding` handler, the self-loop foot-gun + two fixes, and the phased **Phase 1 (edge cutover) / Phase 2 (per-tenant D1 flip)** runbook with a pre-prod verification checklist.
- **Changeset** — `@authhero/proxy` minor.

## Not in this PR (external ops)

The actual traffic cutover lives outside this monorepo:

- Moving `*.token.sesamy.*/*` from the `auth2` worker to the custom-domains proxy.
- Repointing `CONTROL_PLANE_URL` off the wildcard.
- Adding per-tenant `proxy_routes`/KV dispatch rows during Phase 2.

The added runbook documents each of these steps.

## Root-cause note

The `getEnrichedClient(..., tenantId=undefined)` global lookup in `authorize.ts` is intentionally **not** patched — routing the host to the tenant's own worker makes that same lookup correctly tenant-scoped against its D1.

## Testing

- `pnpm --filter @authhero/proxy build` ✅
- `pnpm --filter @authhero/proxy exec vitest run` → 85 passed ✅

Closes #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a helper for routing proxy control-plane requests through a Cloudflare service binding.
  * Exported the service-binding fetch utility for use with HTTP proxy adapters.
  * Preserved request methods, headers, bodies, and existing `Request` objects when forwarding calls.

* **Bug Fixes**
  * Prevented control-plane requests from looping back through proxy-at-edge deployments.

* **Documentation**
  * Added proxy-at-edge deployment guidance, cutover and rollback steps, and production verification checklists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->