### PR TITLE
fix(universal-login): don't log user-safe screen errors at error level

### DIFF
--- a/.changeset/silence-user-safe-screen-errors.md
+++ b/.changeset/silence-user-safe-screen-errors.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Stop logging user-safe validation errors at error level in universal-login screens. Expected client errors such as a reused/expired email OTP code ("code already used") or an invalid MFA phone enrollment no longer emit `console.error` to Cloudflare observability — they are still surfaced to the user and recorded in the tenant logs. Only genuinely unexpected failures (5xx / delivery errors) are logged as errors.

--- a/packages/authhero/src/routes/universal-login/screens/email-otp-challenge.ts
+++ b/packages/authhero/src/routes/universal-login/screens/email-otp-challenge.ts
@@ -256,10 +256,35 @@ export const emailOtpChallengeScreenDefinition: ScreenDefinition = {
           }),
         };
       } catch (e: unknown) {
-        console.error(
-          "[email-otp-challenge] Error:",
-          e instanceof Error ? e.stack || e.message : e,
-        );
+        // Determine whether this is an expected, user-safe validation error
+        // (wrong/used/expired code). Those are surfaced to the user and
+        // recorded in the tenant logs, so we don't flag them to Cloudflare
+        // observability as errors.
+        let errorMessage: string = m.unexpectedError() as string;
+        let isUserSafe = false;
+        if (e instanceof JSONHTTPException) {
+          try {
+            const parsed = JSON.parse((e as Error).message);
+            if (parsed.message) {
+              errorMessage = parsed.message;
+            }
+            if (parsed.userSafe) {
+              isUserSafe = true;
+            }
+          } catch {
+            // Keep the generic error message for non-JSON errors
+          }
+        } else if (e instanceof HTTPException) {
+          errorMessage = e.message;
+        }
+
+        // Only log genuinely unexpected errors at error level.
+        if (!isUserSafe) {
+          console.error(
+            "[email-otp-challenge] Error:",
+            e instanceof Error ? e.stack || e.message : e,
+          );
+        }
 
         // Check if user has password login available
         let hasPasswordLogin = false;
@@ -272,20 +297,6 @@ export const emailOtpChallengeScreenDefinition: ScreenDefinition = {
           hasPasswordLogin = !!passwordUser;
         } catch {
           // Ignore errors
-        }
-
-        let errorMessage: string = m.unexpectedError() as string;
-        if (e instanceof JSONHTTPException) {
-          try {
-            const parsed = JSON.parse((e as Error).message);
-            if (parsed.message) {
-              errorMessage = parsed.message;
-            }
-          } catch {
-            // Keep the generic error message for non-JSON errors
-          }
-        } else if (e instanceof HTTPException) {
-          errorMessage = e.message;
         }
 
         return {

--- a/packages/authhero/src/routes/universal-login/screens/mfa-phone-enrollment.ts
+++ b/packages/authhero/src/routes/universal-login/screens/mfa-phone-enrollment.ts
@@ -254,10 +254,18 @@ export const mfaPhoneEnrollmentScreenDefinition: ScreenDefinition = {
           redirect: `${routePrefix}/mfa/phone-challenge?state=${encodeURIComponent(state)}`,
         };
       } catch (err) {
-        console.error(
-          "[mfa-phone-enrollment] Error during phone enrollment:",
-          err,
-        );
+        // Expected client errors (4xx: invalid enrollment session, bad phone
+        // number) are surfaced to the user and recorded in the tenant logs
+        // below, so we don't flag them to Cloudflare observability. Only
+        // unexpected failures (e.g. SMS provider errors) are logged at error
+        // level.
+        const isExpected = err instanceof HTTPException && err.status < 500;
+        if (!isExpected) {
+          console.error(
+            "[mfa-phone-enrollment] Error during phone enrollment:",
+            err,
+          );
+        }
         logMessage(ctx, client.tenant.id, {
           type: LogTypes.MFA_ENROLLMENT_FAILED,
           description: `MFA phone enrollment failed: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Problem

A reused email OTP code produced a **Cloudflare observability error** with a full stack trace, looking like a server fault:

```
[email-otp-challenge] Error: Error: {"message":"Koden er allerede brukt","userSafe":true}
```

The request already returned **400** to the client and the failure was already recorded in the tenant logs — the only issue was that the screen handler's `catch` called `console.error` unconditionally, so an ordinary user mistake (resubmitting a used/expired code) got flagged to observability as an error.

## Fix

Guard the `console.error` calls so only genuinely unexpected failures are logged at error level:

- **`email-otp-challenge.ts`** — parse the `JSONHTTPException` `userSafe` flag first, then only `console.error` when the error is not user-safe. Brings it in line with its sibling `sms-otp-challenge.ts`, which already handled this correctly.
- **`mfa-phone-enrollment.ts`** — only `console.error` when the error isn't an expected 4xx (`err instanceof HTTPException && err.status < 500`), matching the central universal-login error handler's `status >= 500` convention. Genuine SMS-provider failures still log; the `logMessage` tenant-log entry is untouched.

The other `console.error` sites in universal-login screens (login-passwordless-identifier, reset-password-code, signup) are genuine send/delivery failures and were deliberately left as-is.

## Behaviour

- Reused/expired/wrong OTP code → still a **400** with the on-screen error and its tenant-log entry, but **no longer** pages Cloudflare error tracking.
- Real failures (5xx, delivery errors) → still logged as errors.

## Testing

- `pnpm --filter authhero exec vitest run` on `email-otp-mfa.spec.ts` and `code.spec.ts` — 5/5 pass
- Package typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)