### PR TITLE
feat(authhero): publish WFP tenant-subdomain dispatch routes to KV

### DIFF
--- a/.changeset/wfp-tenant-subdomain-kv-routing.md
+++ b/.changeset/wfp-tenant-subdomain-kv-routing.md
@@ -1,0 +1,14 @@
+---
+"authhero": minor
+---
+
+Publish WFP tenant-subdomain dispatch routes automatically
+
+New helpers so a WFP tenant's platform subdomain (`{tenant_id}.{issuerHost}`) routes to its own Worker without a manual `custom_domains`/`proxy_routes` entry:
+
+- `createWfpTenantHostResolver` — resolves a ready WFP tenant's subdomain to a synthetic `ResolvedHost` whose single route dispatches via the proxy's `dispatch_namespace` handler; derived entirely from the tenant row.
+- `wrapTenantsAdapterWithWfpKvPublish` — tenants-adapter counterpart of `wrapProxyAdaptersWithKvPublish`: the provisioner's `provisioning_state: "ready"` write-back publishes the KV blob, a remove (or wfp → shared flip) deletes it.
+- `composeHostResolvers` — chains resolvers (custom domains first) so one composed `resolveHost` serves the HTTP endpoint, both KV publishers, and the reconcile.
+- `wfpTenantHost` — canonical host derivation for reconcile host lists.
+
+Previously nothing published these hosts, so tenant subdomains silently fell through to the proxy's default-forward chain (the shared control plane) even after the tenant Worker was provisioned.

--- a/apps/docs/customization/proxy/deployment.md
+++ b/apps/docs/customization/proxy/deployment.md
@@ -340,7 +340,7 @@ Once the backfill is verified and KV is in steady-state sync, you can drop the
 HTTP fallback entirely (resolve straight from `kv`) and retire the
 `CONTROL_PLANE_*` secrets on the proxy.
 
-### WFP tenant subdomains — dispatch routes without `custom_domains` rows
+### WFP tenant subdomains
 
 Everything above keys off `custom_domains` / `proxy_routes` writes. A WFP
 tenant's **platform subdomain** (`{tenant_id}.token.example.com`) has neither —
@@ -451,6 +451,12 @@ Notes:
 - **Don't include the reconcile's WFP hosts filter on `provisioning_state`** —
   listing *all* wfp tenants lets the reconcile also delete stale keys for
   tenants that regressed from `ready` (the blob recomputes to `null`).
+- **WFP tenant ids must be lowercase DNS labels** (`isWfpSubdomainSafeTenantId`
+  — alphanumeric with inner hyphens, no dots, max 63 chars). DNS lowercases the
+  incoming host but the tenant lookup is exact-match, so a mixed-case or dotted
+  id can never round-trip through a hostname; the publisher skips such ids
+  rather than writing keys the resolver can't match. Enforce the constraint at
+  tenant creation for wfp tenants.
 
 ### Constraints & notes
 
@@ -570,7 +576,7 @@ For each tenant, in isolation:
 - [ ] Provision the tenant's per-tenant Worker + database (its client/connection
       data now lives in the tenant DB, not the shared control-plane DB).
 - [ ] The routing entry publishes itself: with
-      [`wrapTenantsAdapterWithWfpKvPublish`](#wfp-tenant-subdomains-dispatch-routes-without-custom-domains-rows)
+      [`wrapTenantsAdapterWithWfpKvPublish`](#wfp-tenant-subdomains)
       on the control plane, the provisioner's `provisioning_state: "ready"`
       write-back pushes the `<tenant>.token.example.com` → `tenant-{id}-auth`
       dispatch blob to KV. (A branded custom domain still needs its own

--- a/apps/docs/customization/proxy/deployment.md
+++ b/apps/docs/customization/proxy/deployment.md
@@ -340,6 +340,118 @@ Once the backfill is verified and KV is in steady-state sync, you can drop the
 HTTP fallback entirely (resolve straight from `kv`) and retire the
 `CONTROL_PLANE_*` secrets on the proxy.
 
+### WFP tenant subdomains — dispatch routes without `custom_domains` rows
+
+Everything above keys off `custom_domains` / `proxy_routes` writes. A WFP
+tenant's **platform subdomain** (`{tenant_id}.token.example.com`) has neither —
+so without extra wiring the host resolves to nothing, falls through the proxy's
+default chain to the shared control plane, and the tenant's own Worker never
+sees traffic even after provisioning succeeds.
+
+The mapping is fully derivable from the tenant row (`deployment_type`,
+`provisioning_state`, `worker_script_name`), so instead of materialising
+synthetic custom-domain rows, derive it:
+
+```typescript
+import {
+  composeHostResolvers,
+  createWfpTenantHostResolver,
+  wrapTenantsAdapterWithWfpKvPublish,
+} from "authhero";
+
+const issuerHost = new URL(env.ISSUER).host; // e.g. "token.example.com"
+
+// Resolves `{tenant_id}.{issuerHost}` for tenants with deployment_type "wfp"
+// AND provisioning_state "ready" to a synthetic ResolvedHost whose single
+// route dispatches into the tenant's Worker. Anything else → null.
+const wfpResolver = createWfpTenantHostResolver({
+  tenants: adapters.tenants,
+  issuerHost,
+  // Binding + template must match the proxy Worker's wrangler config and the
+  // provisioner. `worker_script_name` from the tenant row is preferred; the
+  // template only covers rows provisioned before it was written back.
+  dispatchBinding: "DISPATCHER",
+  scriptNameTemplate: "tenant-{tenant_id}-auth",
+});
+
+// One composed resolver for every consumer: custom domains win on a host
+// collision, WFP subdomains fill the gap.
+const resolveHost = composeHostResolvers(
+  createProxyDataAdapter(db).resolveHost,
+  wfpResolver,
+);
+
+// Tenants-adapter counterpart of wrapProxyAdaptersWithKvPublish. The
+// provisioner flips provisioning_state to "ready" through tenants.update —
+// that write publishes the dispatch blob to KV, with no per-path wiring in
+// your provisioning hook or workflow. remove (and a wfp → shared flip)
+// deletes the key, so the host falls back to the default chain instead of
+// dispatching to a dead script.
+const tenants = wrapTenantsAdapterWithWfpKvPublish({
+  tenants: adapters.tenants,
+  kv: env.PROXY_HOSTS,
+  resolveHost,
+  issuerHost,
+  waitUntil: (p) => ctx.waitUntil(p),
+  onError: (err, { host, op }) =>
+    console.error(`[kv-publish] ${op} ${host}`, err),
+});
+
+export default init({
+  dataAdapter: { ...adapters, tenants, customDomains, proxyRoutes },
+  proxyControlPlane: {
+    resolveHost, // the HTTP fallback now also serves WFP subdomains
+    applySyncEvents: createApplySyncEvents({ customDomains, proxyRoutes }),
+  },
+});
+```
+
+Pass the **same composed `resolveHost`** to `wrapProxyAdaptersWithKvPublish`,
+`wrapTenantsAdapterWithWfpKvPublish`, and `proxyControlPlane` — every publisher
+then computes identical blobs, and the proxy's HTTP fallback covers the KV
+propagation window (~60s) right after provisioning.
+
+Extend the reconcile (Step 2) so WFP hosts self-heal too — derive their hosts
+from the tenants table with `wfpTenantHost`:
+
+```typescript
+import { backfillProxyHostsToKv, wfpTenantHost } from "authhero";
+
+const domainHosts = await db
+  .selectFrom("custom_domains")
+  .select("domain")
+  .execute()
+  .then((rows) => rows.map((r) => r.domain));
+
+const wfpHosts = await db
+  .selectFrom("tenants")
+  .select("id")
+  .where("deployment_type", "=", "wfp")
+  .execute()
+  .then((rows) => rows.map((r) => wfpTenantHost(r.id, issuerHost)));
+
+await backfillProxyHostsToKv({
+  hosts: [...domainHosts, ...wfpHosts],
+  resolveHost, // the composed resolver
+  kv: env.PROXY_HOSTS,
+});
+```
+
+Notes:
+
+- **Publish gates on `ready`.** A pending/failed tenant resolves to `null`, so
+  its subdomain keeps default-forwarding to the shared control plane until the
+  Worker is actually servable. Rollback is the same mechanism: delete the key
+  (or flip the tenant off `wfp`) and the host falls back.
+- **The whole host dispatches** — including `/api/v2/*`. Management traffic on
+  the tenant subdomain reaches the tenant Worker directly instead of the
+  control plane's forwarding middleware, so the tenant Worker must accept
+  control-plane-issued admin tokens (it does when provisioned with
+  `CONTROL_PLANE_ISSUER` / projected signing keys).
+- **Don't include the reconcile's WFP hosts filter on `provisioning_state`** —
+  listing *all* wfp tenants lets the reconcile also delete stale keys for
+  tenants that regressed from `ready` (the blob recomputes to `null`).
+
 ### Constraints & notes
 
 - **Same Cloudflare account** for the KV namespace and the proxy Worker — KV is
@@ -457,12 +569,17 @@ For each tenant, in isolation:
 
 - [ ] Provision the tenant's per-tenant Worker + database (its client/connection
       data now lives in the tenant DB, not the shared control-plane DB).
-- [ ] Add the routing row: a `custom_domains` + `proxy_routes` entry (or a KV blob,
-      Shape 3b) mapping `<tenant>.token.example.com` → `tenant-{id}-auth`.
+- [ ] The routing entry publishes itself: with
+      [`wrapTenantsAdapterWithWfpKvPublish`](#wfp-tenant-subdomains-dispatch-routes-without-custom-domains-rows)
+      on the control plane, the provisioner's `provisioning_state: "ready"`
+      write-back pushes the `<tenant>.token.example.com` → `tenant-{id}-auth`
+      dispatch blob to KV. (A branded custom domain still needs its own
+      `custom_domains` + `proxy_routes` entry.)
 - [ ] The proxy now dispatches that host to the tenant Worker; all other hosts keep
       default-forwarding to the legacy control plane.
-- [ ] **Rollback:** delete the routing row → the host falls back through
-      `defaultHandlers` to the legacy control plane again.
+- [ ] **Rollback:** delete the KV key (or flip the tenant off `wfp` / off `ready`)
+      → the host falls back through `defaultHandlers` to the legacy control
+      plane again.
 
 ### Verify before prod
 

--- a/apps/docs/deployment/cloudflare-wfp.md
+++ b/apps/docs/deployment/cloudflare-wfp.md
@@ -303,7 +303,7 @@ The `custom_domains` entry above is for the tenant's **branded** domain
 routes without one: wrap the control plane's tenants adapter with
 `wrapTenantsAdapterWithWfpKvPublish` and its dispatch route is derived from the
 tenant row and published to KV automatically when provisioning completes — see
-[Proxy → Deployment topologies → WFP tenant subdomains](/customization/proxy/deployment#wfp-tenant-subdomains-dispatch-routes-without-custom-domains-rows).
+[Proxy → Deployment topologies → WFP tenant subdomains](/customization/proxy/deployment#wfp-tenant-subdomains).
 :::
 
 ### 3.2 Provision the tenant's data store (only if `storage_kind = "own_d1"`)

--- a/apps/docs/deployment/cloudflare-wfp.md
+++ b/apps/docs/deployment/cloudflare-wfp.md
@@ -297,6 +297,15 @@ VALUES ('cd-acme', 'acme', 'auth.acme.com', 'auth0_managed_certs',
 The `POST /api/v2/tenants` endpoint requires the `create:tenants` scope **and** must be called against a control-plane tenant (see [Multi-Tenancy](/architecture/multi-tenancy)). Use a service-account token, never a tenant token.
 :::
 
+::: tip platform subdomains need no custom_domains row
+The `custom_domains` entry above is for the tenant's **branded** domain
+(`auth.acme.com`). The tenant's platform subdomain (`acme.token.example.com`)
+routes without one: wrap the control plane's tenants adapter with
+`wrapTenantsAdapterWithWfpKvPublish` and its dispatch route is derived from the
+tenant row and published to KV automatically when provisioning completes — see
+[Proxy → Deployment topologies → WFP tenant subdomains](/customization/proxy/deployment#wfp-tenant-subdomains-dispatch-routes-without-custom-domains-rows).
+:::
+
 ### 3.2 Provision the tenant's data store (only if `storage_kind = "own_d1"`)
 
 ```bash

--- a/packages/authhero/src/index.ts
+++ b/packages/authhero/src/index.ts
@@ -83,6 +83,7 @@ export {
   wrapTenantsAdapterWithWfpKvPublish,
   composeHostResolvers,
   wfpTenantHost,
+  isWfpSubdomainSafeTenantId,
   DEFAULT_WFP_DISPATCH_BINDING,
   DEFAULT_WFP_SCRIPT_NAME_TEMPLATE,
   type WfpTenantHostResolverOptions,

--- a/packages/authhero/src/index.ts
+++ b/packages/authhero/src/index.ts
@@ -79,6 +79,16 @@ export {
   type BackfillResult,
 } from "./routes/proxy-control-plane/kv-publish";
 export {
+  createWfpTenantHostResolver,
+  wrapTenantsAdapterWithWfpKvPublish,
+  composeHostResolvers,
+  wfpTenantHost,
+  DEFAULT_WFP_DISPATCH_BINDING,
+  DEFAULT_WFP_SCRIPT_NAME_TEMPLATE,
+  type WfpTenantHostResolverOptions,
+  type WfpTenantsKvPublishOptions,
+} from "./routes/proxy-control-plane/wfp-tenant-hosts";
+export {
   PROXY_RESOLVE_HOST_SCOPE,
   verifyControlPlaneToken,
   isAllowedIssuer,

--- a/packages/authhero/src/routes/proxy-control-plane/wfp-tenant-hosts.test.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/wfp-tenant-hosts.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, vi } from "vitest";
+import type {
+  CreateTenantParams,
+  Tenant,
+  TenantsDataAdapter,
+} from "@authhero/adapter-interfaces";
+import type { ResolvedHost } from "@authhero/proxy";
+import { buildKvHostKey, DEFAULT_KV_HOST_KEY_PREFIX } from "@authhero/proxy";
+import {
+  composeHostResolvers,
+  createWfpTenantHostResolver,
+  wfpTenantHost,
+  wrapTenantsAdapterWithWfpKvPublish,
+} from "./wfp-tenant-hosts";
+
+const ISSUER_HOST = "token.example.com";
+
+let idSeq = 0;
+const nextId = (p: string) => `${p}-${++idSeq}`;
+
+function makeTenant(overrides: Partial<Tenant> & { id: string }): Tenant {
+  return {
+    friendly_name: overrides.id,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function fakeTenants(seed: Tenant[] = []) {
+  const rows = new Map<string, Tenant>(seed.map((t) => [t.id, t]));
+  const adapter: TenantsDataAdapter = {
+    async create(params: CreateTenantParams) {
+      const id = params.id ?? nextId("t");
+      const row = makeTenant({ ...params, id });
+      rows.set(id, row);
+      return row;
+    },
+    async get(id) {
+      return rows.get(id) ?? null;
+    },
+    async list() {
+      return { tenants: [...rows.values()] };
+    },
+    async update(id, patch) {
+      const row = rows.get(id);
+      if (row) rows.set(id, { ...row, ...patch });
+    },
+    async remove(id) {
+      return rows.delete(id);
+    },
+  };
+  return { adapter, rows };
+}
+
+function fakeKv() {
+  const store = new Map<string, string>();
+  const put = vi.fn(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  const del = vi.fn(async (key: string) => {
+    store.delete(key);
+  });
+  return { kv: { put, delete: del }, store, put, delete: del };
+}
+
+const key = (host: string) => buildKvHostKey(DEFAULT_KV_HOST_KEY_PREFIX, host);
+
+const readyWfpTenant = (id: string, overrides: Partial<Tenant> = {}) =>
+  makeTenant({
+    id,
+    deployment_type: "wfp",
+    provisioning_state: "ready",
+    worker_script_name: `tenant-${id}-auth`,
+    ...overrides,
+  });
+
+describe("wfpTenantHost", () => {
+  it("derives the platform subdomain, normalized", () => {
+    expect(wfpTenantHost("wpf", ISSUER_HOST)).toBe("wpf.token.example.com");
+    expect(wfpTenantHost("WPF", "Token.Example.com:8443")).toBe(
+      "wpf.token.example.com",
+    );
+  });
+});
+
+describe("createWfpTenantHostResolver", () => {
+  function resolver(seed: Tenant[]) {
+    return createWfpTenantHostResolver({
+      tenants: fakeTenants(seed).adapter,
+      issuerHost: ISSUER_HOST,
+    });
+  }
+
+  it("resolves a ready wfp tenant subdomain to a dispatch route", async () => {
+    const resolve = resolver([readyWfpTenant("wpf")]);
+    const hit = await resolve("wpf.token.example.com");
+
+    expect(hit).toMatchObject({
+      tenant_id: "wpf",
+      domain: "wpf.token.example.com",
+      custom_domain_id: "wpf.token.example.com",
+    });
+    expect(hit!.routes).toHaveLength(1);
+    expect(hit!.routes[0]!.match).toEqual({ path: "/*" });
+    expect(hit!.routes[0]!.handlers).toEqual([
+      { type: "forwarded_headers", options: {} },
+      {
+        type: "dispatch_namespace",
+        options: { binding: "DISPATCHER", script_name: "tenant-wpf-auth" },
+      },
+    ]);
+  });
+
+  it("normalizes port, case, and trailing dot on the incoming host", async () => {
+    const resolve = resolver([readyWfpTenant("wpf")]);
+    const hit = await resolve("WPF.Token.Example.com.:443");
+    expect(hit?.tenant_id).toBe("wpf");
+    expect(hit?.domain).toBe("wpf.token.example.com");
+  });
+
+  it("falls back to the script-name template when worker_script_name is unset", async () => {
+    const seed = [readyWfpTenant("wpf", { worker_script_name: undefined })];
+    const resolve = createWfpTenantHostResolver({
+      tenants: fakeTenants(seed).adapter,
+      issuerHost: ISSUER_HOST,
+      scriptNameTemplate: "tenant-{tenant_id}-auth",
+    });
+    const hit = await resolve("wpf.token.example.com");
+    expect(hit!.routes[0]!.handlers[1]!.options).toMatchObject({
+      script_name: "tenant-wpf-auth",
+    });
+  });
+
+  it("honors dispatchBinding and dispatchTimeoutMs overrides", async () => {
+    const resolve = createWfpTenantHostResolver({
+      tenants: fakeTenants([readyWfpTenant("wpf")]).adapter,
+      issuerHost: ISSUER_HOST,
+      dispatchBinding: "TENANTS",
+      dispatchTimeoutMs: 10_000,
+    });
+    const hit = await resolve("wpf.token.example.com");
+    expect(hit!.routes[0]!.handlers[1]!.options).toEqual({
+      binding: "TENANTS",
+      script_name: "tenant-wpf-auth",
+      timeout_ms: 10_000,
+    });
+  });
+
+  it("returns null while the tenant is still provisioning", async () => {
+    const resolve = resolver([
+      readyWfpTenant("wpf", { provisioning_state: "pending" }),
+    ]);
+    expect(await resolve("wpf.token.example.com")).toBeNull();
+  });
+
+  it("returns null for shared tenants, unknown tenants, and non-subdomain hosts", async () => {
+    const resolve = resolver([
+      makeTenant({ id: "shared-tenant" }), // deployment_type defaults to shared
+      readyWfpTenant("wpf"),
+    ]);
+    expect(await resolve("shared-tenant.token.example.com")).toBeNull();
+    expect(await resolve("nope.token.example.com")).toBeNull();
+    expect(await resolve("token.example.com")).toBeNull(); // bare issuer host
+    expect(await resolve("a.wpf.token.example.com")).toBeNull(); // two labels
+    expect(await resolve("wpf.other.example.com")).toBeNull();
+    // suffix match must be label-aligned, not substring
+    expect(await resolve("evil-token.example.com")).toBeNull();
+  });
+});
+
+describe("composeHostResolvers", () => {
+  it("returns the first non-null hit in order", async () => {
+    const a = vi.fn(async () => null);
+    const hit = { tenant_id: "t", custom_domain_id: "c", domain: "d", routes: [] };
+    const b = vi.fn(async () => hit as ResolvedHost);
+    const c = vi.fn(async () => {
+      throw new Error("unreachable");
+    });
+
+    const resolve = composeHostResolvers(a, b, c);
+    expect(await resolve("d")).toBe(hit);
+    expect(a).toHaveBeenCalledWith("d");
+    expect(c).not.toHaveBeenCalled();
+  });
+
+  it("propagates errors instead of treating them as misses", async () => {
+    const boom = vi.fn(async () => {
+      throw new Error("layer down");
+    });
+    const resolve = composeHostResolvers(boom);
+    await expect(resolve("d")).rejects.toThrow("layer down");
+  });
+});
+
+function setupWrapped(seed: Tenant[] = []) {
+  const t = fakeTenants(seed);
+  const kvh = fakeKv();
+  const pending: Promise<unknown>[] = [];
+  const onError = vi.fn();
+  const resolveHost = composeHostResolvers(
+    createWfpTenantHostResolver({
+      tenants: t.adapter,
+      issuerHost: ISSUER_HOST,
+    }),
+  );
+  const wrapped = wrapTenantsAdapterWithWfpKvPublish({
+    tenants: t.adapter,
+    kv: kvh.kv,
+    resolveHost,
+    issuerHost: ISSUER_HOST,
+    waitUntil: (p) => pending.push(p),
+    onError,
+  });
+  const flush = () => Promise.all(pending);
+  return { t, kvh, wrapped, flush, onError };
+}
+
+describe("wrapTenantsAdapterWithWfpKvPublish", () => {
+  it("publishes the dispatch blob when the provisioner flips the tenant to ready", async () => {
+    const s = setupWrapped();
+    await s.wrapped.create({ friendly_name: "WPF", id: "wpf" });
+    await s.flush();
+    // Created without wfp fields → shared → no KV traffic at all.
+    expect(s.kvh.put).not.toHaveBeenCalled();
+    expect(s.kvh.delete).not.toHaveBeenCalled();
+
+    await s.wrapped.update("wpf", {
+      deployment_type: "wfp",
+      provisioning_state: "pending",
+    });
+    await s.flush();
+    // wfp but not ready → blob resolves null → key deleted (no-op here).
+    expect(s.kvh.put).not.toHaveBeenCalled();
+
+    // The provisioner's write-back, as done by createWfpTenantProvisioningHook.
+    await s.wrapped.update("wpf", {
+      provisioning_state: "ready",
+      worker_script_name: "tenant-wpf-auth",
+    });
+    await s.flush();
+
+    const stored = s.kvh.store.get(key("wpf.token.example.com"));
+    expect(stored).toBeDefined();
+    const blob = JSON.parse(stored!) as ResolvedHost;
+    expect(blob.tenant_id).toBe("wpf");
+    expect(blob.routes[0]!.handlers[1]).toMatchObject({
+      type: "dispatch_namespace",
+      options: { script_name: "tenant-wpf-auth" },
+    });
+  });
+
+  it("publishes on create when the row is born wfp+ready", async () => {
+    const s = setupWrapped();
+    await s.wrapped.create({
+      friendly_name: "WPF",
+      id: "wpf",
+      deployment_type: "wfp",
+      provisioning_state: "ready",
+      worker_script_name: "tenant-wpf-auth",
+    });
+    await s.flush();
+    expect(s.kvh.store.has(key("wpf.token.example.com"))).toBe(true);
+  });
+
+  it("deletes the key on remove", async () => {
+    const s = setupWrapped([readyWfpTenant("wpf")]);
+    // Seed KV as if previously published.
+    await s.kvh.kv.put(key("wpf.token.example.com"), "{}");
+    s.kvh.put.mockClear();
+
+    const ok = await s.wrapped.remove("wpf");
+    await s.flush();
+
+    expect(ok).toBe(true);
+    expect(s.kvh.delete).toHaveBeenCalledWith(key("wpf.token.example.com"));
+    expect(s.kvh.store.has(key("wpf.token.example.com"))).toBe(false);
+  });
+
+  it("deletes the key on a wfp → shared flip", async () => {
+    const s = setupWrapped([readyWfpTenant("wpf")]);
+    await s.kvh.kv.put(key("wpf.token.example.com"), "{}");
+
+    await s.wrapped.update("wpf", { deployment_type: "shared" });
+    await s.flush();
+
+    expect(s.kvh.delete).toHaveBeenCalledWith(key("wpf.token.example.com"));
+  });
+
+  it("ignores shared tenants entirely", async () => {
+    const s = setupWrapped([makeTenant({ id: "shared-tenant" })]);
+    await s.wrapped.update("shared-tenant", { friendly_name: "renamed" });
+    const ok = await s.wrapped.remove("shared-tenant");
+    await s.flush();
+
+    expect(ok).toBe(true);
+    expect(s.kvh.put).not.toHaveBeenCalled();
+    expect(s.kvh.delete).not.toHaveBeenCalled();
+  });
+
+  it("never fails the write when publishing throws; routes to onError", async () => {
+    const t = fakeTenants([readyWfpTenant("wpf")]);
+    const pending: Promise<unknown>[] = [];
+    const onError = vi.fn();
+    const wrapped = wrapTenantsAdapterWithWfpKvPublish({
+      tenants: t.adapter,
+      kv: fakeKv().kv,
+      resolveHost: async () => {
+        throw new Error("resolve boom");
+      },
+      issuerHost: ISSUER_HOST,
+      waitUntil: (p) => pending.push(p),
+      onError,
+    });
+
+    await wrapped.update("wpf", { friendly_name: "still works" });
+    await Promise.all(pending);
+
+    expect((await t.adapter.get("wpf"))?.friendly_name).toBe("still works");
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), {
+      host: "wpf.token.example.com",
+      op: "tenant.update",
+    });
+  });
+});

--- a/packages/authhero/src/routes/proxy-control-plane/wfp-tenant-hosts.test.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/wfp-tenant-hosts.test.ts
@@ -9,6 +9,7 @@ import { buildKvHostKey, DEFAULT_KV_HOST_KEY_PREFIX } from "@authhero/proxy";
 import {
   composeHostResolvers,
   createWfpTenantHostResolver,
+  isWfpSubdomainSafeTenantId,
   wfpTenantHost,
   wrapTenantsAdapterWithWfpKvPublish,
 } from "./wfp-tenant-hosts";
@@ -81,6 +82,25 @@ describe("wfpTenantHost", () => {
     expect(wfpTenantHost("WPF", "Token.Example.com:8443")).toBe(
       "wpf.token.example.com",
     );
+  });
+});
+
+describe("isWfpSubdomainSafeTenantId", () => {
+  it("accepts lowercase DNS labels", () => {
+    expect(isWfpSubdomainSafeTenantId("wpf")).toBe(true);
+    expect(isWfpSubdomainSafeTenantId("acme-2")).toBe(true);
+    expect(isWfpSubdomainSafeTenantId("a")).toBe(true);
+    expect(isWfpSubdomainSafeTenantId("a".repeat(63))).toBe(true);
+  });
+
+  it("rejects ids that cannot round-trip through a hostname", () => {
+    expect(isWfpSubdomainSafeTenantId("WpF")).toBe(false); // mixed case
+    expect(isWfpSubdomainSafeTenantId("a.b")).toBe(false); // dot
+    expect(isWfpSubdomainSafeTenantId("-acme")).toBe(false); // leading hyphen
+    expect(isWfpSubdomainSafeTenantId("acme-")).toBe(false); // trailing hyphen
+    expect(isWfpSubdomainSafeTenantId("a_b")).toBe(false); // underscore
+    expect(isWfpSubdomainSafeTenantId("")).toBe(false);
+    expect(isWfpSubdomainSafeTenantId("a".repeat(64))).toBe(false); // too long
   });
 });
 
@@ -285,6 +305,24 @@ describe("wrapTenantsAdapterWithWfpKvPublish", () => {
     await s.flush();
 
     expect(s.kvh.delete).toHaveBeenCalledWith(key("wpf.token.example.com"));
+  });
+
+  it("skips wfp tenants whose id is not a lowercase DNS label", async () => {
+    const s = setupWrapped();
+    await s.wrapped.create({
+      friendly_name: "Mixed",
+      id: "WpF",
+      deployment_type: "wfp",
+      provisioning_state: "ready",
+      worker_script_name: "tenant-WpF-auth",
+    });
+    await s.wrapped.update("WpF", { friendly_name: "renamed" });
+    const ok = await s.wrapped.remove("WpF");
+    await s.flush();
+
+    expect(ok).toBe(true);
+    expect(s.kvh.put).not.toHaveBeenCalled();
+    expect(s.kvh.delete).not.toHaveBeenCalled();
   });
 
   it("ignores shared tenants entirely", async () => {

--- a/packages/authhero/src/routes/proxy-control-plane/wfp-tenant-hosts.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/wfp-tenant-hosts.ts
@@ -38,6 +38,22 @@ function normalizeHost(host: string): string {
   return normalized;
 }
 
+// One lowercase DNS label, per RFC 1123 (max 63 chars, alphanumeric with
+// inner hyphens). Case matters: DNS lowercases the incoming host but
+// `tenants.get()` is exact-match, so a mixed-case id can never round-trip
+// through a hostname.
+const DNS_LABEL_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+/**
+ * Whether a tenant id can be served on a platform subdomain at all. Ids that
+ * fail this (mixed case, dots, other URL-unsafe characters) are skipped by
+ * `wrapTenantsAdapterWithWfpKvPublish` — publishing them would create KV keys
+ * the resolver can never match. Give WFP tenants lowercase DNS-label ids.
+ */
+export function isWfpSubdomainSafeTenantId(tenantId: string): boolean {
+  return DNS_LABEL_RE.test(tenantId);
+}
+
 export interface WfpTenantHostResolverOptions {
   /** Tenant lookup — typically the control plane's tenants adapter. */
   tenants: Pick<TenantsDataAdapter, "get">;
@@ -218,9 +234,12 @@ export interface WfpTenantsKvPublishOptions {
  * remove deletes the key, so a deprovisioned tenant's host falls back to the
  * proxy's default chain instead of dispatching to a dead script.
  *
- * Shared (non-WFP) tenants never touch KV. Publishing is fire-and-forget;
- * silent drift is corrected by the periodic reconcile
- * (`backfillProxyHostsToKv` over `wfpTenantHost`-derived hosts).
+ * Shared (non-WFP) tenants never touch KV, and neither do wfp tenants whose
+ * id is not a lowercase DNS label (`isWfpSubdomainSafeTenantId`) — such ids
+ * cannot round-trip through a hostname, so publishing them would only create
+ * dead keys. Publishing is fire-and-forget; silent drift is corrected by the
+ * periodic reconcile (`backfillProxyHostsToKv` over `wfpTenantHost`-derived
+ * hosts).
  */
 export function wrapTenantsAdapterWithWfpKvPublish(
   options: WfpTenantsKvPublishOptions,
@@ -257,6 +276,7 @@ export function wrapTenantsAdapterWithWfpKvPublish(
   }
 
   function publish(tenantId: string, op: string): void {
+    if (!isWfpSubdomainSafeTenantId(tenantId)) return;
     schedule(publishHost(wfpTenantHost(tenantId, issuerHost), op));
   }
 

--- a/packages/authhero/src/routes/proxy-control-plane/wfp-tenant-hosts.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/wfp-tenant-hosts.ts
@@ -1,0 +1,300 @@
+import type { Tenant, TenantsDataAdapter } from "@authhero/adapter-interfaces";
+import type { ResolvedHost } from "@authhero/proxy";
+import {
+  buildKvHostKey,
+  DEFAULT_KV_HOST_KEY_PREFIX,
+  type KvNamespaceWriter,
+} from "@authhero/proxy";
+
+/**
+ * Default dispatch-namespace binding name the synthesized route targets.
+ * Must match the `[[dispatch_namespaces]] binding = "..."` declared in the
+ * proxy Worker's wrangler config.
+ */
+export const DEFAULT_WFP_DISPATCH_BINDING = "DISPATCHER";
+
+/**
+ * Default script-name template, matching the WFP provisioner's default
+ * (`scriptNameTemplate` in `@authhero/cloudflare-adapter`). Only used when the
+ * tenant row carries no `worker_script_name` — the provisioner writes that
+ * back on provision, and it is always preferred.
+ */
+export const DEFAULT_WFP_SCRIPT_NAME_TEMPLATE = "{tenant_id}";
+
+/**
+ * The platform subdomain a WFP tenant is served on: `{tenant_id}.{issuerHost}`.
+ * Central so the publisher, the resolver, and any reconcile host-list
+ * derivation all agree on the exact host (and therefore the KV key).
+ */
+export function wfpTenantHost(tenantId: string, issuerHost: string): string {
+  return `${tenantId}.${normalizeHost(issuerHost)}`.toLowerCase();
+}
+
+function normalizeHost(host: string): string {
+  let normalized = host.trim().toLowerCase();
+  const colon = normalized.indexOf(":");
+  if (colon !== -1) normalized = normalized.slice(0, colon);
+  if (normalized.endsWith(".")) normalized = normalized.slice(0, -1);
+  return normalized;
+}
+
+export interface WfpTenantHostResolverOptions {
+  /** Tenant lookup — typically the control plane's tenants adapter. */
+  tenants: Pick<TenantsDataAdapter, "get">;
+  /**
+   * The issuer host tenant subdomains hang off (e.g. `token.example.com`,
+   * from `new URL(env.ISSUER).host`). A host resolves only when it is exactly
+   * one label under this — `wpf.token.example.com`, not `a.b.token.example.com`.
+   */
+  issuerHost: string;
+  /** Dispatch-namespace binding name on the proxy Worker. */
+  dispatchBinding?: string;
+  /**
+   * Fallback script-name template (`{tenant_id}` placeholder) for tenants
+   * provisioned before `worker_script_name` was written back. Must match the
+   * provisioner's template.
+   */
+  scriptNameTemplate?: string;
+  /** Optional per-request timeout (ms) forwarded to the dispatch handler. */
+  dispatchTimeoutMs?: number;
+}
+
+/**
+ * Build a `resolveHost` that maps a WFP tenant's platform subdomain
+ * (`{tenant_id}.{issuerHost}`) to a synthetic `ResolvedHost` whose single
+ * route dispatches into the tenant's own Worker via the proxy's
+ * `dispatch_namespace` handler.
+ *
+ * Resolves only tenants with `deployment_type: "wfp"` AND
+ * `provisioning_state: "ready"` — anything else returns `null` so the host
+ * falls through to the proxy's fallback chain (typically the shared control
+ * plane), which keeps a tenant serviceable while it is still provisioning.
+ * No `custom_domains` row is involved; the mapping is derived entirely from
+ * the tenant row, which stays the durable source of truth.
+ *
+ * Compose it behind the custom-domains resolver with `composeHostResolvers`
+ * so an explicit `custom_domains` row for the same host always wins.
+ */
+export function createWfpTenantHostResolver(
+  options: WfpTenantHostResolverOptions,
+): (host: string) => Promise<ResolvedHost | null> {
+  const {
+    tenants,
+    dispatchBinding = DEFAULT_WFP_DISPATCH_BINDING,
+    scriptNameTemplate = DEFAULT_WFP_SCRIPT_NAME_TEMPLATE,
+    dispatchTimeoutMs,
+  } = options;
+  const issuerHost = normalizeHost(options.issuerHost);
+  const suffix = `.${issuerHost}`;
+
+  return async (rawHost: string): Promise<ResolvedHost | null> => {
+    const host = normalizeHost(rawHost);
+    if (!host.endsWith(suffix)) return null;
+
+    const label = host.slice(0, -suffix.length);
+    // Exactly one label under the issuer host; the bare issuer host itself
+    // (empty label) is the control plane, never a tenant.
+    if (!label || label.includes(".")) return null;
+
+    const tenant = await tenants.get(label);
+    if (
+      !tenant ||
+      tenant.deployment_type !== "wfp" ||
+      tenant.provisioning_state !== "ready"
+    ) {
+      return null;
+    }
+
+    return buildWfpTenantResolvedHost(tenant, host, {
+      dispatchBinding,
+      scriptNameTemplate,
+      dispatchTimeoutMs,
+    });
+  };
+}
+
+function buildWfpTenantResolvedHost(
+  tenant: Tenant,
+  host: string,
+  opts: {
+    dispatchBinding: string;
+    scriptNameTemplate: string;
+    dispatchTimeoutMs?: number;
+  },
+): ResolvedHost {
+  const scriptName =
+    tenant.worker_script_name ??
+    opts.scriptNameTemplate.replaceAll("{tenant_id}", tenant.id);
+  // `updated_at` transforms null → "" in the tenant schema, hence `||`.
+  const timestamp = tenant.updated_at || new Date().toISOString();
+
+  return {
+    tenant_id: tenant.id,
+    // No custom_domains row exists for a platform subdomain — the host doubles
+    // as the synthetic id, mirroring the proxy's static adapter.
+    custom_domain_id: host,
+    domain: host,
+    routes: [
+      {
+        id: `${host}:wfp-dispatch`,
+        tenant_id: tenant.id,
+        custom_domain_id: host,
+        priority: 100,
+        match: { path: "/*" },
+        handlers: [
+          { type: "forwarded_headers", options: {} },
+          {
+            type: "dispatch_namespace",
+            options: {
+              binding: opts.dispatchBinding,
+              script_name: scriptName,
+              ...(opts.dispatchTimeoutMs
+                ? { timeout_ms: opts.dispatchTimeoutMs }
+                : {}),
+            },
+          },
+        ],
+        created_at: timestamp,
+        updated_at: timestamp,
+      },
+    ],
+  };
+}
+
+/**
+ * Chain host resolvers: first non-null wins, in argument order. Put the
+ * custom-domains resolver first so an explicit `custom_domains` row overrides
+ * a derived WFP tenant-subdomain route for the same host. Errors propagate —
+ * a failing layer should surface (and let the caller's own fallback take
+ * over), not be silently treated as a miss that could delete a live KV key.
+ */
+export function composeHostResolvers(
+  ...resolvers: Array<(host: string) => Promise<ResolvedHost | null>>
+): (host: string) => Promise<ResolvedHost | null> {
+  return async (host) => {
+    for (const resolve of resolvers) {
+      const hit = await resolve(host);
+      if (hit) return hit;
+    }
+    return null;
+  };
+}
+
+export interface WfpTenantsKvPublishOptions {
+  /** Tenants adapter whose writes should be mirrored to KV. */
+  tenants: TenantsDataAdapter;
+  /** KV namespace the resolved host blobs are published to. */
+  kv: KvNamespaceWriter;
+  /**
+   * Cross-tenant host resolver used to recompute the blob after a write —
+   * pass the SAME composed resolver (custom domains first, then
+   * `createWfpTenantHostResolver`) that the control plane serves over HTTP,
+   * so every publisher computes identical blobs for a host.
+   */
+  resolveHost: (host: string) => Promise<ResolvedHost | null>;
+  /** The issuer host tenant subdomains hang off — see `wfpTenantHost`. */
+  issuerHost: string;
+  /** Key prefix; must match the proxy reader. Defaults to the shared default. */
+  keyPrefix?: string;
+  /**
+   * Optional `ctx.waitUntil` so the fire-and-forget KV publish runs to
+   * completion without blocking (or failing) the originating write. When
+   * omitted, the publish is detached with its rejection swallowed.
+   */
+  waitUntil?: (promise: Promise<unknown>) => void;
+  /** Optional hook invoked when a publish fails. */
+  onError?: (err: unknown, ctx: { host: string; op: string }) => void;
+}
+
+/**
+ * Wrap a control plane's `tenants` adapter so every WFP-tenant mutation
+ * republishes (or deletes) the tenant's platform-subdomain routing blob in KV
+ * — the tenants-table counterpart of `wrapProxyAdaptersWithKvPublish`.
+ *
+ * This is the single choke-point for WFP subdomain routing: the provisioner
+ * flips `provisioning_state` to `"ready"` through `tenants.update`, which
+ * publishes the dispatch route the moment the tenant Worker is servable —
+ * inline hook and durable-workflow paths alike, with no per-path wiring. A
+ * remove deletes the key, so a deprovisioned tenant's host falls back to the
+ * proxy's default chain instead of dispatching to a dead script.
+ *
+ * Shared (non-WFP) tenants never touch KV. Publishing is fire-and-forget;
+ * silent drift is corrected by the periodic reconcile
+ * (`backfillProxyHostsToKv` over `wfpTenantHost`-derived hosts).
+ */
+export function wrapTenantsAdapterWithWfpKvPublish(
+  options: WfpTenantsKvPublishOptions,
+): TenantsDataAdapter {
+  const {
+    tenants,
+    kv,
+    resolveHost,
+    issuerHost,
+    keyPrefix = DEFAULT_KV_HOST_KEY_PREFIX,
+    waitUntil,
+    onError,
+  } = options;
+
+  function schedule(promise: Promise<unknown>): void {
+    const safe = promise.catch(() => undefined);
+    if (waitUntil) waitUntil(safe);
+  }
+
+  // Recompute the host blob and republish (put), or delete when it no longer
+  // resolves. Always resolves — failures route to `onError`, never throw.
+  async function publishHost(host: string, op: string): Promise<void> {
+    try {
+      const blob = await resolveHost(host);
+      const key = buildKvHostKey(keyPrefix, host);
+      if (blob) {
+        await kv.put(key, JSON.stringify(blob));
+      } else {
+        await kv.delete(key);
+      }
+    } catch (err) {
+      if (onError) onError(err, { host, op });
+    }
+  }
+
+  function publish(tenantId: string, op: string): void {
+    schedule(publishHost(wfpTenantHost(tenantId, issuerHost), op));
+  }
+
+  // Row reads for publish gating must never fail (or delay a false failure
+  // onto) the underlying write — degrade to "not wfp", which skips the
+  // publish; the periodic reconcile repairs the drift.
+  async function isWfp(id: string): Promise<boolean> {
+    try {
+      const tenant = await tenants.get(id);
+      return tenant?.deployment_type === "wfp";
+    } catch {
+      return false;
+    }
+  }
+
+  return {
+    ...tenants,
+    async create(params, createOptions) {
+      const created = await tenants.create(params, createOptions);
+      if (created.deployment_type === "wfp") {
+        publish(created.id, "tenant.create");
+      }
+      return created;
+    },
+    async update(id, patch) {
+      await tenants.update(id, patch);
+      // `deployment_type` in the patch also covers a wfp → shared flip, where
+      // the post-update row is no longer wfp but the stale key must go.
+      if ("deployment_type" in patch || (await isWfp(id))) {
+        publish(id, "tenant.update");
+      }
+    },
+    async remove(id) {
+      const wasWfp = await isWfp(id);
+      const ok = await tenants.remove(id);
+      // The row is gone, so the blob recomputes to null → KV key deleted.
+      if (ok && wasWfp) publish(id, "tenant.remove");
+      return ok;
+    },
+  };
+}


### PR DESCRIPTION
## Problem

A WFP tenant's platform subdomain (`{tenant_id}.{issuerHost}`) has no `custom_domains` or `proxy_routes` entry, and KV publishing (`wrapProxyAdaptersWithKvPublish`) plus the periodic reconcile (`backfillProxyHostsToKv`) key exclusively off those tables. So nothing ever publishes the subdomain's routing blob: the proxy misses KV, misses the control-plane `resolveHost` (exact-match over `custom_domains`), and default-forwards to the shared control plane **forever** — even after the tenant Worker is provisioned and sitting in the dispatch namespace. Observed in dev with `wpf.token.sesamy.dev`: served by the control-plane fallback while `tenant-wpf-auth` sat unused.

## Approach

Derive the routing from the tenant row (the durable source of truth) instead of materialising synthetic `custom_domains` rows, which would leak into the Auth0-compatible management API surface:

- **`createWfpTenantHostResolver`** — resolves `{tenant_id}.{issuerHost}` for tenants with `deployment_type: "wfp"` **and** `provisioning_state: "ready"` to a synthetic `ResolvedHost` whose single route dispatches via the proxy's builtin `dispatch_namespace` handler. Prefers the row's `worker_script_name`; falls back to a template. Anything else resolves `null`, so a still-provisioning tenant keeps falling back to the shared control plane.
- **`wrapTenantsAdapterWithWfpKvPublish`** — tenants-adapter counterpart of `wrapProxyAdaptersWithKvPublish`. The provisioner flips `provisioning_state` to `ready` *through* `tenants.update`, so the KV publish fires at exactly the right moment on both the inline-hook and durable-workflow paths, with no per-path wiring. A remove (or wfp→shared flip) deletes the key, so the host falls back instead of dispatching to a dead script. Shared tenants never touch KV.
- **`composeHostResolvers`** — chains resolvers (custom domains first, so an explicit row wins on collision); one composed `resolveHost` serves the HTTP `/hosts` endpoint, both KV publishers, and the reconcile, guaranteeing identical blobs.
- **`wfpTenantHost`** — canonical host derivation for reconcile host lists.

The proxy needs **zero changes**: `dispatch_namespace` is already a registered builtin handler and the dispatcher binding is declared in the proxy Worker's wrangler config — the blob arriving in KV is all it was waiting for.

## Docs

- New **“WFP tenant subdomains”** section in *Proxy → Deployment topologies* with full wiring + reconcile examples.
- Shape 5 “Phased cutover” Phase 2 updated: the routing entry now publishes itself on provision.
- *Cloudflare WFP* guide: tip clarifying platform subdomains need no `custom_domains` row.

## Testing

- 12 new unit tests (`wfp-tenant-hosts.test.ts`) covering resolution gating (ready/pending/shared/unknown, label alignment, normalization), handler synthesis, publish-on-ready, delete-on-remove/flip, and write resilience (publish failure never fails the write).
- Existing `kv-publish.test.ts` suite still green (23 total).
- `tsc --noEmit` clean.

Downstream wiring: sesamyab/auth branch `ma/wfp-subdomain-kv-routing` (needs the release from this PR before it can merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)