### PR TITLE
fix(users): tolerate unmapped sort field in list to prevent 500

### DIFF
--- a/.changeset/admin-global-search-users-sort.md
+++ b/.changeset/admin-global-search-users-sort.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": patch
+---
+
+Fix global search crashing user lookups. The search box issued every resource query with a hardcoded `sort: { field: "id" }`, but the `users` resource has no `id` column (only `user_id`), so a search emitted `sort=id:1` and the users endpoint failed with "Unknown column 'id' in 'order clause'". Sort field is now per-resource, defaulting to `id` and using `user_id` for users.

--- a/.changeset/kysely-users-list-unmapped-sort.md
+++ b/.changeset/kysely-users-list-unmapped-sort.md
@@ -1,0 +1,5 @@
+---
+"@authhero/kysely-adapter": patch
+---
+
+Ignore an unmapped `sort_by` in `users.list()` instead of passing it through to SQL. A request like `sort=id:1` (where `id` isn't a users column) produced an unqualified `order by id`, which MySQL/Vitess rejects with "Unknown column 'id' in 'order clause'" once `user_activity` is joined. Unknown sort fields are now dropped, matching the drizzle adapter.

--- a/apps/admin/src/components/admin/global-search.tsx
+++ b/apps/admin/src/components/admin/global-search.tsx
@@ -58,6 +58,9 @@ type HitConfig = {
   primary: (record: RaRecord) => string;
   secondary?: (record: RaRecord) => string | undefined;
   icon: typeof Users;
+  // Column to sort the `q` lookup by. Defaults to `id`; override where the
+  // resource has no `id` column (e.g. `users`, keyed by `user_id`).
+  sortField?: string;
 };
 
 // Resources to query for record search. Singletons (branding, settings,
@@ -72,6 +75,7 @@ const SEARCHABLE: Record<string, HitConfig> = {
       return name && email && name !== email ? name : undefined;
     },
     icon: Users,
+    sortField: "user_id",
   },
   clients: {
     primary: (r) => str(r.name) || str(r.client_id) || str(r.id),
@@ -306,7 +310,11 @@ function ResourceHits({
     resource,
     {
       pagination: { page: 1, perPage: 5 },
-      sort: { field: "id", order: "ASC" },
+      // Sort field is resource-specific: `users` has no `id` column (only
+      // `user_id`), and a hardcoded `id` sort made the dataProvider emit
+      // `sort=id:1`, which the users endpoint rejects. Order is irrelevant for
+      // a top-N `q` lookup, so any indexed column the resource exposes is fine.
+      sort: { field: config.sortField ?? "id", order: "ASC" },
       filter: { q: query },
     },
     {

--- a/packages/kysely/src/users/list.ts
+++ b/packages/kysely/src/users/list.ts
@@ -95,13 +95,19 @@ export function list(db: Kysely<Database>) {
       }
     }
 
+    // Only sort on a known field. An unmapped sort_by (e.g. `sort=id:1`, where
+    // `id` isn't a users column) must be ignored rather than passed through to
+    // SQL — an unqualified `order by id` is rejected by MySQL/Vitess as an
+    // unknown column once user_activity is joined. Mirrors the drizzle adapter.
     if (sort && sort.sort_by) {
-      const { ref } = db.dynamic;
-      const mapped = FIELD_MAP[sort.sort_by] ?? sort.sort_by;
-      query = query.orderBy(
-        typeof mapped === "string" ? ref(mapped) : coalescedRef(mapped),
-        sort.sort_order,
-      );
+      const mapped = FIELD_MAP[sort.sort_by];
+      if (mapped) {
+        const { ref } = db.dynamic;
+        query = query.orderBy(
+          typeof mapped === "string" ? ref(mapped) : coalescedRef(mapped),
+          sort.sort_order,
+        );
+      }
     }
 
     const filteredQuery = query.offset(page * per_page).limit(per_page);

--- a/packages/kysely/test/users/index.spec.ts
+++ b/packages/kysely/test/users/index.spec.ts
@@ -250,5 +250,20 @@ describe("users", () => {
         "email|never",
       ]);
     });
+
+    it("ignores an unmapped sort_by instead of emitting invalid SQL", async () => {
+      const data = await seed();
+
+      // `id` isn't a users column; after the user_activity join an unqualified
+      // `order by id` is rejected by MySQL/Vitess. The sort must be dropped.
+      const result = await data.users.list("t1", {
+        sort: { sort_by: "id", sort_order: "asc" },
+      });
+
+      expect(result.users.map((u) => u.user_id).sort()).toEqual([
+        "email|active",
+        "email|never",
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## Problem

Production (`auth2.sesamy.com`) logged repeated 500s from the users list endpoint:

```
DatabaseError: ... Unknown column 'id' in 'order clause' (errno 1054)
Sql: select users.*, user_activity.last_login, ... from users
     left join user_activity on ... order by id asc limit ...
```

The triggering request was `GET /api/v2/users?page=0&per_page=5&sort=id:1&q=url`.

### Root cause

The admin UI's **global search** box ([`global-search.tsx`](apps/admin/src/components/admin/global-search.tsx)) fires a `useGetList` against every resource with a hardcoded `sort: { field: "id", order: "ASC" }`. For most resources `id` is a real column, but the `users` table is keyed by `user_id` and has no `id`. Typing into global search (here, `url`) produced `sort=id:1` against `users`.

The kysely adapter then passed the unmapped `id` straight through to SQL as `order by id asc`. On its own that's already invalid, and once `user_activity` is LEFT JOINed the column can't resolve — Vitess/PlanetScale rejects the whole query, so the endpoint 500s instead of returning results.

## Fix

Two layers:

- **`@authhero/kysely-adapter`** — `users.list()` now ignores an unmapped `sort_by` instead of emitting it as raw SQL, matching what the drizzle adapter already does (`if (col)` guard). An invalid/unknown sort field yields default ordering rather than a crash. Adds a regression test.
- **`@authhero/admin`** — global search sort is now per-resource: defaults to `id`, uses `user_id` for `users`, so it no longer emits `sort=id:1` for the users resource.

The server fix alone stops the production error and hardens the endpoint against any client sending an unknown sort field; the admin fix removes the specific trigger.

## Testing

- `pnpm --filter @authhero/kysely-adapter exec vitest run test/users/index.spec.ts` — 9 passed (incl. new `ignores an unmapped sort_by` case)
- `pnpm --filter @authhero/admin exec tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed global search for users so results load correctly using the appropriate user identifier for sorting.
  - Prevented invalid sort fields from causing user list requests or database queries to fail.
  - Improved reliability of user search and listing when unsupported sorting options are provided.

- **Tests**
  - Added coverage to verify user lists remain available when an unmapped sort field is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->