### PR TITLE
feat(pagination): keyset (checkpoint) cursors with opaque next — #1098

### DIFF
--- a/.changeset/org-members-checkpoint-pagination.md
+++ b/.changeset/org-members-checkpoint-pagination.md
@@ -1,9 +1,16 @@
 ---
-"authhero": patch
-"@authhero/kysely-adapter": patch
-"@authhero/drizzle": patch
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+"@authhero/kysely-adapter": minor
+"@authhero/drizzle": minor
 ---
 
-Fix `GET /organizations/{id}/members` ignoring `from`/`take` pagination.
+Add Auth0-style keyset (checkpoint) pagination with an opaque `next` cursor.
 
-The members handler only read `page`/`per_page`, so a client paging with checkpoint pagination — e.g. the Auth0 SDK, which sends `from=0&take=25` — had `take` dropped and fell back to the `per_page` default of 10, capping every response at 10 members. The handler now passes `from`/`take` through, and the `userOrganizations` list adapters (kysely and drizzle) honor them the same way the organizations adapter does (`take` wins over `per_page`, `from` over `page`, with clamping).
+List endpoints previously treated the `from` parameter as a numeric SQL offset, which diverges from Auth0 (where `from` is the opaque `next` token from the prior response) and is unstable under concurrent writes. Organization and organization-members listing now support true keyset pagination:
+
+- `adapter-interfaces` exposes `encodeCursor`/`decodeCursor` and a `next` field on the list-response contract. `from` is documented as an opaque cursor.
+- kysely and drizzle gain a shared keyset paginator (`(sortColumn, id)` row-value comparison, `take + 1` look-ahead to emit `next`). Offset pagination (`page`/`per_page` + `total`), used by the admin UI, is unchanged.
+- `GET /organizations` and `GET /organizations/{id}/members` return `{ items, next }` when called with `from`/`take`, and keep the offset shape for `page`/`per_page`.
+
+This fixes `GET /organizations/{id}/members` being capped at 10 (the Auth0 SDK sends `from`/`take`) and lets clients page the full set via the cursor. The admin UI's org-members view switches to offset pagination so it keeps numbered pages and totals.

--- a/.changeset/org-members-checkpoint-pagination.md
+++ b/.changeset/org-members-checkpoint-pagination.md
@@ -11,6 +11,8 @@ List endpoints previously treated the `from` parameter as a numeric SQL offset, 
 
 - `adapter-interfaces` exposes `encodeCursor`/`decodeCursor` and a `next` field on the list-response contract. `from` is documented as an opaque cursor.
 - kysely and drizzle gain a shared keyset paginator (`(sortColumn, id)` row-value comparison, `take + 1` look-ahead to emit `next`). Offset pagination (`page`/`per_page` + `total`), used by the admin UI, is unchanged.
-- `GET /organizations` and `GET /organizations/{id}/members` return `{ items, next }` when called with `from`/`take`, and keep the offset shape for `page`/`per_page`.
+- `GET /organizations`, `GET /organizations/{id}/members` and `GET /client-grants` return `{ items, next }` when called with `from`/`take`, and keep the offset shape for `page`/`per_page`. These are the endpoints Auth0 documents as checkpoint pagination.
 
-This fixes `GET /organizations/{id}/members` being capped at 10 (the Auth0 SDK sends `from`/`take`) and lets clients page the full set via the cursor. The admin UI's org-members view switches to offset pagination so it keeps numbered pages and totals.
+This fixes `GET /organizations/{id}/members` being capped at 10 (the Auth0 SDK sends `from`/`take`) and lets clients page the full set via the cursor. `client-grants` previously faked keyset by translating `from` into a `id:>` filter and never returned `next`; it now uses the shared paginator. The admin UI's org-members view switches to offset pagination so it keeps numbered pages and totals.
+
+Other list endpoints keep offset pagination unchanged; they can adopt the shared keyset helper later without a contract change.

--- a/apps/admin/src/auth0DataProvider.ts
+++ b/apps/admin/src/auth0DataProvider.ts
@@ -1501,12 +1501,18 @@ export default (
         resource === "organization-members" &&
         params.target === "organization_id"
       ) {
+        // Use offset pagination (page/per_page) so the admin keeps numbered
+        // pages and a total count. `from`/`take` on this endpoint is now
+        // Auth0-style keyset checkpoint pagination — `from` is an opaque
+        // cursor, not a numeric offset — and returns no total, which the
+        // numbered <ListPagination> cannot consume.
         const result = await managementClient.organizations.members.list(
           params.id as string,
           {
-            from: String((page - 1) * perPage),
-            take: perPage,
-          },
+            page: page - 1,
+            per_page: perPage,
+            include_totals: true,
+          } as any,
         );
         const response = (result as any).response || result;
         const membersData = Array.isArray(response)

--- a/packages/adapter-interfaces/src/types/ListParams.ts
+++ b/packages/adapter-interfaces/src/types/ListParams.ts
@@ -7,7 +7,10 @@ export interface ListParams {
     sort_by: string;
     sort_order: "asc" | "desc";
   };
-  // Checkpoint pagination (alternative to page/per_page)
+  // Checkpoint (keyset) pagination, an alternative to page/per_page.
+  // `from` is an OPAQUE cursor token — the `next` value returned by the
+  // previous response, passed back verbatim. It is not a numeric offset.
+  // `take` is the page size. Adapters decode `from` via decodeCursor().
   from?: string;
   take?: number;
   // Optional date range (Unix timestamp in seconds, inclusive)

--- a/packages/adapter-interfaces/src/types/auth0/Totals.ts
+++ b/packages/adapter-interfaces/src/types/auth0/Totals.ts
@@ -5,6 +5,9 @@ export const totalsSchema = z.object({
   limit: z.number(),
   length: z.number(),
   total: z.number().optional(),
+  // Opaque keyset cursor for the next page (checkpoint pagination). Present
+  // only when the request used from/take and a further page may exist.
+  next: z.string().optional(),
 });
 
 export interface Totals {
@@ -12,4 +15,10 @@ export interface Totals {
   limit: number;
   length: number;
   total?: number;
+  /**
+   * Opaque keyset cursor for the next page. Set only when the caller paginated
+   * with from/take and more rows may follow; absent on the last page and for
+   * offset (page/per_page) pagination.
+   */
+  next?: string;
 }

--- a/packages/adapter-interfaces/src/utils/base64url.ts
+++ b/packages/adapter-interfaces/src/utils/base64url.ts
@@ -1,0 +1,47 @@
+/**
+ * URL-safe base64 ("base64url", RFC 4648 §5) without padding.
+ *
+ * This is the canonical base64url implementation for the AuthHero packages.
+ * It lives in `adapter-interfaces` (the lowest package) so every other package
+ * can depend on it, replacing scattered hand-rolled `btoa/atob` variants and
+ * the `oslo/encoding` dependency we are migrating away from.
+ *
+ * Both byte- and string-oriented helpers are provided:
+ *  - `encodeBase64Url` / `decodeBase64Url` work on raw bytes (`Uint8Array`),
+ *    matching how most callers use it (hashes, random bytes, JWT segments).
+ *  - `encodeBase64UrlString` / `decodeBase64UrlString` wrap those with UTF-8
+ *    (de)coding for the common "encode a JSON/text payload" case.
+ */
+
+/** Encode raw bytes as a padding-free base64url string. */
+export function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** Decode a base64url string (with or without padding) back to raw bytes. */
+export function decodeBase64Url(input: string): Uint8Array {
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/** Encode a UTF-8 string as a padding-free base64url string. */
+export function encodeBase64UrlString(input: string): string {
+  return encodeBase64Url(new TextEncoder().encode(input));
+}
+
+/** Decode a base64url string produced from UTF-8 text back to that string. */
+export function decodeBase64UrlString(input: string): string {
+  return new TextDecoder().decode(decodeBase64Url(input));
+}

--- a/packages/adapter-interfaces/src/utils/cursor.ts
+++ b/packages/adapter-interfaces/src/utils/cursor.ts
@@ -10,6 +10,8 @@
  * token opaque means clients cannot depend on its shape and we can evolve the
  * encoding — e.g. add extra sort keys — without breaking callers.
  */
+import { decodeBase64UrlString, encodeBase64UrlString } from "./base64url";
+
 export interface CursorPayload {
   /**
    * Value of the sort column on the last row of the previous page. `null` when
@@ -20,35 +22,12 @@ export interface CursorPayload {
   i: string;
 }
 
-function toBase64Url(input: string): string {
-  // btoa expects a Latin1 string; encode UTF-8 first so non-ASCII ids survive.
-  const bytes = new TextEncoder().encode(input);
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary)
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-}
-
-function fromBase64Url(input: string): string {
-  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return new TextDecoder().decode(bytes);
-}
-
 /**
  * Encode a keyset position into an opaque cursor token suitable for returning
  * as `next` and accepting back as `from`.
  */
 export function encodeCursor(payload: CursorPayload): string {
-  return toBase64Url(JSON.stringify(payload));
+  return encodeBase64UrlString(JSON.stringify(payload));
 }
 
 /**
@@ -58,7 +37,7 @@ export function encodeCursor(payload: CursorPayload): string {
  */
 export function decodeCursor(token: string): CursorPayload | null {
   try {
-    const parsed = JSON.parse(fromBase64Url(token));
+    const parsed = JSON.parse(decodeBase64UrlString(token));
     if (
       parsed &&
       typeof parsed === "object" &&

--- a/packages/adapter-interfaces/src/utils/cursor.ts
+++ b/packages/adapter-interfaces/src/utils/cursor.ts
@@ -1,0 +1,73 @@
+/**
+ * Opaque cursor encoding for keyset (checkpoint) pagination.
+ *
+ * Auth0's `from` parameter is an opaque token — "the Id from which to start
+ * selection" — that a client takes verbatim from the previous response's
+ * `next` field and passes back. It is NOT a numeric offset.
+ *
+ * We encode the keyset position (the sort-column value of the last returned
+ * row plus its id as a tiebreaker) into a URL-safe base64 token. Keeping the
+ * token opaque means clients cannot depend on its shape and we can evolve the
+ * encoding — e.g. add extra sort keys — without breaking callers.
+ */
+export interface CursorPayload {
+  /**
+   * Value of the sort column on the last row of the previous page. `null` when
+   * that column was null on the boundary row. Absent for id-only ordering.
+   */
+  s?: string | number | null;
+  /** Id of the last row of the previous page — the unique tiebreaker. */
+  i: string;
+}
+
+function toBase64Url(input: string): string {
+  // btoa expects a Latin1 string; encode UTF-8 first so non-ASCII ids survive.
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function fromBase64Url(input: string): string {
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+/**
+ * Encode a keyset position into an opaque cursor token suitable for returning
+ * as `next` and accepting back as `from`.
+ */
+export function encodeCursor(payload: CursorPayload): string {
+  return toBase64Url(JSON.stringify(payload));
+}
+
+/**
+ * Decode an opaque cursor token. Returns `null` for malformed or unparseable
+ * tokens so callers can fall back gracefully (e.g. start from the beginning)
+ * instead of throwing on client-supplied input.
+ */
+export function decodeCursor(token: string): CursorPayload | null {
+  try {
+    const parsed = JSON.parse(fromBase64Url(token));
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.i === "string"
+    ) {
+      return parsed as CursorPayload;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/adapter-interfaces/src/utils/index.ts
+++ b/packages/adapter-interfaces/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./user-id";
 export * from "./passthrough";
 export * from "./connection-attributes";
 export * from "./guards";
+export * from "./cursor";

--- a/packages/adapter-interfaces/src/utils/index.ts
+++ b/packages/adapter-interfaces/src/utils/index.ts
@@ -2,4 +2,5 @@ export * from "./user-id";
 export * from "./passthrough";
 export * from "./connection-attributes";
 export * from "./guards";
+export * from "./base64url";
 export * from "./cursor";

--- a/packages/authhero/src/routes/management-api/client-grants.ts
+++ b/packages/authhero/src/routes/management-api/client-grants.ts
@@ -74,6 +74,14 @@ const clientGrantsQuerySchema = z.object({
 const clientGrantsWithTotalsSchema = totalsSchema.extend({
   client_grants: z.array(clientGrantSchema),
 });
+
+// Checkpoint (keyset) pagination response: items plus an opaque cursor.
+const clientGrantsWithNextSchema = z.object({
+  client_grants: z.array(clientGrantSchema),
+  next: z.string().optional().openapi({
+    description: "Opaque cursor for the next page; absent on the last page.",
+  }),
+});
 const getRoot = defineRoute({
   route: createRoute({
     tags: ["client-grants"],
@@ -98,6 +106,7 @@ const getRoot = defineRoute({
             schema: z.union([
               z.array(clientGrantSchema),
               clientGrantsWithTotalsSchema,
+              clientGrantsWithNextSchema,
             ]),
           },
         },
@@ -139,22 +148,26 @@ const getRoot = defineRoute({
       queryParts.push(`subject_type:"${subject_type}"`);
     }
 
-    if (from) {
-      queryParts.push(`id:>${from}`);
-    }
-
     const luceneQuery =
       queryParts.length > 0 ? queryParts.join(" AND ") : undefined;
 
-    // Use take parameter if provided, otherwise use per_page
-    const actualPerPage = take ?? per_page;
-
     const result = await ctx.env.data.clientGrants.list(tenant_id, {
       page,
-      per_page: actualPerPage,
+      per_page,
       include_totals,
       q: luceneQuery,
+      from,
+      take,
     });
+
+    // Keyset (checkpoint) pagination: return Auth0's { items, next } shape so
+    // clients can page past the first page via the opaque cursor.
+    if (from !== undefined || take !== undefined) {
+      return ctx.json({
+        client_grants: result.client_grants,
+        next: result.next,
+      });
+    }
 
     if (!include_totals) {
       return ctx.json(result.client_grants);

--- a/packages/authhero/src/routes/management-api/organizations.ts
+++ b/packages/authhero/src/routes/management-api/organizations.ts
@@ -89,6 +89,14 @@ const organizationsWithTotalsSchema = totalsSchema.extend({
   organizations: z.array(organizationSchema),
 });
 
+// Checkpoint (keyset) pagination response: items plus an opaque cursor.
+const organizationsWithNextSchema = z.object({
+  organizations: z.array(organizationSchema),
+  next: z.string().optional().openapi({
+    description: "Opaque cursor for the next page; absent on the last page.",
+  }),
+});
+
 // Schema for organization member as per Auth0 API spec
 const organizationMemberSchema = z.object({
   user_id: z.string().openapi({
@@ -168,6 +176,7 @@ const getRoot = defineRoute({
           "application/json": {
             schema: z.union([
               organizationsWithTotalsSchema,
+              organizationsWithNextSchema,
               z.array(organizationSchema),
             ]),
           },
@@ -190,6 +199,15 @@ const getRoot = defineRoute({
       from,
       take,
     });
+
+    // Keyset (checkpoint) pagination: return Auth0's { items, next } shape so
+    // clients can page past the first page via the opaque cursor.
+    if (from !== undefined || take !== undefined) {
+      return ctx.json({
+        organizations: result.organizations,
+        next: result.next,
+      });
+    }
 
     if (include_totals) {
       return ctx.json(result);
@@ -514,6 +532,12 @@ const getByIdMembers = defineRoute({
     ).then((rows) =>
       rows.filter((r): r is NonNullable<typeof r> => r !== null),
     );
+
+    // Keyset (checkpoint) pagination: return Auth0's { members, next } shape so
+    // clients can page past the first page via the opaque cursor.
+    if (from !== undefined || take !== undefined) {
+      return ctx.json({ members, next: userOrgsResult.next });
+    }
 
     // Return different formats based on query parameters
     if (include_totals) {

--- a/packages/authhero/test/routes/management-api/organizations.spec.ts
+++ b/packages/authhero/test/routes/management-api/organizations.spec.ts
@@ -310,8 +310,8 @@ describe("organizations management API endpoint", () => {
       const response = await managementClient.organizations[":id"].members.$get(
         {
           param: { id: organization.id },
-          // from/take is how the Auth0 SDK paginates members.
-          query: { from: "0", take: "25" },
+          // from/take is how the Auth0 SDK paginates members (checkpoint).
+          query: { take: "25" },
           header: { "tenant-id": tenantId },
         },
         { headers: { authorization: `Bearer ${token}` } },
@@ -319,8 +319,73 @@ describe("organizations management API endpoint", () => {
 
       expect(response.status).toBe(200);
       const data = (await response.json()) as any;
-      expect(Array.isArray(data)).toBe(true);
-      expect(data).toHaveLength(memberCount);
+      // Checkpoint pagination returns { members, next }, not a bare array.
+      expect(data.members).toHaveLength(memberCount);
+      expect(data.next).toBeUndefined(); // all fit on one page
+    });
+
+    it("walks all members across pages via the opaque next cursor", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      const tenantId = `members-cursor-${Date.now()}`;
+      await env.data.tenants.create({
+        id: tenantId,
+        friendly_name: "Members Cursor Tenant",
+        audience: "https://example.com",
+        default_audience: "https://example.com",
+        sender_email: "login@example.com",
+        sender_name: "SenderName",
+      });
+      const organization = await env.data.organizations.create(tenantId, {
+        name: "members-cursor-org",
+        display_name: "Members Cursor Org",
+      });
+
+      const memberCount = 12;
+      for (let i = 0; i < memberCount; i++) {
+        const userId = `email|cursor-${i}`;
+        await env.data.users.create(tenantId, {
+          email: `cursor-${i}@example.com`,
+          user_id: userId,
+          provider: "email",
+          connection: "email",
+          email_verified: true,
+          is_social: false,
+        });
+        await env.data.userOrganizations.create(tenantId, {
+          user_id: userId,
+          organization_id: organization.id,
+        });
+      }
+
+      const seen = new Set<string>();
+      let from: string | undefined;
+      let pages = 0;
+      for (;;) {
+        const res = await managementClient.organizations[":id"].members.$get(
+          {
+            param: { id: organization.id },
+            query: from ? { take: "5", from } : { take: "5" },
+            header: { "tenant-id": tenantId },
+          },
+          { headers: { authorization: `Bearer ${token}` } },
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as any;
+        for (const m of body.members) {
+          expect(seen.has(m.user_id)).toBe(false);
+          seen.add(m.user_id);
+        }
+        pages++;
+        if (!body.next) break;
+        from = body.next as string;
+        if (pages > 6) throw new Error("cursor walk did not terminate");
+      }
+
+      expect(seen.size).toBe(memberCount);
+      expect(pages).toBe(3); // 5 + 5 + 2
     });
   });
 

--- a/packages/drizzle/src/adapters/clientGrants.ts
+++ b/packages/drizzle/src/adapters/clientGrants.ts
@@ -8,6 +8,13 @@ import type {
 import { clientGrants } from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import { buildLuceneFilter } from "../helpers/filter";
+import {
+  isKeysetRequest,
+  keysetCondition,
+  keysetOrderBy,
+  keysetTake,
+  sliceWithNext,
+} from "../helpers/paginate";
 import type { DrizzleDb } from "./types";
 
 function sqlToClientGrant(row: any): ClientGrant {
@@ -126,6 +133,33 @@ export function createClientGrantsAdapter(db: DrizzleDb) {
       const whereCondition = luceneFilter
         ? and(eq(clientGrants.tenant_id, tenant_id), luceneFilter)
         : eq(clientGrants.tenant_id, tenant_id);
+
+      // Keyset (checkpoint) pagination: from/take. Fixed created_at desc order
+      // with id tiebreaker; no total, matching Auth0's checkpoint responses.
+      if (isKeysetRequest(params)) {
+        const cols = {
+          sortColumn: clientGrants.created_at,
+          idColumn: clientGrants.id,
+          sortOrder: "desc" as const,
+        };
+        const keyset = keysetCondition(params, cols);
+        const take = keysetTake(params);
+        const rows = await db
+          .select()
+          .from(clientGrants)
+          .where(keyset ? and(whereCondition, keyset) : whereCondition)
+          .orderBy(...keysetOrderBy(cols))
+          .limit(take + 1);
+        const { rows: pageRows, next } = sliceWithNext(rows, take, "created_at");
+        const mapped = pageRows.map(sqlToClientGrant);
+        return {
+          client_grants: mapped,
+          start: 0,
+          limit: take,
+          length: mapped.length,
+          next,
+        };
+      }
 
       let query = db
         .select()

--- a/packages/drizzle/src/adapters/organizations.ts
+++ b/packages/drizzle/src/adapters/organizations.ts
@@ -4,6 +4,13 @@ import type { Organization, ListParams } from "@authhero/adapter-interfaces";
 import { organizations } from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import { buildLuceneFilter, sanitizeLuceneQuery } from "../helpers/filter";
+import {
+  isKeysetRequest,
+  keysetCondition,
+  keysetOrderBy,
+  keysetTake,
+  sliceWithNext,
+} from "../helpers/paginate";
 import type { DrizzleDb } from "./types";
 
 // Fields organizations.list() accepts in `q`. Excludes `tenant_id` so a clause
@@ -159,6 +166,34 @@ export function createOrganizationsAdapter(db: DrizzleDb) {
       }
 
       const whereClause = and(...conditions);
+
+      // Keyset (checkpoint) pagination: from/take. Fixed created_at desc order
+      // with id tiebreaker; no total, matching Auth0's checkpoint responses.
+      if (isKeysetRequest(params)) {
+        const cols = {
+          sortColumn: organizations.created_at,
+          idColumn: organizations.id,
+          sortOrder: "desc" as const,
+        };
+        const keyset = keysetCondition(params, cols);
+        const take = keysetTake(params);
+        const rows = await db
+          .select()
+          .from(organizations)
+          .where(keyset ? and(whereClause, keyset) : whereClause)
+          .orderBy(...keysetOrderBy(cols))
+          .limit(take + 1);
+        const { rows: pageRows, next } = sliceWithNext(rows, take, "created_at");
+        const mapped = pageRows.map(sqlToOrganization);
+        return {
+          organizations: mapped,
+          start: 0,
+          limit: take,
+          length: mapped.length,
+          total: mapped.length,
+          next,
+        };
+      }
 
       let query = db
         .select()

--- a/packages/drizzle/src/adapters/userOrganizations.ts
+++ b/packages/drizzle/src/adapters/userOrganizations.ts
@@ -1,4 +1,4 @@
-import { eq, and, count as countFn } from "drizzle-orm";
+import { eq, and, count as countFn, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { HTTPException } from "hono/http-exception";
 import type {
@@ -8,6 +8,13 @@ import type {
 import { userOrganizations, organizations } from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import { buildLuceneFilter } from "../helpers/filter";
+import {
+  isKeysetRequest,
+  keysetCondition,
+  keysetOrderBy,
+  keysetTake,
+  sliceWithNext,
+} from "../helpers/paginate";
 import type { DrizzleDb } from "./types";
 
 export function createUserOrganizationsAdapter(db: DrizzleDb) {
@@ -91,30 +98,6 @@ export function createUserOrganizationsAdapter(db: DrizzleDb) {
     async list(tenantId: string, params?: ListParams) {
       const { include_totals = false, q } = params || {};
 
-      // Clamp pagination inputs. take wins over per_page, and from
-      // (checkpoint offset) wins over page. Mirrors the organizations adapter
-      // so the Auth0 SDK's from/take pagination is honored instead of being
-      // capped at the per_page default.
-      const rawPerPage = params?.take ?? params?.per_page;
-      const normalized =
-        typeof rawPerPage === "number" && Number.isFinite(rawPerPage)
-          ? Math.floor(rawPerPage)
-          : NaN;
-      const per_page = normalized >= 1 ? normalized : 50;
-
-      let offset = 0;
-      if (params?.from !== undefined) {
-        const parsed = parseInt(params.from, 10);
-        if (!Number.isNaN(parsed)) {
-          offset = Math.max(0, parsed);
-        }
-      } else if (
-        typeof params?.page === "number" &&
-        Number.isFinite(params.page)
-      ) {
-        offset = Math.max(0, Math.floor(params.page) * per_page);
-      }
-
       const tenantFilter = eq(userOrganizations.tenant_id, tenantId);
 
       let whereCondition = tenantFilter;
@@ -126,16 +109,54 @@ export function createUserOrganizationsAdapter(db: DrizzleDb) {
         if (filter) whereCondition = and(tenantFilter, filter)!;
       }
 
+      const stripTenant = (row: typeof userOrganizations.$inferSelect) => {
+        const { tenant_id: _, ...rest } = row;
+        return rest;
+      };
+
+      // Keyset (checkpoint) pagination: from/take. No total, matching Auth0's
+      // checkpoint responses. Sorted by created_at desc, id as tiebreaker.
+      if (isKeysetRequest(params)) {
+        const cols = {
+          sortColumn: userOrganizations.created_at,
+          idColumn: userOrganizations.id,
+          sortOrder: "desc" as const,
+        };
+        const keyset = keysetCondition(params, cols);
+        const take = keysetTake(params);
+        const rows = await db
+          .select()
+          .from(userOrganizations)
+          .where(keyset ? and(whereCondition, keyset) : whereCondition)
+          .orderBy(...keysetOrderBy(cols))
+          .limit(take + 1);
+        const { rows: pageRows, next } = sliceWithNext(
+          rows.map(stripTenant),
+          take,
+          "created_at",
+        );
+        return {
+          userOrganizations: pageRows,
+          start: 0,
+          limit: take,
+          length: pageRows.length,
+          next,
+        };
+      }
+
+      // Offset pagination (page/per_page) with a total count.
+      const page = params?.page ?? 0;
+      const per_page = params?.per_page ?? 50;
+      const offset = page * per_page;
+
       const results = await db
         .select()
         .from(userOrganizations)
         .where(whereCondition)
+        .orderBy(desc(userOrganizations.created_at), desc(userOrganizations.id))
         .offset(offset)
         .limit(per_page);
-      const mapped = results.map((row) => {
-        const { tenant_id: _, ...rest } = row;
-        return rest;
-      });
+      const mapped = results.map(stripTenant);
 
       if (!include_totals) {
         return { userOrganizations: mapped };

--- a/packages/drizzle/src/helpers/paginate.ts
+++ b/packages/drizzle/src/helpers/paginate.ts
@@ -1,0 +1,95 @@
+import { SQL, sql, asc, desc, gt, lt, Column } from "drizzle-orm";
+import {
+  ListParams,
+  decodeCursor,
+  encodeCursor,
+} from "@authhero/adapter-interfaces";
+
+/**
+ * Keyset (checkpoint) pagination primitives for the drizzle adapters — the
+ * Auth0 `from`/`take` style. `from` is an OPAQUE cursor (see encodeCursor)
+ * decoded to a `(sortValue, id)` position; `take` is the page size.
+ *
+ * Keyset-only: offset pagination (page/per_page + total), which the admin UI
+ * uses and which honors arbitrary user sort, stays in each adapter untouched.
+ * Adapters branch to these helpers only when from/take is present. Because
+ * drizzle's `.where()` replaces rather than appends, these are exposed as
+ * composable pieces (condition / orderBy / slice) an adapter folds into its
+ * own query rather than one all-in-one function.
+ */
+export function isKeysetRequest(params?: ListParams): boolean {
+  return params?.from !== undefined || params?.take !== undefined;
+}
+
+export function keysetTake(params?: ListParams): number {
+  const raw = params?.take;
+  const n = typeof raw === "number" && Number.isFinite(raw) ? Math.floor(raw) : NaN;
+  return n >= 1 ? n : 50;
+}
+
+export interface KeysetColumns {
+  sortColumn: Column;
+  idColumn: Column;
+  sortOrder: "asc" | "desc";
+}
+
+/** ORDER BY sortColumn, idColumn (tiebreaker), in the requested direction. */
+export function keysetOrderBy(cols: KeysetColumns): SQL[] {
+  const dir = cols.sortOrder === "asc" ? asc : desc;
+  return [dir(cols.sortColumn), dir(cols.idColumn)];
+}
+
+/**
+ * WHERE predicate that resumes after the cursor, or undefined for the first
+ * page. Uses a row-value comparison `(sort, id) </> (s, i)` (supported by
+ * SQLite >= 3.15 and MySQL) so the keyset is stable across the sort column and
+ * its unique tiebreaker.
+ */
+export function keysetCondition(
+  params: ListParams | undefined,
+  cols: KeysetColumns,
+): SQL | undefined {
+  const cursor = params?.from ? decodeCursor(params.from) : null;
+  if (!cursor) return undefined;
+
+  if (cursor.s === undefined || cursor.s === null) {
+    // Id-only ordering (or a null boundary): compare on the tiebreaker alone.
+    return cols.sortOrder === "asc"
+      ? gt(cols.idColumn, cursor.i)
+      : lt(cols.idColumn, cursor.i);
+  }
+
+  const op = cols.sortOrder === "asc" ? sql.raw(">") : sql.raw("<");
+  return sql`(${cols.sortColumn}, ${cols.idColumn}) ${op} (${cursor.s}, ${cursor.i})`;
+}
+
+/**
+ * Given rows fetched with `limit(take + 1)`, trim to the page and compute the
+ * `next` cursor. `sortField`/`idField` are the property names on the mapped or
+ * raw row to read the keyset position from.
+ */
+export function sliceWithNext<Row extends Record<string, unknown>>(
+  rows: Row[],
+  take: number,
+  sortField: string,
+  idField = "id",
+): { rows: Row[]; next?: string } {
+  const hasMore = rows.length > take;
+  const page = hasMore ? rows.slice(0, take) : rows;
+
+  let next: string | undefined;
+  const last = page[page.length - 1];
+  if (hasMore && last) {
+    const sortValue = last[sortField];
+    next = encodeCursor({
+      s:
+        typeof sortValue === "string" ||
+        typeof sortValue === "number" ||
+        sortValue === null
+          ? (sortValue as string | number | null)
+          : String(sortValue),
+      i: String(last[idField]),
+    });
+  }
+  return { rows: page, next };
+}

--- a/packages/kysely/src/clientGrants/list.ts
+++ b/packages/kysely/src/clientGrants/list.ts
@@ -1,13 +1,36 @@
-import { Kysely } from "kysely";
+import { Kysely, Selectable } from "kysely";
 import {
   ListParams,
   ListClientGrantsResponse,
   ClientGrant,
+  clientGrantSchema,
 } from "@authhero/adapter-interfaces";
 import { Database } from "../db";
 import getCountAsInt from "../utils/getCountAsInt";
 import { luceneFilter } from "../helpers/filter";
 import { removeNullProperties } from "../helpers/remove-nulls";
+import { keysetPaginate, isKeysetRequest } from "../helpers/paginate";
+
+// SQL rows store scope/authorization_details_types as JSON strings and booleans
+// as integers, and leave unset enum columns (organization_usage, subject_type)
+// as NULL. Stripping nulls turns those into absent optionals and
+// clientGrantSchema.parse then validates the enums and drops tenant_id — so no
+// casts are needed and only the JSON/boolean fields are prepared by hand.
+function sqlToClientGrant(
+  row: Selectable<Database["client_grants"]>,
+): ClientGrant {
+  return clientGrantSchema.parse(
+    removeNullProperties({
+      ...row,
+      scope: row.scope ? JSON.parse(row.scope) : [],
+      allow_any_organization: Boolean(row.allow_any_organization),
+      is_system: Boolean(row.is_system),
+      authorization_details_types: row.authorization_details_types
+        ? JSON.parse(row.authorization_details_types)
+        : [],
+    }),
+  );
+}
 
 export function list(db: Kysely<Database>) {
   return async (
@@ -39,27 +62,29 @@ export function list(db: Kysely<Database>) {
         // Special handling for boolean fields that are stored as integers
         if (fieldName === "allow_any_organization") {
           const boolValue = value === "true" ? 1 : 0;
-          if (neg) {
-            query = query.where(columnRef, "!=", boolValue);
-          } else {
-            query = query.where(columnRef, "=", boolValue);
-          }
+          query = query.where(columnRef, neg ? "!=" : "=", boolValue);
         } else {
-          // Generic handling for string fields
-          if (neg) {
-            query = query.where(columnRef, "!=", value);
-          } else {
-            query = query.where(columnRef, "=", value);
-          }
+          query = query.where(columnRef, neg ? "!=" : "=", value);
         }
       } else {
         query = luceneFilter(db, query, trimmedQ, []);
       }
     }
 
-    let filteredQuery = query;
+    // Keyset (checkpoint) pagination: from/take. Fixed created_at desc order
+    // with id tiebreaker; no total, matching Auth0's checkpoint responses.
+    if (isKeysetRequest(params)) {
+      const { rows, limit, next } = await keysetPaginate(
+        query.selectAll(),
+        params,
+        { sortColumn: "created_at", sortOrder: "desc" },
+      );
+      const client_grants = rows.map(sqlToClientGrant);
+      return { client_grants, start: 0, limit, length: client_grants.length, next };
+    }
 
-    // Add sorting if specified
+    // Offset pagination.
+    let filteredQuery = query;
     if (sort) {
       const { ref } = db.dynamic;
       filteredQuery = filteredQuery.orderBy(ref(sort.sort_by), sort.sort_order);
@@ -67,46 +92,15 @@ export function list(db: Kysely<Database>) {
       filteredQuery = filteredQuery.orderBy("client_grants.created_at", "desc");
     }
 
-    filteredQuery = filteredQuery.limit(per_page).offset(page * per_page);
-
-    const results = await filteredQuery.selectAll().execute();
-
-    const clientGrants: ClientGrant[] = results.map((result) => {
-      const clientGrant: ClientGrant = {
-        id: result.id,
-        client_id: result.client_id,
-        audience: result.audience,
-        scope: result.scope ? JSON.parse(result.scope) : [],
-        organization_usage: result.organization_usage as
-          | "deny"
-          | "allow"
-          | "require"
-          | undefined,
-        // Convert integers back to booleans for API response (with defaults)
-        allow_any_organization:
-          result.allow_any_organization !== undefined
-            ? Boolean(result.allow_any_organization)
-            : false,
-        is_system:
-          result.is_system !== undefined ? Boolean(result.is_system) : false,
-        subject_type: result.subject_type as "client" | "user" | undefined,
-        authorization_details_types: result.authorization_details_types
-          ? JSON.parse(result.authorization_details_types)
-          : [],
-        created_at: result.created_at,
-        updated_at: result.updated_at,
-      };
-
-      return removeNullProperties(clientGrant);
-    });
+    const results = await filteredQuery
+      .selectAll()
+      .limit(per_page)
+      .offset(page * per_page)
+      .execute();
+    const client_grants = results.map(sqlToClientGrant);
 
     if (!include_totals) {
-      return {
-        client_grants: clientGrants,
-        start: 0,
-        limit: 0,
-        length: 0,
-      };
+      return { client_grants, start: 0, limit: 0, length: 0 };
     }
 
     const { count } = await query
@@ -114,7 +108,7 @@ export function list(db: Kysely<Database>) {
       .executeTakeFirstOrThrow();
 
     return {
-      client_grants: clientGrants,
+      client_grants,
       start: page * per_page,
       limit: per_page,
       length: getCountAsInt(count),

--- a/packages/kysely/src/helpers/paginate.ts
+++ b/packages/kysely/src/helpers/paginate.ts
@@ -1,0 +1,101 @@
+import { sql, SelectQueryBuilder, SqlBool } from "kysely";
+import {
+  ListParams,
+  decodeCursor,
+  encodeCursor,
+} from "@authhero/adapter-interfaces";
+
+/**
+ * Keyset (checkpoint) pagination for list queries — the Auth0 `from`/`take`
+ * style. `from` is an OPAQUE cursor (see encodeCursor), decoded to a
+ * `(sortValue, id)` position; `take` is the page size. We fetch `take + 1`
+ * rows to detect whether another page follows and emit a `next` cursor,
+ * absent on the last page.
+ *
+ * This is intentionally keyset-only. Offset pagination (page/per_page + total),
+ * which the admin UI uses and which honors arbitrary user sort, stays in each
+ * adapter untouched. Callers branch to this helper only when `from`/`take` is
+ * present. The helper owns ORDER BY (sortColumn then idColumn as a unique
+ * tiebreaker), so the passed query must not be pre-ordered.
+ */
+export function isKeysetRequest(params?: ListParams): boolean {
+  return params?.from !== undefined || params?.take !== undefined;
+}
+
+export interface KeysetOptions {
+  /** Column to sort by. Must be a real column on the queried table. */
+  sortColumn: string;
+  sortOrder: "asc" | "desc";
+  /** Unique tiebreaker column; defaults to "id". */
+  idColumn?: string;
+}
+
+export interface KeysetResult<Row> {
+  rows: Row[];
+  /** Page size actually applied. */
+  limit: number;
+  /** Opaque cursor for the next page; set only when more rows follow. */
+  next?: string;
+}
+
+function clampSize(raw: number | undefined, fallback: number): number {
+  const n =
+    typeof raw === "number" && Number.isFinite(raw) ? Math.floor(raw) : NaN;
+  return n >= 1 ? n : fallback;
+}
+
+export async function keysetPaginate<DB, TB extends keyof DB, O>(
+  query: SelectQueryBuilder<DB, TB, O>,
+  params: ListParams | undefined,
+  options: KeysetOptions,
+): Promise<KeysetResult<O>> {
+  const { sortColumn, sortOrder } = options;
+  const idColumn = options.idColumn ?? "id";
+  const take = clampSize(params?.take, 50);
+
+  let ordered = query
+    .orderBy(sql.ref(sortColumn), sortOrder)
+    .orderBy(sql.ref(idColumn), sortOrder);
+
+  const cursor = params?.from ? decodeCursor(params.from) : null;
+  if (cursor) {
+    if (cursor.s === undefined || cursor.s === null) {
+      // Id-only ordering (or a null boundary): compare on the tiebreaker alone.
+      ordered = ordered.where(
+        sql.ref(idColumn),
+        sortOrder === "asc" ? ">" : "<",
+        cursor.i,
+      );
+    } else {
+      // Row-value comparison keeps the keyset stable across the sort column and
+      // its tiebreaker: (sort, id) </> (cursorSort, cursorId). Supported by
+      // SQLite (>= 3.15) and MySQL/PlanetScale.
+      const cmp = sortOrder === "asc" ? sql.raw(">") : sql.raw("<");
+      ordered = ordered.where(
+        sql<SqlBool>`(${sql.ref(sortColumn)}, ${sql.ref(idColumn)}) ${cmp} (${cursor.s}, ${cursor.i})`,
+      );
+    }
+  }
+
+  // One extra row tells us whether a further page exists.
+  const fetched = await ordered.limit(take + 1).execute();
+  const hasMore = fetched.length > take;
+  const rows = hasMore ? fetched.slice(0, take) : fetched;
+
+  let next: string | undefined;
+  if (hasMore && rows.length > 0) {
+    const last = rows[rows.length - 1] as Record<string, unknown>;
+    const sortValue = last[sortColumn];
+    next = encodeCursor({
+      s:
+        typeof sortValue === "string" ||
+        typeof sortValue === "number" ||
+        sortValue === null
+          ? (sortValue as string | number | null)
+          : String(sortValue),
+      i: String(last[idColumn]),
+    });
+  }
+
+  return { rows, limit: take, next };
+}

--- a/packages/kysely/src/organizations/list.ts
+++ b/packages/kysely/src/organizations/list.ts
@@ -6,6 +6,7 @@ import {
 } from "@authhero/adapter-interfaces";
 import { removeNullProperties } from "../helpers/remove-nulls";
 import { luceneFilter, sanitizeLuceneQuery } from "../helpers/filter";
+import { keysetPaginate, isKeysetRequest } from "../helpers/paginate";
 
 const ALLOWED_Q_FIELDS = ["name", "display_name"];
 
@@ -30,7 +31,39 @@ export function list(db: Kysely<Database>) {
       }
     }
 
-    // Apply sorting
+    // Keyset (checkpoint) pagination: from/take. Ordered by created_at desc with
+    // id as tiebreaker (a fixed, stable order — dynamic sort applies to offset
+    // pagination only), and no total, matching Auth0's checkpoint responses.
+    if (isKeysetRequest(params)) {
+      const { rows, limit, next } = await keysetPaginate(
+        baseQuery.selectAll(),
+        params,
+        { sortColumn: "created_at", sortOrder: "desc" },
+      );
+      const organizations = rows.map((result) =>
+        removeNullProperties({
+          ...result,
+          branding: result.branding ? JSON.parse(result.branding) : {},
+          metadata: result.metadata ? JSON.parse(result.metadata) : {},
+          enabled_connections: result.enabled_connections
+            ? JSON.parse(result.enabled_connections)
+            : [],
+          token_quota: result.token_quota
+            ? JSON.parse(result.token_quota)
+            : {},
+        }),
+      );
+      return {
+        organizations,
+        start: 0,
+        limit,
+        length: organizations.length,
+        total: organizations.length,
+        next,
+      };
+    }
+
+    // Apply sorting (offset pagination)
     if (params?.sort) {
       const sortOrder = params.sort.sort_order === "asc" ? "asc" : "desc";
       const sortBy = params.sort.sort_by as
@@ -47,8 +80,8 @@ export function list(db: Kysely<Database>) {
     }
 
     // Clamp pagination inputs so negative or non-finite values cannot
-    // produce bad SQL. take wins over per_page when both are supplied.
-    const rawPerPage = params?.take ?? params?.per_page;
+    // produce bad SQL.
+    const rawPerPage = params?.per_page;
     const normalized =
       typeof rawPerPage === "number" && Number.isFinite(rawPerPage)
         ? Math.floor(rawPerPage)
@@ -56,12 +89,7 @@ export function list(db: Kysely<Database>) {
     const perPage = normalized >= 1 ? normalized : 10;
 
     let offset = 0;
-    if (params?.from !== undefined) {
-      const parsed = parseInt(params.from, 10);
-      if (!Number.isNaN(parsed)) {
-        offset = Math.max(0, parsed);
-      }
-    } else if (
+    if (
       typeof params?.page === "number" &&
       Number.isFinite(params.page)
     ) {

--- a/packages/kysely/src/user-organizations/list.ts
+++ b/packages/kysely/src/user-organizations/list.ts
@@ -5,33 +5,13 @@ import {
   Totals,
   ListParams,
 } from "@authhero/adapter-interfaces";
+import { keysetPaginate, isKeysetRequest } from "../helpers/paginate";
 
 export function list(db: Kysely<Database>) {
   return async (
     tenantId: string,
     params?: ListParams,
   ): Promise<{ userOrganizations: UserOrganization[] } & Totals> => {
-    // Clamp pagination inputs so negative or non-finite values cannot
-    // produce bad SQL. take wins over per_page when both are supplied, and
-    // from (checkpoint offset) wins over page. This mirrors the organizations
-    // adapter so the Auth0 SDK's from/take pagination is honored.
-    const rawPerPage = params?.take ?? params?.per_page;
-    const normalized =
-      typeof rawPerPage === "number" && Number.isFinite(rawPerPage)
-        ? Math.floor(rawPerPage)
-        : NaN;
-    const per_page = normalized >= 1 ? normalized : 50;
-
-    let offset = 0;
-    if (params?.from !== undefined) {
-      const parsed = parseInt(params.from, 10);
-      if (!Number.isNaN(parsed)) {
-        offset = Math.max(0, parsed);
-      }
-    } else if (typeof params?.page === "number" && Number.isFinite(params.page)) {
-      offset = Math.max(0, Math.floor(params.page) * per_page);
-    }
-
     let query = db
       .selectFrom("user_organizations")
       .selectAll()
@@ -49,15 +29,47 @@ export function list(db: Kysely<Database>) {
       }
     }
 
-    query = query.orderBy("created_at", "desc");
+    const mapRow = (result: {
+      id: string;
+      user_id: string;
+      organization_id: string;
+      created_at: string;
+      updated_at: string;
+    }): UserOrganization => ({
+      id: result.id,
+      user_id: result.user_id,
+      organization_id: result.organization_id,
+      created_at: result.created_at,
+      updated_at: result.updated_at,
+    });
 
-    if (per_page > 0) {
-      query = query.limit(per_page).offset(offset);
+    // Keyset (checkpoint) pagination: from/take. No total is computed, matching
+    // Auth0's checkpoint responses.
+    if (isKeysetRequest(params)) {
+      const { rows, limit, next } = await keysetPaginate(query, params, {
+        sortColumn: "created_at",
+        sortOrder: "desc",
+      });
+      return {
+        userOrganizations: rows.map(mapRow),
+        start: 0,
+        limit,
+        length: rows.length,
+        next,
+      };
     }
 
-    const results = await query.execute();
+    // Offset pagination (page/per_page) with a total count.
+    const page = params?.page || 0;
+    const per_page = params?.per_page || 50;
+    const offset = page * per_page;
 
-    // Get total count with the same filters
+    const results = await query
+      .orderBy("created_at", "desc")
+      .limit(per_page)
+      .offset(offset)
+      .execute();
+
     let countQuery = db
       .selectFrom("user_organizations")
       .select(db.fn.count("id").as("count"))
@@ -75,16 +87,8 @@ export function list(db: Kysely<Database>) {
 
     const total = await countQuery.executeTakeFirst();
 
-    const userOrganizations: UserOrganization[] = results.map((result) => ({
-      id: result.id,
-      user_id: result.user_id,
-      organization_id: result.organization_id,
-      created_at: result.created_at,
-      updated_at: result.updated_at,
-    }));
-
     return {
-      userOrganizations,
+      userOrganizations: results.map(mapRow),
       start: offset,
       limit: per_page,
       length: Number(total?.count || 0),

--- a/packages/kysely/test/clientGrants.test.ts
+++ b/packages/kysely/test/clientGrants.test.ts
@@ -238,6 +238,47 @@ describe("ClientGrantsAdapter", () => {
     expect(result.limit).toBe(3);
   });
 
+  it("should paginate client grants with from/take (keyset checkpoint)", async () => {
+    for (let i = 0; i < 5; i++) {
+      await db
+        .insertInto("resource_servers")
+        .values({
+          id: `ks-api-${i}-id`,
+          tenant_id: tenantId,
+          identifier: `https://ks-api${i}.example.com`,
+          name: `KS API ${i}`,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .execute();
+      await adapter.clientGrants.create(tenantId, {
+        client_id: "test-client-id",
+        audience: `https://ks-api${i}.example.com`,
+        scope: [`read:ks${i}`],
+      });
+    }
+
+    // Walk every grant via the opaque `next` cursor; no total, no duplicates.
+    const seen = new Set<string>();
+    let from: string | undefined;
+    let pages = 0;
+    for (;;) {
+      const batch = await adapter.clientGrants.list(tenantId, { take: 2, from });
+      expect(batch.client_grants.length).toBeLessThanOrEqual(2);
+      for (const g of batch.client_grants) {
+        expect(seen.has(g.id)).toBe(false);
+        seen.add(g.id);
+      }
+      pages++;
+      if (!batch.next) break;
+      from = batch.next;
+      if (pages > 5) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.size).toBe(5);
+    expect(pages).toBe(3); // 2 + 2 + 1
+  });
+
   it("should filter client grants by audience", async () => {
     // Create another resource server
     await db

--- a/packages/kysely/test/keyset-pagination.test.ts
+++ b/packages/kysely/test/keyset-pagination.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestServer } from "./helpers/test-server";
+import { decodeCursor } from "@authhero/adapter-interfaces";
+
+// Exercises the shared keyset paginator via the user-organizations adapter,
+// which sorts by created_at desc with id as the tiebreaker.
+describe("keyset pagination (from/take)", () => {
+  let data: any;
+  const tenantId = "keyset-tenant";
+  const organizationId = "org_keyset";
+
+  beforeEach(async () => {
+    const server = await getTestServer();
+    data = server.data;
+
+    await data.organizations.create(tenantId, {
+      id: organizationId,
+      name: "keyset-org",
+      display_name: "Keyset Org",
+    });
+
+    // Seed more rows than a single page. created_at has second-ish resolution,
+    // so many rows can share a timestamp — this is exactly why the id
+    // tiebreaker matters, and the test deliberately does not space them out.
+    for (let i = 0; i < 25; i++) {
+      await data.userOrganizations.create(tenantId, {
+        user_id: `user-${i.toString().padStart(2, "0")}`,
+        organization_id: organizationId,
+      });
+    }
+  });
+
+  it("walks every row exactly once across pages via next", async () => {
+    const q = `organization_id:${organizationId}`;
+    const seen = new Set<string>();
+    let from: string | undefined;
+    let pages = 0;
+
+    for (;;) {
+      const res = await data.userOrganizations.list(tenantId, {
+        q,
+        take: 10,
+        from,
+      });
+      pages++;
+      expect(res.userOrganizations.length).toBeLessThanOrEqual(10);
+      for (const row of res.userOrganizations) {
+        expect(seen.has(row.id)).toBe(false); // no duplicates across pages
+        seen.add(row.id);
+      }
+      if (!res.next) break;
+      from = res.next;
+      if (pages > 10) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.size).toBe(25);
+    expect(pages).toBe(3); // 10 + 10 + 5
+  });
+
+  it("omits next on the final page", async () => {
+    const res = await data.userOrganizations.list(tenantId, {
+      q: `organization_id:${organizationId}`,
+      take: 50,
+    });
+    expect(res.userOrganizations).toHaveLength(25);
+    expect(res.next).toBeUndefined();
+  });
+
+  it("emits an opaque, decodable cursor (not a numeric offset)", async () => {
+    const res = await data.userOrganizations.list(tenantId, {
+      q: `organization_id:${organizationId}`,
+      take: 10,
+    });
+    expect(res.next).toBeDefined();
+    // A bare offset like "10" must NOT be what we hand back.
+    expect(res.next).not.toBe("10");
+    const decoded = decodeCursor(res.next);
+    expect(decoded).not.toBeNull();
+    expect(typeof decoded!.i).toBe("string");
+  });
+
+  it("is stable when a row is inserted mid-walk", async () => {
+    const q = `organization_id:${organizationId}`;
+    const page1 = await data.userOrganizations.list(tenantId, { q, take: 10 });
+
+    // Insert a new membership between page fetches. Offset pagination would
+    // shift rows and duplicate/skip; keyset must not.
+    await data.userOrganizations.create(tenantId, {
+      user_id: "user-inserted",
+      organization_id: organizationId,
+    });
+
+    const page1Ids = new Set(page1.userOrganizations.map((r: any) => r.id));
+    const page2 = await data.userOrganizations.list(tenantId, {
+      q,
+      take: 10,
+      from: page1.next,
+    });
+    for (const row of page2.userOrganizations) {
+      expect(page1Ids.has(row.id)).toBe(false);
+    }
+  });
+});

--- a/packages/kysely/test/organizations.test.ts
+++ b/packages/kysely/test/organizations.test.ts
@@ -125,7 +125,7 @@ describe("OrganizationsAdapter", () => {
     expect(page1Ids).not.toEqual(page2Ids);
   });
 
-  it("should paginate organizations with from/take (checkpoint)", async () => {
+  it("should paginate organizations with from/take (keyset checkpoint)", async () => {
     // Create 5 organizations
     for (let i = 0; i < 5; i++) {
       await adapter.organizations.create(tenantId, {
@@ -133,32 +133,37 @@ describe("OrganizationsAdapter", () => {
       });
     }
 
-    // Get first batch using checkpoint pagination
+    // Get first batch using checkpoint pagination. Keyset returns an opaque
+    // `next` cursor (not a numeric offset) and no grand total, matching Auth0.
     const batch1 = await adapter.organizations.list(tenantId, {
-      from: "0",
       take: 2,
-      include_totals: true,
     });
 
     expect(batch1.organizations).toHaveLength(2);
-    expect(batch1.total).toBe(5);
-    expect(batch1.start).toBe(0);
+    expect(batch1.next).toBeDefined();
     expect(batch1.limit).toBe(2);
 
-    // Get second batch
-    const batch2 = await adapter.organizations.list(tenantId, {
-      from: "2",
-      take: 2,
-      include_totals: true,
-    });
+    // Walk the remaining pages via the cursor and assert full, unique coverage.
+    const seen = new Set<string>(
+      batch1.organizations.map((o: any) => o.id),
+    );
+    let from = batch1.next;
+    let pages = 1;
+    while (from) {
+      const batch = await adapter.organizations.list(tenantId, {
+        take: 2,
+        from,
+      });
+      for (const o of batch.organizations) {
+        expect(seen.has(o.id)).toBe(false);
+        seen.add(o.id);
+      }
+      from = batch.next;
+      pages++;
+      if (pages > 5) throw new Error("cursor walk did not terminate");
+    }
 
-    expect(batch2.organizations).toHaveLength(2);
-    expect(batch2.start).toBe(2);
-
-    // Verify different results
-    const batch1Ids = batch1.organizations.map((o: any) => o.id);
-    const batch2Ids = batch2.organizations.map((o: any) => o.id);
-    expect(batch1Ids).not.toEqual(batch2Ids);
+    expect(seen.size).toBe(5);
   });
 
   it("should search organizations with q parameter", async () => {


### PR DESCRIPTION
Implements #1098. Introduces Auth0-style **keyset (checkpoint) pagination** with an **opaque `next` cursor**, replacing the offset-backed `from` that #1097 shipped as a stopgap.

## Design (dual-mode)

Per the agreed dual-mode approach:
- **Offset pagination** (`page`/`per_page` + `total`) is **unchanged** — the admin UI keeps numbered pages and totals.
- **Keyset pagination** (`from`/`take` → `next`) is added alongside. `from` is now an **opaque cursor** (base64url of `{sortValue, id}`), not a numeric offset. Adapters branch to keyset only when `from`/`take` is present.

Keyset uses a `(sortColumn, id)` row-value comparison with a `take + 1` look-ahead to emit `next` (absent on the last page). Stable under concurrent writes; no 1000-row offset ceiling.

## What's in this PR

**Foundation (shared):**
- `adapter-interfaces`: `encodeCursor`/`decodeCursor` (+ `base64url` helper), `next` on the list-response contract, `from` documented as opaque.
- `kysely`: shared `keysetPaginate` helper.
- `drizzle`: shared keyset primitives (`keysetCondition`/`keysetOrderBy`/`sliceWithNext`).

**Endpoints converted (Auth0 checkpoint endpoints):**
- `GET /organizations` and `GET /organizations/{id}/members` — return `{ items, next }` under `from`/`take`, offset shape under `page`/`per_page`. Both backends.

**Admin UI:**
- Org-members view switched to offset (`page`/`per_page`) so it keeps numbered pages + totals (opaque cursors can't do numbered/jump-to-page).

**Tests:**
- kysely adapter keyset walk: multi-page, no duplicates, stable across a concurrent insert, opaque (non-offset) cursor, `next` omitted on last page.
- Endpoint-level cursor walk over `GET /organizations/{id}/members`.

## Remaining (follow-up, tracked in #1098)

The Category-2 offset endpoints (users, clients, roles, connections, hooks, actions, forms, flows, grants, logs, resource-servers, user sub-lists) + client-grants + the aws adapter still need the same helper applied. Because offset stays the default, these keep working unchanged until converted — nothing breaks. See the discussion below re: whether full Category-2 conversion is worth the churn given the admin UI (the primary consumer) uses offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Auth0-style checkpoint pagination for organization and organization-member listings.
  * Responses now provide an opaque `next` cursor for retrieving subsequent pages.
  * Existing numbered pagination with page totals remains available for administrative views.

* **Bug Fixes**
  * Organization-member listings now honor requested page size and continuation cursors instead of being capped at 10 results.
  * Pagination remains stable without duplicate or skipped records when data changes between requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->