### PR TITLE
fix(build): stop bundling private copies of shared deps into adapter dists

### DIFF
--- a/.changeset/adapter-bundle-externals.md
+++ b/.changeset/adapter-bundle-externals.md
@@ -1,0 +1,11 @@
+---
+"@authhero/kysely-adapter": patch
+"@authhero/drizzle": patch
+"@authhero/aws-adapter": patch
+---
+
+Stop bundling private copies of shared dependencies into the adapter dists.
+
+Rollup's `external` array does exact string matching, so subpath imports slipped into the bundles even when the bare package was listed: kysely inlined `hono/http-exception`, parts of `kysely` itself, and the whole `@authhero/proxy` workspace dep; aws inlined `hono/http-exception` and `nanoid`; drizzle had no externals at all and bundled everything (dist shrinks from ~520 kB to ~172 kB). All three configs now use a subpath-aware external function, the same pattern `@authhero/multi-tenancy` and `@authhero/cloudflare` already use.
+
+The user-visible consequence of the old behavior: HTTPExceptions thrown inside an adapter had a different class identity than the host app's `HTTPException`, so `instanceof` checks in error handlers failed and adapter-thrown 4xx errors could surface as 500s. Fresh builds now share the host's hono. (The management API also duck-types these errors since the `GET /logs` keyset PR, so older published adapter versions remain handled.)

--- a/packages/aws/vite.config.ts
+++ b/packages/aws/vite.config.ts
@@ -33,11 +33,20 @@ export default defineConfig({
       fileName: (format) => fileName[format],
     },
     rollupOptions: {
-      external: [
-        "@authhero/adapter-interfaces",
-        "@aws-sdk/client-dynamodb",
-        "@aws-sdk/lib-dynamodb",
-      ],
+      // Matches exact ids and their subpaths — Rollup's `external` array does
+      // exact string matching, so subpath imports (e.g. "hono/http-exception")
+      // would otherwise be inlined. A bundled copy of hono means
+      // HTTPExceptions thrown here fail the host app's `instanceof` checks.
+      external: (id) =>
+        [
+          "@authhero/adapter-interfaces",
+          "@authhero/proxy",
+          "@aws-sdk/client-dynamodb",
+          "@aws-sdk/lib-dynamodb",
+          "@hono/zod-openapi",
+          "hono",
+          "nanoid",
+        ].some((dep) => id === dep || id.startsWith(`${dep}/`)),
     },
   },
   resolve: {

--- a/packages/drizzle/vite.config.ts
+++ b/packages/drizzle/vite.config.ts
@@ -32,6 +32,21 @@ module.exports = defineConfig({
       formats,
       fileName: (format) => fileName[format],
     },
+    rollupOptions: {
+      // Everything declared in dependencies/peerDependencies stays external —
+      // without this list, vite lib mode bundles them all. Matches exact ids
+      // and their subpaths (e.g. "hono/http-exception", "drizzle-orm/batch");
+      // a bundled copy of hono means HTTPExceptions thrown here fail the host
+      // app's `instanceof` checks.
+      external: (id) =>
+        [
+          "@authhero/adapter-interfaces",
+          "@authhero/proxy",
+          "drizzle-orm",
+          "hono",
+          "nanoid",
+        ].some((dep) => id === dep || id.startsWith(`${dep}/`)),
+    },
   },
   resolve: {
     alias: [

--- a/packages/kysely/vite.config.ts
+++ b/packages/kysely/vite.config.ts
@@ -33,14 +33,21 @@ export default defineConfig({
       fileName: (format) => fileName[format],
     },
     rollupOptions: {
-      external: [
-        "@hono/zod-openapi",
-        "hono",
-        "kysely",
-        "kysely-planetscale",
-        "@authhero/adapter-interfaces",
-        "nanoid",
-      ],
+      // Matches exact ids and their subpaths — Rollup's `external` array does
+      // exact string matching, so subpath imports (e.g. "hono/http-exception",
+      // "@authhero/adapter-interfaces/sql") would otherwise be inlined. A
+      // bundled copy of hono means HTTPExceptions thrown here fail the host
+      // app's `instanceof` checks.
+      external: (id) =>
+        [
+          "@hono/zod-openapi",
+          "hono",
+          "kysely",
+          "kysely-planetscale",
+          "@authhero/adapter-interfaces",
+          "@authhero/proxy",
+          "nanoid",
+        ].some((dep) => id === dep || id.startsWith(`${dep}/`)),
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

Follow-up to the discussion on #1107: the adapter packages were shipping private copies of shared dependencies because of how their vite configs declared externals.

Rollup's `external` array does **exact string matching**, so subpath imports slipped into the bundles even when the bare package was listed:

- **kysely**: `"hono"` was listed, but `hono/http-exception` wasn't → the `HTTPException` class was inlined while the rest of hono stayed external. Also inlined: parts of `kysely` itself (pulled in via the unlisted `@authhero/adapter-interfaces/sql` subpath) and the whole `@authhero/proxy` workspace dep.
- **drizzle**: no `rollupOptions.external` at all — every dependency it touches was bundled. Dist shrinks from **~520 kB to ~172 kB**.
- **aws**: `hono/http-exception` and `nanoid` inlined.

All three now use the subpath-aware external function that `@authhero/multi-tenancy` (`build-externals.ts`, which documents this exact HTTPException/`instanceof` failure) and `@authhero/cloudflare` already use. Everything in each package's dependencies/peerDependencies stays external.

## Why it matters

A bundled hono copy means `HTTPException`s thrown inside an adapter have a different class identity than the host app's, so `instanceof` checks in error handlers fail and adapter-thrown 4xx errors surface as 500s (or escape entirely). Fresh builds now share the host's hono. The duck-typed error handling added in #1107 stays — it still covers older published adapter versions and minified bundles.

## Verification

- Rebuilt all three dists: zero inlined `node_modules` regions; `hono/http-exception`, `kysely/migration`, `drizzle-orm/*`, `nanoid` all appear as real imports.
- Test suites green against the new bundles: kysely 268, drizzle 75, aws 25, authhero 1759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed adapter error handling so HTTP errors are correctly recognized by host applications, preventing certain client errors from being reported as server errors.
  * Improved compatibility between adapter packages and the applications that use them.

* **Performance**
  * Reduced published adapter bundle sizes, particularly for the Drizzle adapter, by avoiding duplication of shared dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->