### PR TITLE
feat(logs): true keyset cursors for GET /logs — #1098

### DIFF
--- a/.changeset/logs-keyset-pagination.md
+++ b/.changeset/logs-keyset-pagination.md
@@ -1,0 +1,14 @@
+---
+"authhero": minor
+"@authhero/adapter-interfaces": minor
+"@authhero/kysely-adapter": minor
+"@authhero/drizzle": minor
+---
+
+`GET /logs` now supports true keyset (checkpoint) pagination with an opaque `next` cursor.
+
+Auth0 documents `/logs` as a checkpoint endpoint, but our implementation only supported `page`/`per_page` offsets. The kysely and drizzle adapters now branch to the shared keyset paginator (date desc by default, log_id tiebreaker) when `from`/`take` is present, and the endpoint returns `{ logs, next }` in that mode. As a superset of Auth0 — which ignores `q`/`sort` under `from`/`take` on `/logs` — `q` and `from_date`/`to_date` filters stay in effect during a cursor walk, and sorting by `date` (asc/desc) is honored; other sort columns are rejected with a 400 rather than silently ignored.
+
+To make sort-aware cursors safe, the cursor payload gains an optional sort-key field (`k`): a token minted under one sort that is replayed under a different sort is rejected with a 400 instead of returning pages from the wrong position.
+
+The management API error handler now duck-types HTTPException-like errors (numeric `status` + `getResponse`) instead of `instanceof HTTPException`, so 4xx errors thrown inside the bundled kysely/drizzle adapters map to proper HTTP responses rather than escaping as 500s.

--- a/packages/adapter-interfaces/src/utils/cursor.ts
+++ b/packages/adapter-interfaces/src/utils/cursor.ts
@@ -20,6 +20,13 @@ export interface CursorPayload {
   s?: string | number | null;
   /** Id of the last row of the previous page — the unique tiebreaker. */
   i: string;
+  /**
+   * Sort spec the cursor was minted under (e.g. `date:desc`). Set by endpoints
+   * that honor a caller-chosen sort in checkpoint mode, so a token replayed
+   * with a different sort is rejected instead of silently returning pages from
+   * the wrong position. Absent on fixed-sort endpoints.
+   */
+  k?: string;
 }
 
 /**

--- a/packages/authhero/src/errors/is-http-exception-like.ts
+++ b/packages/authhero/src/errors/is-http-exception-like.ts
@@ -1,0 +1,19 @@
+/**
+ * Check whether an error walks and quacks like hono's HTTPException.
+ *
+ * Uses duck typing rather than `instanceof HTTPException` because adapter
+ * packages (kysely, drizzle) bundle their own copy of hono, so exceptions
+ * they throw don't share a class identity with the app's HTTPException.
+ */
+export function isHTTPExceptionLike(
+  err: unknown,
+): err is { status: number; getResponse: () => Response } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    typeof err.status === "number" &&
+    "getResponse" in err &&
+    typeof err.getResponse === "function"
+  );
+}

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -5,6 +5,7 @@ import { LogTypes } from "@authhero/adapter-interfaces";
 import { Bindings, Variables, AuthHeroConfig } from "../../types";
 import { getIssuer } from "../../variables";
 import { logMessage } from "../../helpers/logging";
+import { isHTTPExceptionLike } from "../../errors/is-http-exception-like";
 import { actionsRoutes } from "./actions";
 import { actionExecutionsRoutes } from "./action-executions";
 import { actionTriggersRoutes } from "./action-triggers";
@@ -258,7 +259,10 @@ export default function create(config: AuthHeroConfig) {
   // authhero produces by default that aren't that shape: (1) plaintext from
   // HTTPException, (2) zod-openapi's default validation-failure JSON.
   app.onError((err, ctx) => {
-    if (!(err instanceof HTTPException)) {
+    // Duck-typed rather than `instanceof HTTPException`: adapter packages
+    // bundle their own hono, so their HTTPExceptions have a different class
+    // identity.
+    if (!isHTTPExceptionLike(err)) {
       // Let the parent app's onError do its thing (logging, 500 response).
       throw err;
     }

--- a/packages/authhero/src/routes/management-api/logs.ts
+++ b/packages/authhero/src/routes/management-api/logs.ts
@@ -9,6 +9,14 @@ import { defineRoute } from "../../utils/define-route";
 const logsWithTotalsSchema = totalsSchema.extend({
   logs: z.array(logSchema),
 });
+
+// Checkpoint (keyset) pagination response: items plus an opaque cursor.
+const logsWithNextSchema = z.object({
+  logs: z.array(logSchema),
+  next: z.string().optional().openapi({
+    description: "Opaque cursor for the next page; absent on the last page.",
+  }),
+});
 const getRoot = defineRoute({
   route: createRoute({
     tags: ["logs"],
@@ -29,7 +37,11 @@ const getRoot = defineRoute({
       200: {
         content: {
           "application/json": {
-            schema: z.union([z.array(logSchema), logsWithTotalsSchema]),
+            schema: z.union([
+              z.array(logSchema),
+              logsWithTotalsSchema,
+              logsWithNextSchema,
+            ]),
           },
         },
         description: "List of log rows",
@@ -37,8 +49,17 @@ const getRoot = defineRoute({
     },
   }),
   handler: async (ctx) => {
-    const { page, per_page, include_totals, sort, q, from_date, to_date } =
-      ctx.req.valid("query");
+    const {
+      page,
+      per_page,
+      include_totals,
+      sort,
+      q,
+      from,
+      take,
+      from_date,
+      to_date,
+    } = ctx.req.valid("query");
 
     const result = await ctx.env.data.logs.list(ctx.var.tenant_id, {
       page,
@@ -46,9 +67,20 @@ const getRoot = defineRoute({
       include_totals,
       sort: parseSort(sort),
       q,
+      from,
+      take,
       from_date,
       to_date,
     });
+
+    // Keyset (checkpoint) pagination: return Auth0's { items, next } shape so
+    // callers can page past the first page via the opaque cursor.
+    if (from !== undefined || take !== undefined) {
+      return ctx.json({
+        logs: result.logs,
+        next: result.next,
+      });
+    }
 
     if (include_totals) {
       return ctx.json(result);

--- a/packages/authhero/test/routes/management-api/logs.spec.ts
+++ b/packages/authhero/test/routes/management-api/logs.spec.ts
@@ -163,4 +163,78 @@ describe("logs", () => {
   //   expect(log.log_id).toBeTypeOf("string");
   //   expect(log.details?.request.method).toBe("GET");
   // });
+
+  it("pages with take/from and an opaque next cursor", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    for (let i = 0; i < 5; i++) {
+      await env.data.logs.create("tenantId", {
+        log_id: `log-${i}`,
+        type: "s",
+        date: `2026-01-01T00:00:0${i}.000Z`,
+        isMobile: false,
+      });
+    }
+
+    const seen = new Set<string>();
+    let from: string | undefined;
+    let pages = 0;
+
+    for (;;) {
+      const response = await managementClient.logs.$get(
+        {
+          query: from ? { take: "2", from } : { take: "2" },
+          header: {
+            "tenant-id": "tenantId",
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+      );
+      expect(response.status).toBe(200);
+      pages++;
+
+      const body = (await response.json()) as { logs: Log[]; next?: string };
+      expect(Array.isArray(body.logs)).toBe(true);
+      for (const log of body.logs) {
+        expect(seen.has(log.log_id)).toBe(false);
+        seen.add(log.log_id);
+      }
+      if (!body.next) break;
+      // The cursor is opaque — never a numeric offset.
+      expect(body.next).not.toMatch(/^\d+$/);
+      from = body.next;
+      if (pages > 5) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.size).toBe(5);
+    expect(pages).toBe(3); // 2 + 2 + 1
+  });
+
+  it("returns 400 for unsupported sort in checkpoint mode", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const response = await managementClient.logs.$get(
+      {
+        query: { take: "2", sort: "user_id:1" },
+        header: {
+          "tenant-id": "tenantId",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(response.status).toBe(400);
+  });
 });

--- a/packages/drizzle/src/adapters/logs.ts
+++ b/packages/drizzle/src/adapters/logs.ts
@@ -1,9 +1,17 @@
 import { eq, and, count as countFn, asc, desc, gte, lt } from "drizzle-orm";
 import { nanoid } from "nanoid";
+import { HTTPException } from "hono/http-exception";
 import type { Log, ListParams } from "@authhero/adapter-interfaces";
 import { logs } from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import { buildLuceneFilter } from "../helpers/filter";
+import {
+  isKeysetRequest,
+  keysetCondition,
+  keysetOrderBy,
+  keysetTake,
+  sliceWithNext,
+} from "../helpers/paginate";
 import type { DrizzleDb } from "./types";
 
 function sqlToLog(row: any): Log {
@@ -138,6 +146,50 @@ export function createLogsAdapter(db: DrizzleDb) {
       }
 
       const whereClause = and(...baseConditions);
+
+      // Keyset (checkpoint) pagination: from/take. Unlike Auth0 — which
+      // ignores q/sort in checkpoint mode on /logs — the q and date-range
+      // filters above stay in effect, and sorting by date (asc/desc) is
+      // honored as a superset. Only `date` is keyset-sortable; log_id is the
+      // unique tiebreaker.
+      if (isKeysetRequest(params)) {
+        if (sort?.sort_by && sort.sort_by !== "date") {
+          throw new HTTPException(400, {
+            message: `Sorting by ${sort.sort_by} is not supported with checkpoint pagination (from/take); only date is`,
+          });
+        }
+        const sortOrder: "asc" | "desc" =
+          sort?.sort_order === "asc" ? "asc" : "desc";
+        const cols = {
+          sortColumn: logs.date,
+          idColumn: logs.log_id,
+          sortOrder,
+          sortKey: `date:${sortOrder}`,
+        };
+        const keyset = keysetCondition(params, cols);
+        const take = keysetTake(params);
+        const rows = await db
+          .select()
+          .from(logs)
+          .where(keyset ? and(whereClause, keyset) : whereClause)
+          .orderBy(...keysetOrderBy(cols))
+          .limit(take + 1);
+        const { rows: pageRows, next } = sliceWithNext(
+          rows,
+          take,
+          "date",
+          "log_id",
+          cols.sortKey,
+        );
+        const mapped = pageRows.map(sqlToLog);
+        return {
+          logs: mapped,
+          start: 0,
+          limit: take,
+          length: mapped.length,
+          next,
+        };
+      }
 
       let query = db.select().from(logs).where(whereClause).$dynamic();
 

--- a/packages/drizzle/src/helpers/paginate.ts
+++ b/packages/drizzle/src/helpers/paginate.ts
@@ -1,4 +1,5 @@
 import { SQL, sql, asc, desc, gt, lt, Column } from "drizzle-orm";
+import { HTTPException } from "hono/http-exception";
 import {
   ListParams,
   decodeCursor,
@@ -31,6 +32,13 @@ export interface KeysetColumns {
   sortColumn: Column;
   idColumn: Column;
   sortOrder: "asc" | "desc";
+  /**
+   * Sort spec (e.g. `date:desc`) for endpoints that honor a caller-chosen sort
+   * in checkpoint mode. Minted into the cursor; a cursor presented under a
+   * different sort spec is rejected with a 400, because its keyset position is
+   * meaningless in the new order. Omit on fixed-sort endpoints.
+   */
+  sortKey?: string;
 }
 
 /** ORDER BY sortColumn, idColumn (tiebreaker), in the requested direction. */
@@ -51,6 +59,13 @@ export function keysetCondition(
 ): SQL | undefined {
   const cursor = params?.from ? decodeCursor(params.from) : null;
   if (!cursor) return undefined;
+
+  if (cursor.k !== cols.sortKey) {
+    throw new HTTPException(400, {
+      message:
+        "The `from` cursor was issued under a different sort and cannot be used with this request",
+    });
+  }
 
   if (cursor.s === undefined || cursor.s === null) {
     // Id-only ordering (or a null boundary): compare on the tiebreaker alone.
@@ -73,6 +88,7 @@ export function sliceWithNext<Row extends Record<string, unknown>>(
   take: number,
   sortField: string,
   idField = "id",
+  sortKey?: string,
 ): { rows: Row[]; next?: string } {
   const hasMore = rows.length > take;
   const page = hasMore ? rows.slice(0, take) : rows;
@@ -89,6 +105,7 @@ export function sliceWithNext<Row extends Record<string, unknown>>(
           ? (sortValue as string | number | null)
           : String(sortValue),
       i: String(last[idField]),
+      ...(sortKey !== undefined && { k: sortKey }),
     });
   }
   return { rows: page, next };

--- a/packages/drizzle/test/adapters/logs-keyset.test.ts
+++ b/packages/drizzle/test/adapters/logs-keyset.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+
+// Logs honor q, date-range filters, and a date asc/desc sort in checkpoint
+// mode (a superset of Auth0, which ignores q/sort under from/take on /logs).
+// The cursor records the sort it was minted under so a token replayed with a
+// different sort fails instead of returning pages from the wrong position.
+describe("logs keyset pagination (from/take)", () => {
+  let data: ReturnType<typeof getTestServer>["data"];
+  const tenantId = "t1";
+
+  beforeEach(async () => {
+    const server = getTestServer();
+    data = server.data;
+
+    await data.tenants.create({ id: tenantId, name: "Tenant 1" });
+
+    // 25 logs across 5 timestamps (5 rows per timestamp) so pages routinely
+    // split inside a shared date — exactly where the log_id tiebreaker
+    // matters. Alternate user_ids for the filtered-walk test.
+    for (let i = 0; i < 25; i++) {
+      const second = Math.floor(i / 5);
+      await data.logs.create(tenantId, {
+        log_id: `log-${i.toString().padStart(2, "0")}`,
+        type: "s",
+        date: `2026-01-01T00:00:0${second}.000Z`,
+        isMobile: false,
+        user_id: i % 2 === 0 ? "user-even" : "user-odd",
+      });
+    }
+  });
+
+  it("walks every row exactly once in date desc order by default", async () => {
+    const seen: string[] = [];
+    let from: string | undefined;
+    let pages = 0;
+    let lastDate: string | undefined;
+
+    for (;;) {
+      const res = await data.logs.list(tenantId, { take: 10, from });
+      pages++;
+      for (const log of res.logs) {
+        expect(seen.includes(log.log_id)).toBe(false);
+        seen.push(log.log_id);
+        if (lastDate !== undefined) {
+          expect(log.date <= lastDate).toBe(true);
+        }
+        lastDate = log.date;
+      }
+      if (!res.next) break;
+      from = res.next;
+      if (pages > 10) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.length).toBe(25);
+    expect(pages).toBe(3);
+  });
+
+  it("honors sort=date asc in checkpoint mode", async () => {
+    const res = await data.logs.list(tenantId, {
+      take: 10,
+      sort: { sort_by: "date", sort_order: "asc" },
+    });
+    expect(res.logs).toHaveLength(10);
+    expect(res.logs[0]!.date <= res.logs[9]!.date).toBe(true);
+
+    const page2 = await data.logs.list(tenantId, {
+      take: 10,
+      from: res.next,
+      sort: { sort_by: "date", sort_order: "asc" },
+    });
+    expect(res.logs[9]!.date <= page2.logs[0]!.date).toBe(true);
+  });
+
+  it("honors q filters inside a cursor walk", async () => {
+    const seen = new Set<string>();
+    let from: string | undefined;
+
+    for (;;) {
+      const res = await data.logs.list(tenantId, {
+        q: "user_id:user-even",
+        take: 5,
+        from,
+      });
+      for (const log of res.logs) {
+        expect(log.user_id).toBe("user-even");
+        seen.add(log.log_id);
+      }
+      if (!res.next) break;
+      from = res.next;
+    }
+
+    expect(seen.size).toBe(13); // even indices 0..24
+  });
+
+  it("is stable when a row is inserted mid-walk", async () => {
+    const page1 = await data.logs.list(tenantId, { take: 10 });
+
+    // Insert a log dated inside the walked range between page fetches.
+    // Offset pagination would shift rows and duplicate/skip; keyset must not
+    // repeat anything already returned.
+    await data.logs.create(tenantId, {
+      log_id: "log-inserted",
+      type: "s",
+      date: "2026-01-01T00:00:04.500Z",
+      isMobile: false,
+    });
+
+    const page1Ids = new Set(page1.logs.map((log) => log.log_id));
+    const page2 = await data.logs.list(tenantId, {
+      take: 10,
+      from: page1.next,
+    });
+    for (const log of page2.logs) {
+      expect(page1Ids.has(log.log_id)).toBe(false);
+    }
+  });
+
+  it("rejects a cursor replayed under a different sort", async () => {
+    const page1 = await data.logs.list(tenantId, { take: 10 });
+    expect(page1.next).toBeDefined();
+
+    await expect(
+      data.logs.list(tenantId, {
+        take: 10,
+        from: page1.next,
+        sort: { sort_by: "date", sort_order: "asc" },
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects unsupported sort columns in checkpoint mode", async () => {
+    await expect(
+      data.logs.list(tenantId, {
+        take: 10,
+        sort: { sort_by: "user_id", sort_order: "asc" },
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("omits next on the final page", async () => {
+    const res = await data.logs.list(tenantId, { take: 50 });
+    expect(res.logs).toHaveLength(25);
+    expect(res.next).toBeUndefined();
+  });
+});

--- a/packages/kysely/src/helpers/paginate.ts
+++ b/packages/kysely/src/helpers/paginate.ts
@@ -1,4 +1,5 @@
 import { sql, SelectQueryBuilder, SqlBool } from "kysely";
+import { HTTPException } from "hono/http-exception";
 import {
   ListParams,
   decodeCursor,
@@ -28,6 +29,13 @@ export interface KeysetOptions {
   sortOrder: "asc" | "desc";
   /** Unique tiebreaker column; defaults to "id". */
   idColumn?: string;
+  /**
+   * Sort spec (e.g. `date:desc`) for endpoints that honor a caller-chosen sort
+   * in checkpoint mode. Minted into the cursor; a cursor presented under a
+   * different sort spec is rejected with a 400, because its keyset position is
+   * meaningless in the new order. Omit on fixed-sort endpoints.
+   */
+  sortKey?: string;
 }
 
 export interface KeysetResult<Row> {
@@ -58,6 +66,12 @@ export async function keysetPaginate<DB, TB extends keyof DB, O>(
     .orderBy(sql.ref(idColumn), sortOrder);
 
   const cursor = params?.from ? decodeCursor(params.from) : null;
+  if (cursor && cursor.k !== options.sortKey) {
+    throw new HTTPException(400, {
+      message:
+        "The `from` cursor was issued under a different sort and cannot be used with this request",
+    });
+  }
   if (cursor) {
     if (cursor.s === undefined || cursor.s === null) {
       // Id-only ordering (or a null boundary): compare on the tiebreaker alone.
@@ -94,6 +108,7 @@ export async function keysetPaginate<DB, TB extends keyof DB, O>(
           ? (sortValue as string | number | null)
           : String(sortValue),
       i: String(last[idColumn]),
+      ...(options.sortKey !== undefined && { k: options.sortKey }),
     });
   }
 

--- a/packages/kysely/src/logs/list.ts
+++ b/packages/kysely/src/logs/list.ts
@@ -1,9 +1,11 @@
 import { Kysely } from "kysely";
+import { HTTPException } from "hono/http-exception";
 import { ListParams } from "@authhero/adapter-interfaces";
 import { luceneFilter, sanitizeLuceneQuery } from "../helpers/filter";
 import { getLogResponse } from "./logs";
 import { Database } from "../db";
 import getCountAsInt from "../utils/getCountAsInt";
+import { isKeysetRequest, keysetPaginate } from "../helpers/paginate";
 
 // Fields logs.list() accepts as `field:value` clauses in `q`. Every entry maps
 // to a real column on the logs table. Excludes `tenant_id` so a clause like
@@ -88,6 +90,38 @@ export function listLogs(db: Kysely<Database>) {
         "<=",
         new Date(Math.floor(to_date) * 1000 + 999).toISOString(),
       );
+    }
+
+    // Keyset (checkpoint) pagination: from/take. Unlike Auth0 — which ignores
+    // q/sort in checkpoint mode on /logs — the q and date-range filters above
+    // stay in effect, and sorting by date (asc/desc) is honored as a superset.
+    // Only `date` is keyset-sortable; log_id is the unique tiebreaker.
+    if (isKeysetRequest(params)) {
+      if (sort?.sort_by && sort.sort_by !== "date") {
+        throw new HTTPException(400, {
+          message: `Sorting by ${sort.sort_by} is not supported with checkpoint pagination (from/take); only date is`,
+        });
+      }
+      const sortOrder: "asc" | "desc" =
+        sort?.sort_order === "asc" ? "asc" : "desc";
+      const { rows, limit, next } = await keysetPaginate(
+        query.selectAll(),
+        params,
+        {
+          sortColumn: "date",
+          sortOrder,
+          idColumn: "log_id",
+          sortKey: `date:${sortOrder}`,
+        },
+      );
+      const logs = rows.map(getLogResponse);
+      return {
+        logs,
+        start: 0,
+        limit,
+        length: logs.length,
+        next,
+      };
     }
 
     let filteredQuery = query;

--- a/packages/kysely/test/keyset-pagination.test.ts
+++ b/packages/kysely/test/keyset-pagination.test.ts
@@ -101,3 +101,122 @@ describe("keyset pagination (from/take)", () => {
     }
   });
 });
+
+// Logs honor q, date-range filters, and a date asc/desc sort in checkpoint
+// mode (a superset of Auth0, which ignores q/sort under from/take on /logs).
+// The cursor records the sort it was minted under so a token replayed with a
+// different sort fails instead of returning pages from the wrong position.
+describe("logs keyset pagination (from/take)", () => {
+  let data: any;
+  const tenantId = "keyset-logs-tenant";
+
+  beforeEach(async () => {
+    const server = await getTestServer();
+    data = server.data;
+
+    // 25 logs across 5 timestamps (5 rows per timestamp) so pages routinely
+    // split inside a shared date — exactly where the log_id tiebreaker
+    // matters. Alternate user_ids for the filtered-walk test.
+    for (let i = 0; i < 25; i++) {
+      const second = Math.floor(i / 5);
+      await data.logs.create(tenantId, {
+        log_id: `log-${i.toString().padStart(2, "0")}`,
+        type: "s",
+        date: `2026-01-01T00:00:0${second}.000Z`,
+        isMobile: false,
+        user_id: i % 2 === 0 ? "user-even" : "user-odd",
+      });
+    }
+  });
+
+  it("walks every row exactly once in date desc order by default", async () => {
+    const seen: string[] = [];
+    let from: string | undefined;
+    let pages = 0;
+    let lastDate: string | undefined;
+
+    for (;;) {
+      const res = await data.logs.list(tenantId, { take: 10, from });
+      pages++;
+      for (const log of res.logs) {
+        expect(seen.includes(log.log_id)).toBe(false);
+        seen.push(log.log_id);
+        if (lastDate !== undefined) {
+          expect(log.date <= lastDate).toBe(true);
+        }
+        lastDate = log.date;
+      }
+      if (!res.next) break;
+      from = res.next;
+      if (pages > 10) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.length).toBe(25);
+    expect(pages).toBe(3);
+  });
+
+  it("honors sort=date asc in checkpoint mode", async () => {
+    const res = await data.logs.list(tenantId, {
+      take: 10,
+      sort: { sort_by: "date", sort_order: "asc" },
+    });
+    expect(res.logs).toHaveLength(10);
+    expect(res.logs[0].date <= res.logs[9].date).toBe(true);
+
+    const page2 = await data.logs.list(tenantId, {
+      take: 10,
+      from: res.next,
+      sort: { sort_by: "date", sort_order: "asc" },
+    });
+    expect(res.logs[9].date <= page2.logs[0].date).toBe(true);
+  });
+
+  it("honors q filters inside a cursor walk", async () => {
+    const seen = new Set<string>();
+    let from: string | undefined;
+
+    for (;;) {
+      const res = await data.logs.list(tenantId, {
+        q: "user_id:user-even",
+        take: 5,
+        from,
+      });
+      for (const log of res.logs) {
+        expect(log.user_id).toBe("user-even");
+        seen.add(log.log_id);
+      }
+      if (!res.next) break;
+      from = res.next;
+    }
+
+    expect(seen.size).toBe(13); // even indices 0..24
+  });
+
+  it("rejects a cursor replayed under a different sort", async () => {
+    const page1 = await data.logs.list(tenantId, { take: 10 });
+    expect(page1.next).toBeDefined();
+
+    await expect(
+      data.logs.list(tenantId, {
+        take: 10,
+        from: page1.next,
+        sort: { sort_by: "date", sort_order: "asc" },
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects unsupported sort columns in checkpoint mode", async () => {
+    await expect(
+      data.logs.list(tenantId, {
+        take: 10,
+        sort: { sort_by: "user_id", sort_order: "asc" },
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("omits next on the final page", async () => {
+    const res = await data.logs.list(tenantId, { take: 50 });
+    expect(res.logs).toHaveLength(25);
+    expect(res.next).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Converts `GET /logs` to checkpoint (keyset) pagination — the last remaining Category 1 endpoint from #1098 that exists today (`GET /roles/{id}/users` isn't implemented yet).

- When `from`/`take` is present, the kysely and drizzle adapters branch to the shared keyset paginator (`date` desc by default, `log_id` tiebreaker) and the endpoint returns `{ logs, next }` with an opaque cursor, omitted on the last page.
- Per the decision recorded on #1098 (2026-07-11), this is a superset of Auth0's behavior: `q` and `from_date`/`to_date` filters stay in effect during a cursor walk, and sorting by `date` asc/desc is honored. Auth0 silently ignores `q`/`sort` under `from`/`take` on `/logs`; we reject unsupported sort columns with an explicit 400 instead of returning confidently wrong pages.
- **Sort-aware cursors:** `CursorPayload` gains an optional `k` field recording the sort the token was minted under. A cursor replayed under a different sort is rejected with a 400 rather than resuming from a meaningless keyset position. Fixed-sort endpoints (organizations, org members, client grants, clients) are unaffected — they mint no `k` and validate against `undefined`.
- **Error-handler fix:** the management API `onError` now duck-types HTTPException-like errors (numeric `status` + `getResponse`) instead of `instanceof HTTPException`. The bundled kysely/drizzle dists carry their own copy of hono, so their HTTPExceptions don't share a class identity with the app's — previously an adapter-thrown 4xx escaped as an unhandled error/500. Same rationale as the existing `isUniqueConstraintError` duck-typing.

Offset pagination (`page`/`per_page` + totals), used by the admin UI, is unchanged. The aws/DynamoDB adapter is intentionally not converted in this PR, matching #1100/#1105 precedent.

## Tests

- kysely: full-walk uniqueness/ordering, date-asc sort, `q` honored mid-walk, sort-mismatch cursor → 400, unsupported sort → 400, `next` omitted on last page (pages split inside shared timestamps to exercise the tiebreaker)
- drizzle: same suite plus stability under a mid-walk insert
- authhero route: end-to-end cursor walk over `{ logs, next }`, opaque-cursor assertion, 400 for unsupported sort
- Full suites green: kysely 274, drizzle 82, authhero 1761

Refs #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination to the Logs API using opaque continuation tokens.
  * Supports ascending or descending date sorting, filtering, and stable pagination across changing data.
  * Preserves existing log retrieval behavior when cursor pagination is not requested.

* **Bug Fixes**
  * Added validation to prevent cursor reuse with different sorting options.
  * Improved handling of HTTP errors from bundled adapters.
  * Unsupported checkpoint sorting now returns a clear HTTP 400 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->