### PR TITLE
feat(conformance): add oidcc-formpost-hybrid certification test plan

### DIFF
--- a/apps/conformance-runner/README.md
+++ b/apps/conformance-runner/README.md
@@ -45,13 +45,14 @@ Run a single plan's tests with Playwright's filename filter:
 pnpm conformance:run -- tests/oidcc-config.spec.ts
 ```
 
-The runner currently drives eight plans, each in its own spec file:
+The runner currently drives nine plans, each in its own spec file:
 
 - `oidcc-basic-certification-test-plan` ([oidcc-basic.spec.ts](tests/oidcc-basic.spec.ts))
 - `oidcc-formpost-basic-certification-test-plan` ([oidcc-form-post-basic.spec.ts](tests/oidcc-form-post-basic.spec.ts))
 - `oidcc-implicit-certification-test-plan` ([oidcc-implicit.spec.ts](tests/oidcc-implicit.spec.ts)) — `response_type` is pinned per-module by the plan; status TBD until first green run
 - `oidcc-formpost-implicit-certification-test-plan` ([oidcc-form-post-implicit.spec.ts](tests/oidcc-form-post-implicit.spec.ts)) — implicit profile with `response_mode=form_post`; `response_type` pinned per-module by the plan; status TBD until first green run
 - `oidcc-hybrid-certification-test-plan` ([oidcc-hybrid.spec.ts](tests/oidcc-hybrid.spec.ts)) — hybrid flow (`code id_token`, `code token`, `code id_token token`); `response_type` pinned per-module by the plan; status TBD until first green run
+- `oidcc-formpost-hybrid-certification-test-plan` ([oidcc-form-post-hybrid.spec.ts](tests/oidcc-form-post-hybrid.spec.ts)) — hybrid profile with `response_mode=form_post`; `response_type` pinned per-module by the plan; status TBD until first green run
 - `oidcc-rp-initiated-logout-certification-test-plan` ([oidcc-rp-initiated-logout.spec.ts](tests/oidcc-rp-initiated-logout.spec.ts))
 - `oidcc-config-certification-test-plan` ([oidcc-config.spec.ts](tests/oidcc-config.spec.ts)) — pure metadata verification (discovery + JWKS), no browser flow
 - `oidcc-dynamic-certification-test-plan` ([oidcc-dynamic.spec.ts](tests/oidcc-dynamic.spec.ts)) — basic flow with `client_registration=dynamic_client`; suite registers its own client via `/oidc/register`. Requires the conformance tenant to have `enable_dynamic_client_registration=true` (set automatically by `create-authhero --conformance`). Status TBD until first green run

--- a/apps/conformance-runner/lib/test-plan-config.ts
+++ b/apps/conformance-runner/lib/test-plan-config.ts
@@ -66,6 +66,18 @@ export const HYBRID_PLAN_VARIANT = {
   client_registration: "static_client",
 } as const;
 
+export const FORM_POST_HYBRID_PLAN_NAME =
+  "oidcc-formpost-hybrid-certification-test-plan";
+
+// Same module-level pinning as the hybrid plan — `response_type` is fixed
+// per-module by the suite (`code id_token`, `code token`, `code id_token
+// token`), and `response_mode=form_post` is encoded in the plan name itself.
+// So variants stay limited to server_metadata + client_registration.
+export const FORM_POST_HYBRID_PLAN_VARIANT = {
+  server_metadata: "discovery",
+  client_registration: "static_client",
+} as const;
+
 export const DYNAMIC_PLAN_NAME = "oidcc-dynamic-certification-test-plan";
 
 // Dynamic registration variant — the suite calls /oidc/register itself for
@@ -151,6 +163,10 @@ export function buildFormPostImplicitPlanConfig() {
 
 export function buildHybridPlanConfig() {
   return buildSharedClientConfig("OIDC Hybrid");
+}
+
+export function buildFormPostHybridPlanConfig() {
+  return buildSharedClientConfig("OIDC Form Post Hybrid");
 }
 
 export function buildDynamicPlanConfig() {

--- a/apps/conformance-runner/tests/oidcc-form-post-hybrid.spec.ts
+++ b/apps/conformance-runner/tests/oidcc-form-post-hybrid.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from "@playwright/test";
+import { ConformanceClient, downloadPlanReport } from "../lib/conformance-api";
+import { runBrowserFlow } from "../lib/run-browser-flow";
+import { env } from "../lib/env";
+import {
+  FORM_POST_HYBRID_PLAN_NAME,
+  FORM_POST_HYBRID_PLAN_VARIANT,
+  buildFormPostHybridPlanConfig,
+} from "../lib/test-plan-config";
+
+const client = new ConformanceClient();
+
+let planId: string;
+let modules: { testModule: string; variant?: Record<string, string> }[];
+
+test.beforeAll(async () => {
+  const config = buildFormPostHybridPlanConfig();
+  console.log(
+    `[conformance-runner] Creating plan ${FORM_POST_HYBRID_PLAN_NAME} with alias ${config.alias}`,
+  );
+  const plan = await client.createPlan(
+    FORM_POST_HYBRID_PLAN_NAME,
+    config,
+    FORM_POST_HYBRID_PLAN_VARIANT,
+  );
+  planId = plan.id;
+  modules = plan.modules;
+  console.log(
+    `[conformance-runner] Plan ${planId} created — ${modules.length} module(s)`,
+  );
+  console.log(
+    `[conformance-runner] Plan detail: ${client.baseUrl}/plan-detail.html?plan=${planId}`,
+  );
+});
+
+test.afterAll(async () => {
+  await downloadPlanReport(client, FORM_POST_HYBRID_PLAN_NAME, planId);
+});
+
+const MODULES_ALLOWED_TO_WARN = new Set<string>([]);
+
+// No serial mode: with per-test isolation a failure tears down only its own
+// worker (the next test gets a fresh worker + plan), so one flaky module
+// doesn't skip the rest of the file, and a CI retry re-runs just the failed
+// module instead of the whole plan.
+test.describe.configure({ mode: "default" });
+
+test.describe("OIDCC Form Post Hybrid Certification", () => {
+  for (const moduleName of getStaticModulesForPlan()) {
+    test(moduleName, async ({ page }) => {
+      const moduleEntry = modules.find((m) => m.testModule === moduleName);
+      test.skip(
+        !moduleEntry,
+        `module ${moduleName} not present in created plan`,
+      );
+
+      const created = await client.createTestFromPlan(
+        planId,
+        moduleName,
+        moduleEntry?.variant,
+      );
+      const testId = created.id;
+      console.log(
+        `[conformance-runner] ${moduleName} -> ${client.baseUrl}/log-detail.html?log=${testId}`,
+      );
+
+      const initial = await client.waitForState(testId, [
+        "CONFIGURED",
+        "WAITING",
+        "FINISHED",
+        "INTERRUPTED",
+      ]);
+      if (initial === "CONFIGURED") {
+        await client.startTest(testId);
+        await client.waitForState(testId, [
+          "WAITING",
+          "FINISHED",
+          "INTERRUPTED",
+        ]);
+      }
+
+      const preBrowserInfo = await client.getInfo(testId);
+      if (
+        preBrowserInfo.status !== "FINISHED" &&
+        preBrowserInfo.status !== "INTERRUPTED"
+      ) {
+        await runBrowserFlow({ testId, page, client });
+        await client.waitForState(testId, ["FINISHED", "INTERRUPTED"]);
+      }
+
+      const info = await client.getInfo(testId);
+      const result = info.result;
+      console.log(
+        `[conformance-runner] ${moduleName} status=${info.status} result=${result ?? "(none)"}`,
+      );
+
+      const acceptable: string[] = ["PASSED", "REVIEW", "SKIPPED"];
+      if (env.allowWarning || MODULES_ALLOWED_TO_WARN.has(moduleName)) {
+        acceptable.push("WARNING");
+      }
+
+      let failureDetail = "";
+      if (!acceptable.includes(result ?? "")) {
+        const log = await client.getTestLog(testId).catch(() => []);
+        const firstFail = log.find((l) => l.result === "FAILURE");
+        const firstWarn = log.find((l) => l.result === "WARNING");
+        const parts: string[] = [];
+        if (firstFail) {
+          parts.push(
+            `first FAILURE: [${firstFail.src ?? "?"}] ${firstFail.msg ?? ""}`,
+          );
+        }
+        if (firstWarn) {
+          parts.push(
+            `first WARNING: [${firstWarn.src ?? "?"}] ${firstWarn.msg ?? ""}`,
+          );
+        }
+        if (parts.length > 0) failureDetail = ` | ${parts.join(" | ")}`;
+      }
+
+      expect(
+        acceptable,
+        `expected ${moduleName} result to be ${acceptable.join("/")}; got ${result ?? "(none)"} (status=${info.status}). Log: ${client.baseUrl}/log-detail.html?log=${testId}${failureDetail}`,
+      ).toContain(result ?? "");
+    });
+  }
+});
+
+// Starter superset — modules absent from the live plan are filtered via
+// test.skip above. Mirrors the hybrid plan's module list since the only
+// differentiator is response_mode=form_post (encoded in the plan name).
+// Like the plain hybrid plan, the code is exchanged at the token endpoint,
+// so the code-exchange modules (refresh-token, codereuse, client auth) are
+// included.
+function getStaticModulesForPlan(): string[] {
+  return [
+    "oidcc-server",
+    "oidcc-response-type-missing",
+    "oidcc-idtoken-signature",
+    "oidcc-idtoken-unsigned",
+    "oidcc-userinfo-get",
+    "oidcc-userinfo-post-header",
+    "oidcc-userinfo-post-body",
+    "oidcc-scope-profile",
+    "oidcc-scope-email",
+    "oidcc-scope-address",
+    "oidcc-scope-phone",
+    "oidcc-scope-all",
+    "oidcc-ensure-other-scope-order-succeeds",
+    "oidcc-display-page",
+    "oidcc-display-popup",
+    "oidcc-prompt-login",
+    "oidcc-prompt-none-not-logged-in",
+    "oidcc-prompt-none-logged-in",
+    "oidcc-max-age-1",
+    "oidcc-max-age-10000",
+    "oidcc-ensure-request-with-unknown-parameter-succeeds",
+    "oidcc-id-token-hint",
+    "oidcc-login-hint",
+    "oidcc-ui-locales",
+    "oidcc-claims-locales",
+    "oidcc-ensure-request-with-acr-values-succeeds",
+    "oidcc-ensure-registered-redirect-uri",
+    "oidcc-ensure-post-request-succeeds",
+    "oidcc-request-uri-unsigned",
+    "oidcc-unsigned-request-object-supported-correctly-or-rejected-as-unsupported",
+    "oidcc-claims-essential",
+    "oidcc-ensure-request-object-with-redirect-uri",
+    // Hybrid-flow specific: nonce REQUIRED whenever id_token is issued from
+    // the authorization endpoint (OIDC Core 3.3.2.11 — applies via the same
+    // gate as implicit since hybrid `code id_token` / `code id_token token`
+    // also issue id_tokens at /authorize).
+    "oidcc-implicit-nonce-required",
+    // Hybrid runs through the token endpoint too, so the code-exchange modules
+    // can appear: refresh tokens, PKCE, code reuse, etc.
+    "oidcc-refresh-token",
+    "oidcc-codereuse",
+    "oidcc-codereuse-30seconds",
+    "oidcc-client-secret-basic",
+    "oidcc-server-client-secret-post",
+  ];
+}

--- a/apps/docs/standards/conformance.md
+++ b/apps/docs/standards/conformance.md
@@ -81,7 +81,7 @@ The conformance suite's `/token` request follows OIDC Core verbatim — no `audi
 
 ## What's covered today
 
-The runner currently drives seven plans against AuthHero. Each module below maps 1-to-1 with an upstream conformance suite test (linked from the suite's web UI as `log-detail.html?log=…` on a run).
+The runner currently drives nine plans against AuthHero. Each module below maps 1-to-1 with an upstream conformance suite test (linked from the suite's web UI as `log-detail.html?log=…` on a run).
 
 ::: tip
 The status column is the on-the-record outcome from the most recent green CI run. The lists are kept in sync with the spec files themselves — entries removed from a plan's `getStaticModulesForPlan()` should also disappear here, and new entries should land with a one-liner.
@@ -226,6 +226,10 @@ Newly wired up — the spec file is at [oidcc-dynamic.spec.ts](https://github.co
 ### `oidcc-hybrid-certification-test-plan`
 
 Newly wired up — the spec file is at [oidcc-hybrid.spec.ts](https://github.com/markusahlstrand/authhero/blob/main/apps/conformance-runner/tests/oidcc-hybrid.spec.ts). Variant: `{ server_metadata: "discovery", client_registration: "static_client" }` (the hybrid plan pins `response_type` per-module: `code id_token`, `code token`, `code id_token token`). The OP returns a code on every flow plus an `id_token` and/or `access_token` in the redirect fragment; the code is exchanged at `/oauth/token` afterwards. The id_token issued from `/authorize` carries `c_hash` (always) and `at_hash` (when an access_token is co-issued), per OIDC Core 3.3.2.11. The plan passes in CI; modules absent from the live plan are filtered via `test.skip`.
+
+### `oidcc-formpost-hybrid-certification-test-plan`
+
+Newly wired up — the spec file is at [oidcc-form-post-hybrid.spec.ts](https://github.com/markusahlstrand/authhero/blob/main/apps/conformance-runner/tests/oidcc-form-post-hybrid.spec.ts). Variant: `{ server_metadata: "discovery", client_registration: "static_client" }` (the `formpost` profile is encoded in the plan name itself, not the variant; same module-level pinning of `response_type` as the plain Hybrid plan). Module set mirrors the Hybrid plan, but every authorization response — code plus `id_token` and/or `access_token` — is delivered via `response_mode=form_post` instead of the fragment. This completes the response-mode matrix: all three flows (basic, implicit, hybrid) are now tested in both their default response mode and form_post. Modules absent from the live plan are filtered via `test.skip`; status TBD until first green run.
 
 ### Out of scope (for now)
 


### PR DESCRIPTION
## Summary

Adds the ninth OP certification plan to the conformance runner: `oidcc-formpost-hybrid-certification-test-plan`.

- New spec file `apps/conformance-runner/tests/oidcc-form-post-hybrid.spec.ts` following the established per-plan pattern
- Plan name/variant/config builder added to `lib/test-plan-config.ts` — same variant shape as the other form-post plans (`server_metadata: discovery`, `client_registration: static_client`; `response_type` is pinned per-module by the suite, `response_mode=form_post` is encoded in the plan name)
- Module superset mirrors the hybrid plan, since the only differentiator is the response mode; modules absent from the live plan are filtered via `test.skip`
- README + docs updated (plan count was stale in the docs — said seven, now nine)

This completes the response-mode matrix: basic, implicit, and hybrid flows are now each tested in both their default response mode and `form_post`.

No changeset — only the conformance runner app and docs are touched, no versioned packages.

## Verification

Local run was blocked (port 3000 held by an unrelated dev server), so verified via `workflow_dispatch` of the conformance workflow on this branch with `--grep "Form Post Hybrid"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)