### PR TITLE
feat(clients): true keyset (checkpoint) cursors for GET /clients — #1098

### DIFF
--- a/.changeset/clients-keyset-pagination.md
+++ b/.changeset/clients-keyset-pagination.md
@@ -1,0 +1,11 @@
+---
+"authhero": minor
+"@authhero/kysely-adapter": minor
+"@authhero/drizzle": minor
+---
+
+`GET /clients` now supports true keyset (checkpoint) pagination with an opaque `next` cursor.
+
+Auth0 documents `/clients` as a checkpoint endpoint, but our implementation treated `from` as a numeric SQL offset and never returned `next`. The kysely and drizzle adapters now branch to the shared keyset paginator (created_at desc, client_id tiebreaker) when `from`/`take` is present, and the endpoint returns `{ clients, next }` in that mode. Offset pagination (`page`/`per_page` + `total`), used by the admin UI, is unchanged.
+
+The drizzle adapter's list response is also aligned with the adapter contract: totals are now returned as a nested `totals` object (previously flattened and dropped by the management API), `length` reflects the returned page rather than the total count, and the `include_totals` count now honors the `q` filter.

--- a/packages/authhero/src/routes/management-api/clients.ts
+++ b/packages/authhero/src/routes/management-api/clients.ts
@@ -21,10 +21,12 @@ import { defineRoute } from "../../utils/define-route";
 // per-tenant "AuthHero Try Connection" stub created by ensureTryConnectionClient).
 // Hide from the listing and block destructive writes — the row is recreated
 // on demand and admins can't usefully manage it.
-function isSystemClient(client: {
-  client_id?: string;
-  client_metadata?: Record<string, string> | null;
-} | null): boolean {
+function isSystemClient(
+  client: {
+    client_id?: string;
+    client_metadata?: Record<string, string> | null;
+  } | null,
+): boolean {
   if (!client?.client_id) return false;
   if (client.client_metadata?.system_purpose === "try_connection") return true;
   return isTryConnectionClientId(client.client_id);
@@ -125,6 +127,14 @@ const clientWithTotalsSchema = totalsSchema.extend({
   clients: z.array(clientSchema),
 });
 
+// Checkpoint (keyset) pagination response: items plus an opaque cursor.
+const clientsWithNextSchema = z.object({
+  clients: z.array(clientSchema),
+  next: z.string().optional().openapi({
+    description: "Opaque cursor for the next page; absent on the last page.",
+  }),
+});
+
 // Schema for client connections response
 const clientConnectionsResponseSchema = z.object({
   enabled_connections: z.array(
@@ -157,7 +167,11 @@ const getRoot = defineRoute({
       200: {
         content: {
           "application/json": {
-            schema: z.union([clientWithTotalsSchema, z.array(clientSchema)]),
+            schema: z.union([
+              clientWithTotalsSchema,
+              z.array(clientSchema),
+              clientsWithNextSchema,
+            ]),
           },
         },
         description: "List of clients",
@@ -166,7 +180,8 @@ const getRoot = defineRoute({
   }),
   handler: async (ctx) => {
     const tenant_id = ctx.var.tenant_id;
-    const { page, per_page, include_totals, sort, q } = ctx.req.valid("query");
+    const { page, per_page, include_totals, sort, q, from, take } =
+      ctx.req.valid("query");
 
     const result = await ctx.env.data.clients.list(tenant_id, {
       page,
@@ -174,6 +189,8 @@ const getRoot = defineRoute({
       include_totals,
       sort: parseSort(sort),
       q,
+      from,
+      take,
     });
 
     // Strip platform-managed clients (e.g. the try-connection stub) from the
@@ -183,6 +200,17 @@ const getRoot = defineRoute({
     // tenant. `length` reflects the filtered page so the client can render
     // the slice it received.
     const clients = result.clients.filter((c) => !isSystemClient(c));
+
+    // Keyset (checkpoint) pagination: return Auth0's { items, next } shape so
+    // clients can page past the first page via the opaque cursor. The cursor
+    // is taken from the adapter's unfiltered last row, so stripping system
+    // clients above can shorten a page but never breaks the walk.
+    if (from !== undefined || take !== undefined) {
+      return ctx.json({
+        clients,
+        next: result.totals?.next,
+      });
+    }
 
     if (include_totals) {
       return ctx.json({

--- a/packages/authhero/test/routes/management-api/clients.spec.ts
+++ b/packages/authhero/test/routes/management-api/clients.spec.ts
@@ -176,6 +176,58 @@ describe("clients", () => {
     expect(get404Response.status).toBe(404);
   });
 
+  it("walks all clients across pages via the opaque next cursor", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const tenantId = "clients-cursor-tenant";
+    await env.data.tenants.create({
+      id: tenantId,
+      friendly_name: "Clients Cursor Tenant",
+      audience: "https://example.com",
+      sender_email: "login@example.com",
+      sender_name: "SenderName",
+    });
+
+    for (let i = 0; i < 7; i++) {
+      await env.data.clients.create(tenantId, {
+        client_id: `cursor-client-${i}`,
+        name: `Cursor Client ${i}`,
+      });
+    }
+
+    const seen = new Set<string>();
+    let from: string | undefined;
+    let pages = 0;
+    for (;;) {
+      const response = await managementClient.clients.$get(
+        {
+          query: from ? { take: "3", from } : { take: "3" },
+          header: { "tenant-id": tenantId },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(response.status).toBe(200);
+      // Checkpoint pagination returns { clients, next }, not a bare array.
+      const data = (await response.json()) as {
+        clients: Client[];
+        next?: string;
+      };
+      for (const client of data.clients) {
+        expect(seen.has(client.client_id)).toBe(false);
+        seen.add(client.client_id);
+      }
+      pages++;
+      if (!data.next) break;
+      from = data.next;
+      if (pages > 5) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.size).toBe(7);
+    expect(pages).toBe(3); // 3 + 3 + 1
+  });
+
   it("should get and update client connections", async () => {
     const { managementApp, env } = await getTestServer();
     const managementClient = testClient(managementApp, env);

--- a/packages/drizzle/src/adapters/clients.ts
+++ b/packages/drizzle/src/adapters/clients.ts
@@ -13,6 +13,13 @@ import {
   removeUndefinedAndNull,
 } from "../helpers/transform";
 import { buildLuceneFilter } from "../helpers/filter";
+import {
+  isKeysetRequest,
+  keysetCondition,
+  keysetOrderBy,
+  keysetTake,
+  sliceWithNext,
+} from "../helpers/paginate";
 import type { DrizzleDb } from "./types";
 
 const BOOLEAN_FIELDS = [
@@ -239,17 +246,44 @@ export function createClientsAdapter(db: DrizzleDb): ClientsAdapter {
         q,
       } = params || {};
 
-      let query = db
-        .select()
-        .from(clients)
-        .where(eq(clients.tenant_id, tenant_id))
-        .$dynamic();
+      const luceneFilter = q
+        ? buildLuceneFilter(clients, q, ["name", "client_id"])
+        : undefined;
+      const whereCondition = luceneFilter
+        ? and(eq(clients.tenant_id, tenant_id), luceneFilter)
+        : eq(clients.tenant_id, tenant_id);
 
-      if (q) {
-        const filter = buildLuceneFilter(clients, q, ["name", "client_id"]);
-        if (filter)
-          query = query.where(and(eq(clients.tenant_id, tenant_id), filter));
+      // Keyset (checkpoint) pagination: from/take. Fixed created_at desc order
+      // with client_id tiebreaker; no total, matching Auth0's checkpoint
+      // responses.
+      if (isKeysetRequest(params)) {
+        const cols = {
+          sortColumn: clients.created_at,
+          idColumn: clients.client_id,
+          sortOrder: "desc" as const,
+        };
+        const keyset = keysetCondition(params, cols);
+        const take = keysetTake(params);
+        const rows = await db
+          .select()
+          .from(clients)
+          .where(keyset ? and(whereCondition, keyset) : whereCondition)
+          .orderBy(...keysetOrderBy(cols))
+          .limit(take + 1);
+        const { rows: pageRows, next } = sliceWithNext(
+          rows,
+          take,
+          "created_at",
+          "client_id",
+        );
+        const mapped = pageRows.map(sqlToClient);
+        return {
+          clients: mapped,
+          totals: { start: 0, limit: take, length: mapped.length, next },
+        };
       }
+
+      let query = db.select().from(clients).where(whereCondition).$dynamic();
 
       if (sort?.sort_by) {
         const col = (clients as any)[sort.sort_by];
@@ -270,13 +304,16 @@ export function createClientsAdapter(db: DrizzleDb): ClientsAdapter {
       const [countResult] = await db
         .select({ count: countFn() })
         .from(clients)
-        .where(eq(clients.tenant_id, tenant_id));
+        .where(whereCondition);
 
       return {
         clients: mapped,
-        start: page * per_page,
-        limit: per_page,
-        length: Number(countResult?.count ?? 0),
+        totals: {
+          start: page * per_page,
+          limit: per_page,
+          length: mapped.length,
+          total: Number(countResult?.count ?? 0),
+        },
       };
     },
 

--- a/packages/kysely/src/clients/list.ts
+++ b/packages/kysely/src/clients/list.ts
@@ -1,8 +1,56 @@
 import { Client, Totals } from "@authhero/adapter-interfaces";
-import { Kysely, sql } from "kysely";
+import { Kysely, Selectable, sql } from "kysely";
 import { Database } from "../db";
 import { ListParams } from "@authhero/adapter-interfaces";
 import { removeNullProperties } from "../helpers/remove-nulls";
+import { keysetPaginate, isKeysetRequest } from "../helpers/paginate";
+
+function sqlToClient(result: Selectable<Database["clients"]>): Client {
+  return removeNullProperties<Client>({
+    ...result,
+    // Convert integer fields back to booleans
+    global: !!result.global,
+    is_first_party: !!result.is_first_party,
+    oidc_conformant: !!result.oidc_conformant,
+    auth0_conformant: !!result.auth0_conformant,
+    sso: !!result.sso,
+    sso_disabled: !!result.sso_disabled,
+    cross_origin_authentication: !!result.cross_origin_authentication,
+    custom_login_page_on: !!result.custom_login_page_on,
+    require_pushed_authorization_requests:
+      !!result.require_pushed_authorization_requests,
+    require_proof_of_possession: !!result.require_proof_of_possession,
+    hide_sign_up_disabled_error: !!result.hide_sign_up_disabled_error,
+    // Parse JSON string fields back to objects/arrays
+    callbacks: JSON.parse(result.callbacks),
+    allowed_origins: JSON.parse(result.allowed_origins),
+    web_origins: JSON.parse(result.web_origins),
+    client_aliases: JSON.parse(result.client_aliases),
+    allowed_clients: JSON.parse(result.allowed_clients),
+    connections: JSON.parse(result.connections || "[]"),
+    allowed_logout_urls: JSON.parse(result.allowed_logout_urls),
+    session_transfer: JSON.parse(result.session_transfer),
+    oidc_logout: JSON.parse(result.oidc_logout),
+    grant_types: JSON.parse(result.grant_types),
+    jwt_configuration: JSON.parse(result.jwt_configuration),
+    signing_keys: JSON.parse(result.signing_keys),
+    encryption_key: JSON.parse(result.encryption_key),
+    addons: JSON.parse(result.addons),
+    client_metadata: JSON.parse(result.client_metadata),
+    mobile: JSON.parse(result.mobile),
+    native_social_login: JSON.parse(result.native_social_login),
+    refresh_token: JSON.parse(result.refresh_token),
+    default_organization: JSON.parse(result.default_organization),
+    client_authentication_methods: JSON.parse(
+      result.client_authentication_methods,
+    ),
+    signed_request_object: JSON.parse(result.signed_request_object),
+    token_quota: JSON.parse(result.token_quota),
+    registration_metadata: result.registration_metadata
+      ? JSON.parse(result.registration_metadata)
+      : undefined,
+  });
+}
 
 export function list(db: Kysely<Database>) {
   return async (
@@ -46,7 +94,23 @@ export function list(db: Kysely<Database>) {
       }
     }
 
-    // Apply sorting
+    // Keyset (checkpoint) pagination: from/take. Fixed created_at desc order
+    // with client_id tiebreaker; no total, matching Auth0's checkpoint
+    // responses.
+    if (isKeysetRequest(params)) {
+      const { rows, limit, next } = await keysetPaginate(
+        query.selectAll(),
+        params,
+        { sortColumn: "created_at", sortOrder: "desc", idColumn: "client_id" },
+      );
+      const clients = rows.map(sqlToClient);
+      return {
+        clients,
+        totals: { start: 0, limit, length: clients.length, next },
+      };
+    }
+
+    // Offset pagination.
     if (params?.sort) {
       const sortOrder = params.sort.sort_order === "asc" ? "asc" : "desc";
       const sortBy = params.sort.sort_by as
@@ -63,23 +127,14 @@ export function list(db: Kysely<Database>) {
       query = query.orderBy("created_at", "desc");
     }
 
-    // Handle checkpoint pagination (from/take)
-    if (params?.from !== undefined) {
-      const offset = parseInt(params.from, 10);
-      if (!isNaN(offset)) {
-        query = query.offset(offset);
-      }
-    } else if (params?.page !== undefined) {
-      const perPage = params?.per_page || params?.take || 10;
-      const offset = params.page * perPage;
-      query = query.offset(offset);
-    }
+    const page = params?.page ?? 0;
+    const limit = params?.per_page || 10;
 
-    // Apply limit (take or per_page)
-    const limit = params?.take || params?.per_page || 10;
-    query = query.limit(limit);
-
-    const results = await query.selectAll().execute();
+    const results = await query
+      .selectAll()
+      .limit(limit)
+      .offset(page * limit)
+      .execute();
 
     // Get total count for include_totals
     let total = results.length;
@@ -117,65 +172,13 @@ export function list(db: Kysely<Database>) {
       total = Number(countResult?.count || 0);
     }
 
-    const clients: Client[] = results.map((result) =>
-      removeNullProperties<Client>({
-        ...result,
-        // Convert integer fields back to booleans
-        global: !!result.global,
-        is_first_party: !!result.is_first_party,
-        oidc_conformant: !!result.oidc_conformant,
-        auth0_conformant: !!result.auth0_conformant,
-        sso: !!result.sso,
-        sso_disabled: !!result.sso_disabled,
-        cross_origin_authentication: !!result.cross_origin_authentication,
-        custom_login_page_on: !!result.custom_login_page_on,
-        require_pushed_authorization_requests:
-          !!result.require_pushed_authorization_requests,
-        require_proof_of_possession: !!result.require_proof_of_possession,
-        hide_sign_up_disabled_error: !!result.hide_sign_up_disabled_error,
-        // Parse JSON string fields back to objects/arrays
-        callbacks: JSON.parse(result.callbacks),
-        allowed_origins: JSON.parse(result.allowed_origins),
-        web_origins: JSON.parse(result.web_origins),
-        client_aliases: JSON.parse(result.client_aliases),
-        allowed_clients: JSON.parse(result.allowed_clients),
-        connections: JSON.parse(result.connections || "[]"),
-        allowed_logout_urls: JSON.parse(result.allowed_logout_urls),
-        session_transfer: JSON.parse(result.session_transfer),
-        oidc_logout: JSON.parse(result.oidc_logout),
-        grant_types: JSON.parse(result.grant_types),
-        jwt_configuration: JSON.parse(result.jwt_configuration),
-        signing_keys: JSON.parse(result.signing_keys),
-        encryption_key: JSON.parse(result.encryption_key),
-        addons: JSON.parse(result.addons),
-        client_metadata: JSON.parse(result.client_metadata),
-        mobile: JSON.parse(result.mobile),
-        native_social_login: JSON.parse(result.native_social_login),
-        refresh_token: JSON.parse(result.refresh_token),
-        default_organization: JSON.parse(result.default_organization),
-        client_authentication_methods: JSON.parse(
-          result.client_authentication_methods,
-        ),
-        signed_request_object: JSON.parse(result.signed_request_object),
-        token_quota: JSON.parse(result.token_quota),
-        registration_metadata: result.registration_metadata
-          ? JSON.parse(result.registration_metadata)
-          : undefined,
-      }),
-    );
-
-    const perPage = params?.take || params?.per_page || 10;
-    const start = params?.from
-      ? parseInt(params.from, 10)
-      : params?.page
-        ? params.page * perPage
-        : 0;
+    const clients: Client[] = results.map(sqlToClient);
 
     return {
       clients,
       totals: {
-        start: isNaN(start) ? 0 : start,
-        limit: perPage,
+        start: page * limit,
+        limit,
         length: clients.length,
         total,
       },

--- a/packages/kysely/test/clients/list.spec.ts
+++ b/packages/kysely/test/clients/list.spec.ts
@@ -167,7 +167,7 @@ describe("clients", () => {
       });
     });
 
-    it("should support checkpoint pagination with from/take", async () => {
+    it("should paginate clients with from/take (keyset checkpoint)", async () => {
       const { data } = await getTestServer();
 
       await data.tenants.create({
@@ -185,19 +185,75 @@ describe("clients", () => {
         });
       }
 
-      const result = await data.clients.list("tenantId", {
-        from: "2",
-        take: 2,
-        include_totals: true,
+      // Walk every client via the opaque `next` cursor; no duplicates.
+      const seen = new Set<string>();
+      let from: string | undefined;
+      let pages = 0;
+      for (;;) {
+        const batch = await data.clients.list("tenantId", { take: 2, from });
+        expect(batch.clients.length).toBeLessThanOrEqual(2);
+        for (const c of batch.clients) {
+          expect(seen.has(c.client_id)).toBe(false);
+          seen.add(c.client_id);
+        }
+        pages++;
+        if (!batch.totals?.next) break;
+        // The cursor is opaque — not a numeric offset.
+        expect(Number.isNaN(Number(batch.totals.next))).toBe(true);
+        from = batch.totals.next;
+        if (pages > 5) throw new Error("cursor walk did not terminate");
+      }
+
+      expect(seen.size).toBe(5);
+      expect(pages).toBe(3); // 2 + 2 + 1
+    });
+
+    it("keyset walk stays stable when a client is inserted mid-walk", async () => {
+      const { data } = await getTestServer();
+
+      await data.tenants.create({
+        id: "tenantId",
+        friendly_name: "Test Tenant",
+        audience: "https://example.com",
+        sender_email: "login@example.com",
+        sender_name: "SenderName",
       });
 
-      expect(result.clients).toHaveLength(2);
-      expect(result.totals).toMatchObject({
-        start: 2,
-        limit: 2,
-        length: 2,
-        total: 5,
+      for (let i = 0; i < 4; i++) {
+        await data.clients.create("tenantId", {
+          client_id: `stable-${i}`,
+          name: `Stable ${i}`,
+        });
+      }
+
+      const page1 = await data.clients.list("tenantId", { take: 2 });
+      expect(page1.clients).toHaveLength(2);
+      expect(page1.totals?.next).toBeDefined();
+
+      // A row inserted mid-walk must not shift the remaining pages
+      // (OFFSET-based paging would skip or duplicate here).
+      await data.clients.create("tenantId", {
+        client_id: "stable-late",
+        name: "Late arrival",
       });
+
+      const page1Ids = page1.clients.map((c) => c.client_id);
+      const rest: string[] = [];
+      let from = page1.totals?.next;
+      while (from) {
+        const batch = await data.clients.list("tenantId", { take: 2, from });
+        rest.push(...batch.clients.map((c) => c.client_id));
+        from = batch.totals?.next;
+      }
+
+      for (const id of page1Ids) {
+        expect(rest).not.toContain(id);
+      }
+      // All four originals appear exactly once across the walk.
+      const all = [...page1Ids, ...rest];
+      for (let i = 0; i < 4; i++) {
+        expect(all.filter((id) => id === `stable-${i}`)).toHaveLength(1);
+      }
     });
 
     it("should support sorting", async () => {


### PR DESCRIPTION
## Summary

`GET /clients` is [documented by Auth0 as a checkpoint endpoint](https://auth0.com/docs/api/management/v2/clients/get-clients) (`from`/`take` + `next`), but our implementation treated `from` as a numeric SQL `OFFSET` and never emitted `next`. This converts it to the shared keyset paginator, continuing the per-endpoint rollout from PR #1100.

- **kysely + drizzle**: branch to keyset (`created_at` desc, `client_id` tiebreaker) when `from`/`take` is present; opaque `next` cursor returned via `totals.next`. Offset pagination (`page`/`per_page` + `total`), used by the admin UI, is unchanged.
- **Endpoint**: returns `{ clients, next }` under `from`/`take`, keeps the offset/array shapes otherwise. The system-client strip happens after pagination — a page can come up short, but the cursor comes from the adapter's unfiltered last row so the walk stays complete.
- **drizzle contract fix**: `list` previously returned totals flattened at the top level, which the route dropped (`result.totals` was always `undefined` on drizzle), reported `length` as the total count, and ignored `q` in the `include_totals` count. It now matches kysely: nested `totals`, page-length `length`, filtered count.

## Tests

- kysely adapter: cursor walk (3 pages, no dupes, token is opaque/non-numeric) and stability across a mid-walk insert (offset paging would skip/duplicate).
- Endpoint: full cursor walk via `next` over 7 clients with `take=3`.
- Full suites green locally: authhero 1759, kysely 268, drizzle 75.

Part of #1098. Remaining Category 1 endpoints after this: logs (`from` = log event id, other params ignored per Auth0) and role users (`GET /roles/{id}/users` — endpoint not implemented yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)