### PR TITLE
refactor(authhero): migrate base64url call sites off oslo (#1099, step 1)

### DIFF
--- a/.changeset/oslo-base64url-migration.md
+++ b/.changeset/oslo-base64url-migration.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Replace oslo's base64url with the canonical encodeBase64Url/decodeBase64Url helpers from @authhero/adapter-interfaces (first step of the oslo removal, #1099). Encrypted field payloads are now written without base64 padding; existing padded values keep decrypting via the lenient decoder.

--- a/packages/authhero/src/helpers/client-assertion.ts
+++ b/packages/authhero/src/helpers/client-assertion.ts
@@ -1,5 +1,4 @@
-import { base64url } from "oslo/encoding";
-import { Jwk } from "@authhero/adapter-interfaces";
+import { Jwk, decodeBase64Url } from "@authhero/adapter-interfaces";
 import { importParamsForJwk, SupportedAlg } from "../utils/jwk-alg";
 import {
   loadClientJwks,
@@ -86,7 +85,7 @@ export interface VerifiedClientAssertion {
 
 function decodeJoseSegment<T = unknown>(segment: string): T {
   const decoded = new TextDecoder().decode(
-    base64url.decode(segment, { strict: false }),
+    decodeBase64Url(segment),
   );
   const parsed = JSON.parse(decoded);
   if (typeof parsed !== "object" || parsed === null) {
@@ -157,7 +156,7 @@ export async function verifyClientAssertion(
     new TextEncoder().encode(`${headerSeg}.${payloadSeg}`),
   );
   const signature = new Uint8Array(
-    base64url.decode(signatureSeg, { strict: false }),
+    decodeBase64Url(signatureSeg),
   );
 
   let method: ClientAssertionMethod;

--- a/packages/authhero/src/helpers/dcr/mint-token.ts
+++ b/packages/authhero/src/helpers/dcr/mint-token.ts
@@ -1,5 +1,6 @@
 import { sha256 } from "oslo/crypto";
-import { base64url, encodeHex } from "oslo/encoding";
+import { encodeHex } from "oslo/encoding";
+import { encodeBase64Url } from "@authhero/adapter-interfaces";
 import { nanoid } from "nanoid";
 
 export interface GeneratedRegistrationToken {
@@ -20,7 +21,7 @@ export async function hashRegistrationToken(token: string): Promise<string> {
 }
 
 export async function mintRegistrationToken(): Promise<GeneratedRegistrationToken> {
-  const token = base64url.encode(randomBytes(32), { includePadding: false });
+  const token = encodeBase64Url(randomBytes(32));
   const token_hash = await hashRegistrationToken(token);
   return {
     id: nanoid(),

--- a/packages/authhero/src/helpers/request-object.ts
+++ b/packages/authhero/src/helpers/request-object.ts
@@ -1,5 +1,4 @@
-import { base64url } from "oslo/encoding";
-import { Jwk } from "@authhero/adapter-interfaces";
+import { Jwk, decodeBase64Url } from "@authhero/adapter-interfaces";
 import { importParamsForJwk, SupportedAlg } from "../utils/jwk-alg";
 import {
   loadClientJwks,
@@ -77,7 +76,7 @@ interface JoseHeader {
 
 function decodeJoseSegment<T = unknown>(segment: string): T {
   const decoded = new TextDecoder().decode(
-    base64url.decode(segment, { strict: false }),
+    decodeBase64Url(segment),
   );
   const parsed = JSON.parse(decoded);
   if (typeof parsed !== "object" || parsed === null) {
@@ -153,7 +152,7 @@ export async function verifyRequestObject(
     new TextEncoder().encode(`${headerSeg}.${payloadSeg}`),
   );
   const signature = new Uint8Array(
-    base64url.decode(signatureSeg, { strict: false }),
+    decodeBase64Url(signatureSeg),
   );
 
   if (SUPPORTED_SYMMETRIC_ALGS.has(header.alg)) {

--- a/packages/authhero/src/routes/auth-api/token.ts
+++ b/packages/authhero/src/routes/auth-api/token.ts
@@ -3,6 +3,7 @@ import {
   LogType,
   LogTypes,
   tokenResponseSchema,
+  decodeBase64Url,
 } from "@authhero/adapter-interfaces";
 import { logMessage } from "../../helpers/logging";
 import { Bindings, Variables } from "../../types";
@@ -46,8 +47,6 @@ import { prefetchClientBundle } from "../../helpers/prefetch-client-bundle";
 import { isCimdClientId } from "../../helpers/cimd";
 import { getAuthUrl, getIssuer } from "../../variables";
 import { resolveConnectionName } from "../../helpers/connection";
-import { base64url } from "oslo/encoding";
-
 import { defineRoute } from "../../utils/define-route";
 const optionalClientCredentials = z.object({
   client_id: z.string().optional(),
@@ -61,7 +60,7 @@ function peekAssertionClientId(jwt: string): string | undefined {
   if (parts.length !== 3 || !parts[1]) return undefined;
   try {
     const payload = JSON.parse(
-      new TextDecoder().decode(base64url.decode(parts[1], { strict: false })),
+      new TextDecoder().decode(decodeBase64Url(parts[1])),
     );
     if (payload && typeof payload === "object") {
       const iss = (payload as Record<string, unknown>).iss;

--- a/packages/authhero/src/utils/crypto.ts
+++ b/packages/authhero/src/utils/crypto.ts
@@ -1,5 +1,5 @@
 import { sha256 } from "oslo/crypto";
-import { base64url } from "oslo/encoding";
+import { encodeBase64Url } from "@authhero/adapter-interfaces";
 
 export function pemToBuffer(pem: string): ArrayBuffer {
   try {
@@ -33,7 +33,5 @@ export async function computeCodeChallenge(
   const hashedVerifier = await sha256(encodedData);
 
   // Convert to base64url without padding
-  return base64url.encode(new Uint8Array(hashedVerifier), {
-    includePadding: false,
-  });
+  return encodeBase64Url(new Uint8Array(hashedVerifier));
 }

--- a/packages/authhero/src/utils/encryption.ts
+++ b/packages/authhero/src/utils/encryption.ts
@@ -1,9 +1,9 @@
 import { nanoid } from "nanoid";
 import * as x509 from "@peculiar/x509";
-import { encodeHex, base64, base64url } from "oslo/encoding";
+import { encodeHex, base64 } from "oslo/encoding";
 import { sha256 } from "oslo/crypto";
 import { getRuntimeKey } from "hono/adapter";
-import { SigningKey } from "@authhero/adapter-interfaces";
+import { SigningKey, encodeBase64Url } from "@authhero/adapter-interfaces";
 
 const RFC7638_REQUIRED_MEMBERS: Record<string, string[]> = {
   RSA: ["e", "kty", "n"],
@@ -191,5 +191,5 @@ export async function computeJWKThumbprint(jwk: JsonWebKey): Promise<string> {
 
   const json = JSON.stringify(canonical);
   const digest = await sha256(new TextEncoder().encode(json));
-  return base64url.encode(new Uint8Array(digest), { includePadding: false });
+  return encodeBase64Url(new Uint8Array(digest));
 }

--- a/packages/authhero/src/utils/field-encryption.ts
+++ b/packages/authhero/src/utils/field-encryption.ts
@@ -1,4 +1,8 @@
-import { base64, base64url } from "oslo/encoding";
+import { base64 } from "oslo/encoding";
+import {
+  encodeBase64Url,
+  decodeBase64Url,
+} from "@authhero/adapter-interfaces";
 
 // Version-tagged prefix for encrypted field values. Stored values that do not
 // start with this prefix are treated as legacy plaintext and returned as-is,
@@ -97,7 +101,7 @@ async function encryptWithKey(
   combined.set(iv, 0);
   combined.set(new Uint8Array(ciphertext), iv.byteLength);
 
-  const payload = base64url.encode(combined);
+  const payload = encodeBase64Url(combined);
   return keyId ? `${PREFIX}${keyId}:${payload}` : `${PREFIX}${payload}`;
 }
 
@@ -109,7 +113,9 @@ async function decryptWithKey(
   const colon = remainder.indexOf(":");
   const payload = colon === -1 ? remainder : remainder.slice(colon + 1);
 
-  const combined = base64url.decode(payload);
+  // Values stored before 2026-07 carry base64 padding ("="); the decoder must
+  // stay lenient so both padded and unpadded payloads keep decrypting.
+  const combined = decodeBase64Url(payload);
   const iv = combined.slice(0, IV_BYTES);
   const ciphertext = combined.slice(IV_BYTES);
 

--- a/packages/authhero/src/utils/id-token-hash.ts
+++ b/packages/authhero/src/utils/id-token-hash.ts
@@ -1,4 +1,4 @@
-import { base64url } from "oslo/encoding";
+import { encodeBase64Url } from "@authhero/adapter-interfaces";
 
 // OIDC Core 3.3.2.11 / 3.1.3.6: c_hash and at_hash are computed by hashing the
 // ASCII representation of the code or access_token with the hash function
@@ -31,5 +31,5 @@ export async function computeIdTokenHash(
   const hashBuffer = await crypto.subtle.digest(digest, encoded);
   const full = new Uint8Array(hashBuffer);
   const half = full.slice(0, full.length / 2);
-  return base64url.encode(half, { includePadding: false });
+  return encodeBase64Url(half);
 }

--- a/packages/authhero/src/utils/refresh-token-format.ts
+++ b/packages/authhero/src/utils/refresh-token-format.ts
@@ -1,5 +1,6 @@
 import { sha256 } from "oslo/crypto";
-import { base64url, encodeHex } from "oslo/encoding";
+import { encodeHex } from "oslo/encoding";
+import { encodeBase64Url } from "@authhero/adapter-interfaces";
 
 export const REFRESH_TOKEN_PREFIX = "rt_";
 export const LOOKUP_BYTES = 7;
@@ -29,12 +30,8 @@ export function generateRefreshTokenParts(): {
   secret: string;
 } {
   return {
-    lookup: base64url.encode(randomBytes(LOOKUP_BYTES), {
-      includePadding: false,
-    }),
-    secret: base64url.encode(randomBytes(SECRET_BYTES), {
-      includePadding: false,
-    }),
+    lookup: encodeBase64Url(randomBytes(LOOKUP_BYTES)),
+    secret: encodeBase64Url(randomBytes(SECRET_BYTES)),
   };
 }
 

--- a/packages/authhero/test/helpers/client-assertion.spec.ts
+++ b/packages/authhero/test/helpers/client-assertion.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createJWT } from "oslo/jwt";
 import { TimeSpan } from "oslo";
-import { base64url } from "oslo/encoding";
+import { encodeBase64Url } from "@authhero/adapter-interfaces";
 import {
   verifyClientAssertion,
   ClientAssertionError,
@@ -111,18 +111,16 @@ describe("verifyClientAssertion (RFC 7523)", () => {
   });
 
   it("rejects alg=none", async () => {
-    const header = base64url.encode(
+    const header = encodeBase64Url(
       new TextEncoder().encode(JSON.stringify({ alg: "none", typ: "JWT" })),
-      { includePadding: false },
     );
-    const payload = base64url.encode(
+    const payload = encodeBase64Url(
       new TextEncoder().encode(
         JSON.stringify({
           ...standardClaims(),
           exp: Math.floor(Date.now() / 1000) + 300,
         }),
       ),
-      { includePadding: false },
     );
     await expect(
       verifyClientAssertion(

--- a/packages/authhero/test/helpers/request-object.spec.ts
+++ b/packages/authhero/test/helpers/request-object.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createJWT } from "oslo/jwt";
 import { TimeSpan } from "oslo";
-import { base64url } from "oslo/encoding";
+import { encodeBase64Url } from "@authhero/adapter-interfaces";
 import {
   verifyRequestObject,
   RequestObjectVerificationError,
@@ -122,11 +122,10 @@ describe("verifyRequestObject", () => {
   });
 
   it("rejects alg=none even when payload looks well-formed", async () => {
-    const header = base64url.encode(
+    const header = encodeBase64Url(
       new TextEncoder().encode(JSON.stringify({ alg: "none", typ: "JWT" })),
-      { includePadding: false },
     );
-    const payload = base64url.encode(
+    const payload = encodeBase64Url(
       new TextEncoder().encode(
         JSON.stringify({
           iss: CLIENT_ID,
@@ -135,7 +134,6 @@ describe("verifyRequestObject", () => {
           exp: Math.floor(Date.now() / 1000) + 300,
         }),
       ),
-      { includePadding: false },
     );
     const jwt = `${header}.${payload}.`;
 
@@ -295,13 +293,12 @@ describe("verifyRequestObject", () => {
   it("rejects request objects that omit the exp claim", async () => {
     const { privateBuffer, publicJwk } = await generateRsaKeypair();
     // createJWT requires expiresIn, so build the JWT manually without exp.
-    const header = base64url.encode(
+    const header = encodeBase64Url(
       new TextEncoder().encode(
         JSON.stringify({ alg: "RS256", typ: "JWT", kid: publicJwk.kid }),
       ),
-      { includePadding: false },
     );
-    const body = base64url.encode(
+    const body = encodeBase64Url(
       new TextEncoder().encode(
         JSON.stringify({
           iss: CLIENT_ID,
@@ -310,7 +307,6 @@ describe("verifyRequestObject", () => {
           iat: Math.floor(Date.now() / 1000),
         }),
       ),
-      { includePadding: false },
     );
     const signingInput = new TextEncoder().encode(`${header}.${body}`);
     const cryptoKey = await crypto.subtle.importKey(
@@ -323,7 +319,7 @@ describe("verifyRequestObject", () => {
     const sig = new Uint8Array(
       await crypto.subtle.sign("RSASSA-PKCS1-v1_5", cryptoKey, signingInput),
     );
-    const jwt = `${header}.${body}.${base64url.encode(sig, { includePadding: false })}`;
+    const jwt = `${header}.${body}.${encodeBase64Url(sig)}`;
 
     await expect(
       verifyRequestObject(jwt, clientWithJwks(publicJwk), {

--- a/packages/authhero/test/routes/auth-api/private-key-jwt.spec.ts
+++ b/packages/authhero/test/routes/auth-api/private-key-jwt.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { testClient } from "hono/testing";
 import { createJWT, parseJWT } from "oslo/jwt";
 import { TimeSpan } from "oslo";
-import { base64url } from "oslo/encoding";
+import { encodeBase64Url } from "@authhero/adapter-interfaces";
 import { getTestServer } from "../../helpers/test-server";
 
 const TOKEN_ENDPOINT = "http://localhost:3000/oauth/token";
@@ -188,11 +188,10 @@ describe("/oauth/token with RFC 7523 client_assertion", () => {
     const { publicJwk } = await generateRsaKeypair();
     await attachClientJwks(env, publicJwk);
 
-    const header = base64url.encode(
+    const header = encodeBase64Url(
       new TextEncoder().encode(JSON.stringify({ alg: "none", typ: "JWT" })),
-      { includePadding: false },
     );
-    const payload = base64url.encode(
+    const payload = encodeBase64Url(
       new TextEncoder().encode(
         JSON.stringify({
           iss: "clientId",
@@ -201,7 +200,6 @@ describe("/oauth/token with RFC 7523 client_assertion", () => {
           exp: Math.floor(Date.now() / 1000) + 300,
         }),
       ),
-      { includePadding: false },
     );
     const unsignedAssertion = `${header}.${payload}.`;
 

--- a/packages/authhero/test/routes/auth-api/request-object.spec.ts
+++ b/packages/authhero/test/routes/auth-api/request-object.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { testClient } from "hono/testing";
 import { createJWT } from "oslo/jwt";
 import { TimeSpan } from "oslo";
-import { base64url } from "oslo/encoding";
+import { encodeBase64Url } from "@authhero/adapter-interfaces";
 import { getTestServer } from "../../helpers/test-server";
 
 const ISSUER = "http://localhost:3000/";
@@ -86,11 +86,10 @@ describe("/authorize request= and request_uri (RFC 9101 / OIDC Core 6.1, 6.2)", 
     const { publicJwk } = await generateRsaKeypairWithJwks();
     await attachClientJwks(env, publicJwk);
 
-    const header = base64url.encode(
+    const header = encodeBase64Url(
       new TextEncoder().encode(JSON.stringify({ alg: "none", typ: "JWT" })),
-      { includePadding: false },
     );
-    const payload = base64url.encode(
+    const payload = encodeBase64Url(
       new TextEncoder().encode(
         JSON.stringify({
           iss: "clientId",
@@ -101,7 +100,6 @@ describe("/authorize request= and request_uri (RFC 9101 / OIDC Core 6.1, 6.2)", 
           exp: Math.floor(Date.now() / 1000) + 300,
         }),
       ),
-      { includePadding: false },
     );
     const unsignedJwt = `${header}.${payload}.`;
 

--- a/packages/authhero/test/routes/proxy-control-plane/jwt-fixture.ts
+++ b/packages/authhero/test/routes/proxy-control-plane/jwt-fixture.ts
@@ -1,17 +1,20 @@
+import {
+  encodeBase64Url,
+  encodeBase64UrlString,
+} from "@authhero/adapter-interfaces";
+
 type JWK = JsonWebKey;
 
 const encoder = new TextEncoder();
 
 function base64UrlEncode(bytes: Uint8Array | ArrayBuffer): string {
-  const arr =
-    bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes as ArrayBuffer);
-  let bin = "";
-  for (const b of arr) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return encodeBase64Url(
+    bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes),
+  );
 }
 
 function base64UrlEncodeJson(obj: unknown): string {
-  return base64UrlEncode(encoder.encode(JSON.stringify(obj)));
+  return encodeBase64UrlString(JSON.stringify(obj));
 }
 
 const ALG_HASH: Record<string, string> = {


### PR DESCRIPTION
## Summary

First slice of #1099: every `oslo/encoding` `base64url` import in `packages/authhero` (src + tests) now uses the canonical `encodeBase64Url`/`decodeBase64Url` helpers from `@authhero/adapter-interfaces`. Replaces the abandoned approach in #520.

- 9 src files swapped: `crypto.ts`, `encryption.ts`, `field-encryption.ts`, `id-token-hash.ts`, `refresh-token-format.ts`, `client-assertion.ts`, `request-object.ts`, `dcr/mint-token.ts`, `routes/auth-api/token.ts`
- 4 test files swapped: `client-assertion.spec.ts`, `request-object.spec.ts`, `private-key-jwt.spec.ts`, `routes/auth-api/request-object.spec.ts`
- Hand-rolled duplicate in `test/routes/proxy-control-plane/jwt-fixture.ts` folded into the shared helpers

## Equivalence notes

Every call site except `field-encryption.ts` already passed `{ includePadding: false }` / `{ strict: false }`, so the swap is byte-for-byte identical there.

`field-encryption.ts` used oslo's defaults (padded encode, strict decode). New encrypted payloads are written **unpadded**; the lenient decoder accepts both padded (pre-existing stored values) and unpadded input, so previously stored ciphertext keeps decrypting. A comment in the decoder records that it must stay lenient.

Malformed-JWT decode paths (`strict: false` before) now throw on truncated input instead of decoding garbage — all wrapped in existing try/catch / verification-error handling.

## Out of scope (tracked in #1099)

`oslo` `base64`/`base32`/`encodeHex`/`TimeSpan`/`jwt`/`oauth2`/`otp` surfaces; removing the dependency itself.

## Testing

- `pnpm --filter @authhero/adapter-interfaces build && pnpm --filter authhero build`
- `pnpm authhero test`: 214 files passed, 1779 tests passed (1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)