### PR TITLE
fix(drizzle): replace runtime require("nanoid") with ESM imports

### DIFF
--- a/.changeset/drizzle-esm-nanoid-require.md
+++ b/.changeset/drizzle-esm-nanoid-require.md
@@ -1,0 +1,5 @@
+---
+"@authhero/drizzle": patch
+---
+
+Fix runtime crash in the ESM bundle when creating connections, organizations, resource servers, invites, or hooks. Five adapters loaded nanoid with a lazy `require("nanoid")`, which worked while nanoid was bundled into the dist but throws under Node ESM now that nanoid is external. Replaced with top-level ESM imports.

--- a/packages/drizzle/src/adapters/connections.ts
+++ b/packages/drizzle/src/adapters/connections.ts
@@ -1,4 +1,5 @@
 import { eq, and, count as countFn, asc, desc } from "drizzle-orm";
+import { customAlphabet } from "nanoid";
 import { HTTPException } from "hono/http-exception";
 import type { Connection, ListParams } from "@authhero/adapter-interfaces";
 import { connections } from "../schema/sqlite";
@@ -7,7 +8,6 @@ import { buildLuceneFilter } from "../helpers/filter";
 import type { DrizzleDb } from "./types";
 
 function generateConnectionId(): string {
-  const { customAlphabet } = require("nanoid");
   const generate = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyz", 17);
   return `con_${generate()}`;
 }

--- a/packages/drizzle/src/adapters/hooks.ts
+++ b/packages/drizzle/src/adapters/hooks.ts
@@ -1,4 +1,5 @@
 import { eq, and, count as countFn, asc, desc } from "drizzle-orm";
+import { customAlphabet } from "nanoid";
 import type { Hook, ListParams } from "@authhero/adapter-interfaces";
 import { hooks } from "../schema/sqlite";
 import { removeNullProperties } from "../helpers/transform";
@@ -7,7 +8,6 @@ import { buildLuceneFilter } from "../helpers/filter";
 import type { DrizzleDb } from "./types";
 
 function generateHookId(): string {
-  const { customAlphabet } = require("nanoid");
   const generate = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyz", 17);
   return `h_${generate()}`;
 }

--- a/packages/drizzle/src/adapters/invites.ts
+++ b/packages/drizzle/src/adapters/invites.ts
@@ -1,4 +1,5 @@
 import { eq, and, count as countFn, asc, desc } from "drizzle-orm";
+import { customAlphabet } from "nanoid";
 import { HTTPException } from "hono/http-exception";
 import type { Invite, ListParams } from "@authhero/adapter-interfaces";
 import { invites } from "../schema/sqlite";
@@ -6,7 +7,6 @@ import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
 import type { DrizzleDb } from "./types";
 
 function generateInviteId(): string {
-  const { customAlphabet } = require("nanoid");
   const generate = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyz", 17);
   return `inv_${generate()}`;
 }

--- a/packages/drizzle/src/adapters/organizations.ts
+++ b/packages/drizzle/src/adapters/organizations.ts
@@ -1,4 +1,5 @@
 import { eq, and, count as countFn, asc, desc } from "drizzle-orm";
+import { customAlphabet } from "nanoid";
 import { HTTPException } from "hono/http-exception";
 import type { Organization, ListParams } from "@authhero/adapter-interfaces";
 import { organizations } from "../schema/sqlite";
@@ -18,7 +19,6 @@ import type { DrizzleDb } from "./types";
 const ALLOWED_Q_FIELDS = ["name", "display_name"];
 
 function generateOrganizationId(): string {
-  const { customAlphabet } = require("nanoid");
   const generate = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyz", 17);
   return `org_${generate()}`;
 }

--- a/packages/drizzle/src/adapters/resourceServers.ts
+++ b/packages/drizzle/src/adapters/resourceServers.ts
@@ -1,4 +1,5 @@
 import { eq, and, count as countFn, asc, desc, sql } from "drizzle-orm";
+import { customAlphabet } from "nanoid";
 import type { ResourceServer, ListParams } from "@authhero/adapter-interfaces";
 import { resourceServers } from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
@@ -10,7 +11,6 @@ import type { DrizzleDb } from "./types";
 const ALLOWED_Q_FIELDS = ["name", "identifier"];
 
 function generateResourceServerId(): string {
-  const { customAlphabet } = require("nanoid");
   const generate = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyz", 17);
   return `api_${generate()}`;
 }


### PR DESCRIPTION
## Summary

The OIDC conformance seed broke on main after #1108 with:

```
Error: Calling `require` for "nanoid" in an environment that doesn't expose the `require` function.
    at .../packages/drizzle/dist/drizzle-adapter.mjs
```

Five drizzle adapters (`connections`, `organizations`, `resourceServers`, `invites`, `hooks`) loaded nanoid via a lazy `require("nanoid")` inside their id-generator helpers (a pattern dating back to April). This was latent while nanoid was bundled into the dist — the bundler rewrote the require to the inlined copy. #1108 correctly made nanoid external, so rolldown now emits a runtime `require` shim that throws under Node ESM, killing the seed at "Creating password connection".

## Fix

Hoist to top-level `import { customAlphabet } from "nanoid"` — the same style every other adapter in the package already uses (e.g. `hookCode.ts`). Includes a patch changeset for `@authhero/drizzle`.

## Verification

- `grep` of the rebuilt `dist/drizzle-adapter.mjs`: nanoid now comes in via a single ESM import; no require shim remains.
- `pnpm --filter @authhero/drizzle test`: 82/82 pass.
- `pnpm conformance:seed` on a fresh db: completes end-to-end, including the password connection (CI failure point), organization, and resource-server creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime crashes in ESM environments when creating connections, organizations, resource servers, invites, or hooks.
  * ID generation continues to use the same formats and behavior across affected features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->