### PR TITLE
fix(organizations): honor from/take pagination on members list

### DIFF
--- a/.changeset/org-members-checkpoint-pagination.md
+++ b/.changeset/org-members-checkpoint-pagination.md
@@ -1,0 +1,9 @@
+---
+"authhero": patch
+"@authhero/kysely-adapter": patch
+"@authhero/drizzle": patch
+---
+
+Fix `GET /organizations/{id}/members` ignoring `from`/`take` pagination.
+
+The members handler only read `page`/`per_page`, so a client paging with checkpoint pagination — e.g. the Auth0 SDK, which sends `from=0&take=25` — had `take` dropped and fell back to the `per_page` default of 10, capping every response at 10 members. The handler now passes `from`/`take` through, and the `userOrganizations` list adapters (kysely and drizzle) honor them the same way the organizations adapter does (`take` wins over `per_page`, `from` over `page`, with clamping).

--- a/packages/authhero/src/routes/management-api/organizations.ts
+++ b/packages/authhero/src/routes/management-api/organizations.ts
@@ -458,7 +458,8 @@ const getByIdMembers = defineRoute({
   handler: async (ctx) => {
     const tenant_id = ctx.var.tenant_id;
     const { id: organizationId } = ctx.req.valid("param");
-    const { page, per_page, include_totals, sort } = ctx.req.valid("query");
+    const { page, per_page, include_totals, sort, from, take } =
+      ctx.req.valid("query");
 
     // First verify organization exists
     const organization = await ctx.env.data.organizations.get(
@@ -469,7 +470,10 @@ const getByIdMembers = defineRoute({
       throw new HTTPException(404, { message: "Organization not found" });
     }
 
-    // Get user-organization relationships
+    // Get user-organization relationships. Pass through checkpoint pagination
+    // (from/take) as well as page/per_page so clients using either style —
+    // e.g. the Auth0 SDK, which sends from/take — page correctly instead of
+    // being capped at the per_page default.
     const userOrgsResult = await ctx.env.data.userOrganizations.list(
       tenant_id,
       {
@@ -478,6 +482,8 @@ const getByIdMembers = defineRoute({
         include_totals,
         sort: parseSort(sort),
         q: `organization_id:${organization.id}`,
+        from,
+        take,
       },
     );
 

--- a/packages/authhero/test/routes/management-api/organizations.spec.ts
+++ b/packages/authhero/test/routes/management-api/organizations.spec.ts
@@ -266,6 +266,64 @@ describe("organizations management API endpoint", () => {
     });
   });
 
+  describe("GET /api/v2/organizations/:id/members", () => {
+    it("honors the take parameter instead of capping at the per_page default", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      const tenantId = `members-take-${Date.now()}`;
+
+      await env.data.tenants.create({
+        id: tenantId,
+        friendly_name: "Members Take Tenant",
+        audience: "https://example.com",
+        default_audience: "https://example.com",
+        sender_email: "login@example.com",
+        sender_name: "SenderName",
+      });
+
+      const organization = await env.data.organizations.create(tenantId, {
+        name: "members-org",
+        display_name: "Members Org",
+      });
+
+      // Create more members than the default per_page (10) so a regression
+      // where take is ignored would surface as a truncated list.
+      const memberCount = 15;
+      for (let i = 0; i < memberCount; i++) {
+        const userId = `email|member-${i}`;
+        await env.data.users.create(tenantId, {
+          email: `member-${i}@example.com`,
+          user_id: userId,
+          provider: "email",
+          connection: "email",
+          email_verified: true,
+          is_social: false,
+        });
+        await env.data.userOrganizations.create(tenantId, {
+          user_id: userId,
+          organization_id: organization.id,
+        });
+      }
+
+      const response = await managementClient.organizations[":id"].members.$get(
+        {
+          param: { id: organization.id },
+          // from/take is how the Auth0 SDK paginates members.
+          query: { from: "0", take: "25" },
+          header: { "tenant-id": tenantId },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as any;
+      expect(Array.isArray(data)).toBe(true);
+      expect(data).toHaveLength(memberCount);
+    });
+  });
+
   describe("POST /api/v2/organizations/:id/members", () => {
     it("should return 404 when the organization does not exist", async () => {
       const { managementApp, env } = await getTestServer();

--- a/packages/drizzle/src/adapters/userOrganizations.ts
+++ b/packages/drizzle/src/adapters/userOrganizations.ts
@@ -89,12 +89,31 @@ export function createUserOrganizationsAdapter(db: DrizzleDb) {
     },
 
     async list(tenantId: string, params?: ListParams) {
-      const {
-        page = 0,
-        per_page = 50,
-        include_totals = false,
-        q,
-      } = params || {};
+      const { include_totals = false, q } = params || {};
+
+      // Clamp pagination inputs. take wins over per_page, and from
+      // (checkpoint offset) wins over page. Mirrors the organizations adapter
+      // so the Auth0 SDK's from/take pagination is honored instead of being
+      // capped at the per_page default.
+      const rawPerPage = params?.take ?? params?.per_page;
+      const normalized =
+        typeof rawPerPage === "number" && Number.isFinite(rawPerPage)
+          ? Math.floor(rawPerPage)
+          : NaN;
+      const per_page = normalized >= 1 ? normalized : 50;
+
+      let offset = 0;
+      if (params?.from !== undefined) {
+        const parsed = parseInt(params.from, 10);
+        if (!Number.isNaN(parsed)) {
+          offset = Math.max(0, parsed);
+        }
+      } else if (
+        typeof params?.page === "number" &&
+        Number.isFinite(params.page)
+      ) {
+        offset = Math.max(0, Math.floor(params.page) * per_page);
+      }
 
       const tenantFilter = eq(userOrganizations.tenant_id, tenantId);
 
@@ -111,7 +130,7 @@ export function createUserOrganizationsAdapter(db: DrizzleDb) {
         .select()
         .from(userOrganizations)
         .where(whereCondition)
-        .offset(page * per_page)
+        .offset(offset)
         .limit(per_page);
       const mapped = results.map((row) => {
         const { tenant_id: _, ...rest } = row;
@@ -129,7 +148,7 @@ export function createUserOrganizationsAdapter(db: DrizzleDb) {
 
       return {
         userOrganizations: mapped,
-        start: page * per_page,
+        start: offset,
         limit: per_page,
         length: Number(countResult?.count ?? 0),
       };

--- a/packages/kysely/src/user-organizations/list.ts
+++ b/packages/kysely/src/user-organizations/list.ts
@@ -11,9 +11,26 @@ export function list(db: Kysely<Database>) {
     tenantId: string,
     params?: ListParams,
   ): Promise<{ userOrganizations: UserOrganization[] } & Totals> => {
-    const page = params?.page || 0;
-    const per_page = params?.per_page || 50;
-    const offset = page * per_page;
+    // Clamp pagination inputs so negative or non-finite values cannot
+    // produce bad SQL. take wins over per_page when both are supplied, and
+    // from (checkpoint offset) wins over page. This mirrors the organizations
+    // adapter so the Auth0 SDK's from/take pagination is honored.
+    const rawPerPage = params?.take ?? params?.per_page;
+    const normalized =
+      typeof rawPerPage === "number" && Number.isFinite(rawPerPage)
+        ? Math.floor(rawPerPage)
+        : NaN;
+    const per_page = normalized >= 1 ? normalized : 50;
+
+    let offset = 0;
+    if (params?.from !== undefined) {
+      const parsed = parseInt(params.from, 10);
+      if (!Number.isNaN(parsed)) {
+        offset = Math.max(0, parsed);
+      }
+    } else if (typeof params?.page === "number" && Number.isFinite(params.page)) {
+      offset = Math.max(0, Math.floor(params.page) * per_page);
+    }
 
     let query = db
       .selectFrom("user_organizations")


### PR DESCRIPTION
## Problem

`GET /api/v2/organizations/{id}/members` was capped at 10 members regardless of how many exist. Real-world repro (from the Sesamy admin UI, via the Auth0 node SDK):

```
GET /api/v2/organizations/{id}/members?from=0&take=25
```

returns only 10 members.

## Root cause

The Auth0 SDK paginates members with **checkpoint pagination** (`from`/`take`). The `getByIdMembers` handler only read `page`/`per_page` and dropped `from`/`take` entirely, so `take=25` was ignored and `per_page` fell back to its schema default of **10** — capping every response at 10.

The sibling `GET /organizations` endpoint already passes `from`/`take` to its adapter, which honors them; the members path was just never wired up the same way.

## Fix

- **Handler** (`organizations.ts`): read `from`/`take` and pass them to `userOrganizations.list`.
- **kysely** & **drizzle** `userOrganizations.list`: honor `take` (wins over `per_page`) and `from` (offset, wins over `page`), with the same clamping the `organizations` adapter uses.

This keeps the existing offset-backed model; `take`/`from` behave as page-size / numeric offset. Added a regression test that seeds 15 members, requests `take=25`, and asserts all 15 come back.

## Not included (follow-up)

True Auth0-style checkpoint pagination — emitting an opaque `next` cursor in the response body (the `organizationMembersWithNextSchema` branch, currently defined but unused) and aligning the default page size with Auth0's 50 — is intentionally out of scope. This PR fixes the reported bug (first page respects `take`); walking past page one via a response `next` token is tracked separately.

## Test plan

- [x] `packages/authhero` `organizations.spec.ts` — 10/10 pass (incl. new members `take` test)
- [x] `packages/kysely` `organizations.test.ts` — 9/9 pass
- [x] drizzle + kysely adapters build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed organization member listings so checkpoint pagination using `from` and `take` is now honored.
  * Pagination now correctly prioritizes checkpoint parameters over page-based values and applies safe limits and offsets.
  * Requests can retrieve more than the previous default page size when a larger `take` value is provided.

* **Tests**
  * Added coverage confirming member listings return the requested number of results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->