### PR TITLE
feat: GET /roles/{id}/users with checkpoint pagination

### DIFF
--- a/.changeset/role-users-endpoint.md
+++ b/.changeset/role-users-endpoint.md
@@ -1,0 +1,13 @@
+---
+"@authhero/adapter-interfaces": minor
+"@authhero/kysely-adapter": minor
+"@authhero/drizzle": minor
+"@authhero/aws-adapter": minor
+"authhero": minor
+---
+
+Add `GET /roles/{id}/users` to the management API with Auth0-style checkpoint pagination
+
+The endpoint returns the distinct users assigned to a role (per-organization assignments collapsed), as user summaries (`user_id`, `email`, `name`, `picture`). It supports the bare array, `include_totals` and checkpoint (`from`/`take` + opaque `next` cursor) response shapes, matching Auth0 — which requires checkpoint pagination on this endpoint past 1000 results.
+
+`UserRolesAdapter` gains a `listUsers(tenantId, roleId, params)` method, implemented with keyset pagination in the kysely and drizzle adapters. The aws/DynamoDB adapter throws an explicit not-implemented error (its key layout has no index by role), mirroring the actions adapters.

--- a/.changeset/role-users-endpoint.md
+++ b/.changeset/role-users-endpoint.md
@@ -1,5 +1,5 @@
 ---
-"@authhero/adapter-interfaces": minor
+"@authhero/adapter-interfaces": major
 "@authhero/kysely-adapter": minor
 "@authhero/drizzle": minor
 "@authhero/aws-adapter": minor
@@ -10,4 +10,4 @@ Add `GET /roles/{id}/users` to the management API with Auth0-style checkpoint pa
 
 The endpoint returns the distinct users assigned to a role (per-organization assignments collapsed), as user summaries (`user_id`, `email`, `name`, `picture`). It supports the bare array, `include_totals` and checkpoint (`from`/`take` + opaque `next` cursor) response shapes, matching Auth0 — which requires checkpoint pagination on this endpoint past 1000 results.
 
-`UserRolesAdapter` gains a `listUsers(tenantId, roleId, params)` method, implemented with keyset pagination in the kysely and drizzle adapters. The aws/DynamoDB adapter throws an explicit not-implemented error (its key layout has no index by role), mirroring the actions adapters.
+Breaking (adapter-interfaces): `UserRolesAdapter` gains a required `listUsers(tenantId, roleId, params)` method, so custom adapter implementations must add it. It is implemented with keyset pagination in the kysely and drizzle adapters. The aws/DynamoDB adapter throws an explicit not-implemented error (its key layout has no index by role), mirroring the actions adapters.

--- a/packages/adapter-interfaces/src/adapters/UserRoles.ts
+++ b/packages/adapter-interfaces/src/adapters/UserRoles.ts
@@ -9,6 +9,20 @@ export interface ListUserRolesResponse {
   length: number;
 }
 
+export interface ListRoleUsersResponse {
+  /** Distinct user ids holding the role, ordered by user_id ascending. */
+  userIds: string[];
+  start: number;
+  limit: number;
+  /**
+   * Offset mode: total number of distinct users holding the role.
+   * Checkpoint mode: number of ids in this page (no total is computed).
+   */
+  length: number;
+  /** Opaque checkpoint cursor for the next page; absent on the last page. */
+  next?: string;
+}
+
 export interface UserRolesAdapter {
   list(
     tenantId: string,
@@ -16,6 +30,16 @@ export interface UserRolesAdapter {
     params?: ListParams,
     organizationId?: string,
   ): Promise<Role[]>; // return a flat list of roles
+  /**
+   * List the distinct users assigned to a role, across all organization
+   * scopes (a user holding the role in several organizations appears once).
+   * Supports offset (page/per_page) and checkpoint (from/take) pagination.
+   */
+  listUsers(
+    tenantId: string,
+    roleId: string,
+    params?: ListParams,
+  ): Promise<ListRoleUsersResponse>;
   create(
     tenantId: string,
     userId: string,

--- a/packages/authhero/src/routes/management-api/roles.ts
+++ b/packages/authhero/src/routes/management-api/roles.ts
@@ -12,6 +12,8 @@ import {
   LogTypes,
 } from "@authhero/adapter-interfaces";
 import { logMessage } from "../../helpers/logging";
+import { getIssuer } from "../../variables";
+import { getDefaultUserPicture } from "../../helpers/avatar";
 
 import { defineRoute } from "../../utils/define-route";
 const rolesWithTotalsSchema = totalsSchema.extend({
@@ -20,6 +22,26 @@ const rolesWithTotalsSchema = totalsSchema.extend({
 
 const rolePermissionsWithTotalsSchema = totalsSchema.extend({
   permissions: z.array(rolePermissionSchema),
+});
+
+// Auth0's GET /roles/{id}/users returns user summaries, not full profiles.
+const roleUserSchema = z.object({
+  user_id: z.string(),
+  email: z.string().optional(),
+  name: z.string().optional(),
+  picture: z.string().optional(),
+});
+
+const roleUsersWithTotalsSchema = totalsSchema.extend({
+  users: z.array(roleUserSchema),
+});
+
+const roleUsersWithNextSchema = z.object({
+  next: z.string().optional().openapi({
+    description:
+      "Checkpoint cursor to be used to retrieve the next set of results",
+  }),
+  users: z.array(roleUserSchema),
 });
 const getRoot = defineRoute({
   route: createRoute({
@@ -385,6 +407,110 @@ const getByIdPermissions = defineRoute({
   },
 });
 
+const getByIdUsers = defineRoute({
+  route: createRoute({
+    tags: ["roles"],
+    method: "get",
+    path: "/{id}/users",
+    request: {
+      params: z.object({
+        id: z.string(),
+      }),
+      headers: z.object({
+        "tenant-id": z.string().optional(),
+      }),
+      query: querySchema,
+    },
+    security: [
+      {
+        Bearer: ["read:roles"],
+      },
+    ],
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: z.union([
+              z.array(roleUserSchema),
+              roleUsersWithTotalsSchema,
+              roleUsersWithNextSchema,
+            ]),
+          },
+        },
+        description: "Users assigned to the role",
+      },
+    },
+  }),
+  handler: async (ctx) => {
+    const { id } = ctx.req.valid("param");
+    const { page, per_page, include_totals, from, take } =
+      ctx.req.valid("query");
+
+    const tenantId = ctx.var.tenant_id;
+    if (!tenantId) {
+      throw new HTTPException(400, {
+        message: "tenant-id header is required",
+      });
+    }
+
+    const role = await ctx.env.data.roles.get(tenantId, id);
+    if (!role) {
+      throw new HTTPException(404, {
+        message: "Role not found",
+      });
+    }
+
+    // Pass through checkpoint pagination (from/take) as well as
+    // page/per_page so clients using either style — e.g. the Auth0 SDK,
+    // which sends from/take past 1000 results — page correctly.
+    const result = await ctx.env.data.userRoles.listUsers(tenantId, id, {
+      page,
+      per_page,
+      include_totals,
+      from,
+      take,
+    });
+
+    const users = await Promise.all(
+      result.userIds.map(async (userId) => {
+        const user = await ctx.env.data.users.get(tenantId, userId);
+        if (!user) return null;
+        return {
+          user_id: user.user_id,
+          email: user.email || undefined,
+          name: user.name || undefined,
+          picture:
+            user.picture ||
+            getDefaultUserPicture(
+              getIssuer(ctx.env, ctx.var.custom_domain),
+              user,
+            ),
+        };
+      }),
+    ).then((rows) =>
+      rows.filter((r): r is NonNullable<typeof r> => r !== null),
+    );
+
+    // Keyset (checkpoint) pagination: return Auth0's { users, next } shape so
+    // clients can page past the first page via the opaque cursor.
+    if (from !== undefined || take !== undefined) {
+      return ctx.json({ users, next: result.next });
+    }
+
+    if (include_totals) {
+      return ctx.json({
+        users,
+        start: result.start,
+        limit: result.limit,
+        length: users.length,
+        total: result.length,
+      });
+    }
+
+    return ctx.json(users);
+  },
+});
+
 const postByIdPermissions = defineRoute({
   route: createRoute({
     tags: ["roles"],
@@ -563,6 +689,7 @@ export const roleRoutes = new OpenAPIHono<{
   patchById,
   deleteById,
   getByIdPermissions,
+  getByIdUsers,
   postByIdPermissions,
   deleteByIdPermissions,
 ] as const);

--- a/packages/authhero/src/routes/management-api/roles.ts
+++ b/packages/authhero/src/routes/management-api/roles.ts
@@ -43,6 +43,15 @@ const roleUsersWithNextSchema = z.object({
   }),
   users: z.array(roleUserSchema),
 });
+
+// Auth0 caps per_page/take at 100 on this endpoint; the cap also bounds the
+// hydration fan-out below (one users.get() per returned user).
+const roleUsersQuerySchema = querySchema.extend({
+  per_page: querySchema.shape.per_page.pipe(z.number().int().min(0).max(100)),
+  take: querySchema.shape.take.pipe(
+    z.number().int().min(1).max(100).optional(),
+  ),
+});
 const getRoot = defineRoute({
   route: createRoute({
     tags: ["roles"],
@@ -419,7 +428,7 @@ const getByIdUsers = defineRoute({
       headers: z.object({
         "tenant-id": z.string().optional(),
       }),
-      query: querySchema,
+      query: roleUsersQuerySchema,
     },
     security: [
       {

--- a/packages/authhero/src/routes/management-api/roles.ts
+++ b/packages/authhero/src/routes/management-api/roles.ts
@@ -45,13 +45,25 @@ const roleUsersWithNextSchema = z.object({
 });
 
 // Auth0 caps per_page/take at 100 on this endpoint; the cap also bounds the
-// hydration fan-out below (one users.get() per returned user).
-const roleUsersQuerySchema = querySchema.extend({
-  per_page: querySchema.shape.per_page.pipe(z.number().int().min(0).max(100)),
-  take: querySchema.shape.take.pipe(
-    z.number().int().min(1).max(100).optional(),
-  ),
-});
+// hydration fan-out below (one users.get() per returned user). Only the
+// parameters the handler consumes are accepted — Auth0 supports neither
+// sort nor q here.
+const roleUsersQuerySchema = querySchema
+  .pick({
+    page: true,
+    per_page: true,
+    include_totals: true,
+    from: true,
+    take: true,
+  })
+  .extend({
+    per_page: querySchema.shape.per_page.pipe(
+      z.number().int().min(0).max(100),
+    ),
+    take: querySchema.shape.take.pipe(
+      z.number().int().min(1).max(100).optional(),
+    ),
+  });
 const getRoot = defineRoute({
   route: createRoute({
     tags: ["roles"],

--- a/packages/authhero/test/routes/management-api/roles.spec.ts
+++ b/packages/authhero/test/routes/management-api/roles.spec.ts
@@ -578,3 +578,114 @@ describe("roles", () => {
     expect(removePermissionsResponse.status).toBe(404);
   });
 });
+
+describe("GET /api/v2/roles/:id/users", () => {
+  async function seedRoleWithUsers(env: any, count: number) {
+    const role = await env.data.roles.create("tenantId", {
+      name: `users-role-${count}`,
+      description: "Role with users",
+    });
+    for (let i = 0; i < count; i++) {
+      const userId = `email|role-user-${i.toString().padStart(2, "0")}`;
+      await env.data.users.create("tenantId", {
+        email: `role-user-${i}@example.com`,
+        user_id: userId,
+        provider: "email",
+        connection: "email",
+        email_verified: true,
+        is_social: false,
+      });
+      await env.data.userRoles.create("tenantId", userId, role.id);
+    }
+    return role;
+  }
+
+  it("returns 404 when the role does not exist", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const response = await managementClient.roles[":id"].users.$get(
+      {
+        param: { id: "non-existent-role" },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("returns a bare array of user summaries by default and totals with include_totals", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const role = await seedRoleWithUsers(env, 3);
+
+    const response = await managementClient.roles[":id"].users.$get(
+      {
+        param: { id: role.id },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(response.status).toBe(200);
+    const users = (await response.json()) as any[];
+    expect(users).toHaveLength(3);
+    expect(users[0].user_id).toBe("email|role-user-00");
+    expect(users[0].email).toBe("role-user-0@example.com");
+    expect(users[0].picture).toBeDefined();
+
+    const totalsResponse = await managementClient.roles[":id"].users.$get(
+      {
+        param: { id: role.id },
+        query: { include_totals: "true", per_page: "2" },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(totalsResponse.status).toBe(200);
+    const body = (await totalsResponse.json()) as any;
+    expect(body.users).toHaveLength(2);
+    expect(body.total).toBe(3);
+    expect(body.start).toBe(0);
+    expect(body.limit).toBe(2);
+  });
+
+  it("walks all users across pages via the opaque next cursor", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const userCount = 12;
+    const role = await seedRoleWithUsers(env, userCount);
+
+    const seen = new Set<string>();
+    let from: string | undefined;
+    let pages = 0;
+    for (;;) {
+      const res = await managementClient.roles[":id"].users.$get(
+        {
+          param: { id: role.id },
+          query: from ? { take: "5", from } : { take: "5" },
+          header: { "tenant-id": "tenantId" },
+        },
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(res.status).toBe(200);
+      // Checkpoint pagination returns { users, next }, not a bare array.
+      const body = (await res.json()) as any;
+      for (const user of body.users) {
+        expect(seen.has(user.user_id)).toBe(false);
+        seen.add(user.user_id);
+      }
+      pages++;
+      if (!body.next) break;
+      from = body.next as string;
+      if (pages > 6) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.size).toBe(userCount);
+    expect(pages).toBe(3); // 5 + 5 + 2
+  });
+});

--- a/packages/authhero/test/routes/management-api/roles.spec.ts
+++ b/packages/authhero/test/routes/management-api/roles.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { testClient } from "hono/testing";
 import { getAdminToken } from "../../helpers/token";
 import { getTestServer } from "../../helpers/test-server";
+import type { Bindings } from "../../../src/types";
 import { env } from "hono/adapter";
 
 describe("roles", () => {
@@ -580,7 +581,14 @@ describe("roles", () => {
 });
 
 describe("GET /api/v2/roles/:id/users", () => {
-  async function seedRoleWithUsers(env: any, count: number) {
+  type RoleUserSummary = {
+    user_id: string;
+    email?: string;
+    name?: string;
+    picture?: string;
+  };
+
+  async function seedRoleWithUsers(env: Bindings, count: number) {
     const role = await env.data.roles.create("tenantId", {
       name: `users-role-${count}`,
       description: "Role with users",
@@ -630,7 +638,7 @@ describe("GET /api/v2/roles/:id/users", () => {
       { headers: { authorization: `Bearer ${token}` } },
     );
     expect(response.status).toBe(200);
-    const users = (await response.json()) as any[];
+    const users = (await response.json()) as RoleUserSummary[];
     expect(users).toHaveLength(3);
     expect(users[0].user_id).toBe("email|role-user-00");
     expect(users[0].email).toBe("role-user-0@example.com");
@@ -645,11 +653,44 @@ describe("GET /api/v2/roles/:id/users", () => {
       { headers: { authorization: `Bearer ${token}` } },
     );
     expect(totalsResponse.status).toBe(200);
-    const body = (await totalsResponse.json()) as any;
+    const body = (await totalsResponse.json()) as {
+      users: RoleUserSummary[];
+      total: number;
+      start: number;
+      limit: number;
+    };
     expect(body.users).toHaveLength(2);
     expect(body.total).toBe(3);
     expect(body.start).toBe(0);
     expect(body.limit).toBe(2);
+  });
+
+  it("rejects per_page and take above Auth0's cap of 100", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+
+    const role = await seedRoleWithUsers(env, 1);
+
+    const perPageResponse = await managementClient.roles[":id"].users.$get(
+      {
+        param: { id: role.id },
+        query: { per_page: "200" },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(perPageResponse.status).toBe(400);
+
+    const takeResponse = await managementClient.roles[":id"].users.$get(
+      {
+        param: { id: role.id },
+        query: { take: "500" },
+        header: { "tenant-id": "tenantId" },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(takeResponse.status).toBe(400);
   });
 
   it("walks all users across pages via the opaque next cursor", async () => {
@@ -674,14 +715,17 @@ describe("GET /api/v2/roles/:id/users", () => {
       );
       expect(res.status).toBe(200);
       // Checkpoint pagination returns { users, next }, not a bare array.
-      const body = (await res.json()) as any;
+      const body = (await res.json()) as {
+        users: RoleUserSummary[];
+        next?: string;
+      };
       for (const user of body.users) {
         expect(seen.has(user.user_id)).toBe(false);
         seen.add(user.user_id);
       }
       pages++;
       if (!body.next) break;
-      from = body.next as string;
+      from = body.next;
       if (pages > 6) throw new Error("cursor walk did not terminate");
     }
 

--- a/packages/aws/src/adapters/userRoles.ts
+++ b/packages/aws/src/adapters/userRoles.ts
@@ -74,6 +74,17 @@ export function createUserRolesAdapter(ctx: DynamoDBContext): UserRolesAdapter {
       );
     },
 
+    async listUsers() {
+      // User-role items are keyed by (tenant, user, organization); there is no
+      // index by role, so listing a role's users would require a full scan or
+      // a new GSI. Throw so the gap is obvious rather than silently returning
+      // empty results, mirroring the actions adapters.
+      throw new Error(
+        "userRoles.listUsers is not implemented in the AWS DynamoDB adapter. " +
+          "Use a SQL-backed adapter (kysely/drizzle) for tenants that need to list a role's users.",
+      );
+    },
+
     async list(
       tenantId: string,
       userId: string,

--- a/packages/drizzle/src/adapters/userRoles.ts
+++ b/packages/drizzle/src/adapters/userRoles.ts
@@ -1,6 +1,17 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, asc, sql } from "drizzle-orm";
+import type {
+  ListParams,
+  ListRoleUsersResponse,
+} from "@authhero/adapter-interfaces";
 import { userRoles, roles } from "../schema/sqlite";
 import { removeNullProperties, parseJsonIfString } from "../helpers/transform";
+import {
+  isKeysetRequest,
+  keysetTake,
+  keysetOrderBy,
+  keysetCondition,
+  sliceWithNext,
+} from "../helpers/paginate";
 import type { DrizzleDb } from "./types";
 
 export function createUserRolesAdapter(db: DrizzleDb) {
@@ -81,6 +92,79 @@ export function createUserRolesAdapter(db: DrizzleDb) {
       );
 
       return roleResults.filter(Boolean) as any[];
+    },
+
+    async listUsers(
+      tenant_id: string,
+      role_id: string,
+      params?: ListParams,
+    ): Promise<ListRoleUsersResponse> {
+      // A user can hold the same role under several organization scopes; the
+      // endpoint lists users, so collapse assignments to distinct user_ids.
+      // user_roles has no surrogate id, so the (unique-after-distinct)
+      // user_id doubles as both sort column and keyset tiebreaker.
+      const roleFilter = and(
+        eq(userRoles.tenant_id, tenant_id),
+        eq(userRoles.role_id, role_id),
+      );
+
+      if (isKeysetRequest(params)) {
+        const cols = {
+          sortColumn: userRoles.user_id,
+          idColumn: userRoles.user_id,
+          sortOrder: "asc" as const,
+        };
+        const keyset = keysetCondition(params, cols);
+        const take = keysetTake(params);
+        const rows = await db
+          .selectDistinct({ user_id: userRoles.user_id })
+          .from(userRoles)
+          .where(keyset ? and(roleFilter, keyset) : roleFilter)
+          .orderBy(...keysetOrderBy(cols))
+          .limit(take + 1)
+          .all();
+        const { rows: pageRows, next } = sliceWithNext(
+          rows,
+          take,
+          "user_id",
+          "user_id",
+        );
+        return {
+          userIds: pageRows.map((row) => row.user_id),
+          start: 0,
+          limit: take,
+          length: pageRows.length,
+          next,
+        };
+      }
+
+      const page = params?.page || 0;
+      const per_page = params?.per_page || 50;
+      const offset = page * per_page;
+
+      const rows = await db
+        .selectDistinct({ user_id: userRoles.user_id })
+        .from(userRoles)
+        .where(roleFilter)
+        .orderBy(asc(userRoles.user_id))
+        .limit(per_page)
+        .offset(offset)
+        .all();
+
+      const total = await db
+        .select({
+          count: sql<number>`count(distinct ${userRoles.user_id})`,
+        })
+        .from(userRoles)
+        .where(roleFilter)
+        .get();
+
+      return {
+        userIds: rows.map((row) => row.user_id),
+        start: offset,
+        limit: per_page,
+        length: Number(total?.count ?? 0),
+      };
     },
 
     async remove(

--- a/packages/drizzle/test/adapters/role-users-keyset.test.ts
+++ b/packages/drizzle/test/adapters/role-users-keyset.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+
+// Role users collapse per-organization assignments to distinct user_ids and
+// keyset on user_id itself (user_roles has no surrogate id, and user_id is
+// unique once assignments are collapsed).
+describe("role users keyset pagination (from/take)", () => {
+  let data: ReturnType<typeof getTestServer>["data"];
+  const tenantId = "t1";
+  let roleId: string;
+
+  beforeEach(async () => {
+    const server = getTestServer();
+    data = server.data;
+
+    await data.tenants.create({ id: tenantId, name: "Tenant 1" });
+
+    const role = await data.roles.create(tenantId, {
+      name: "keyset-role",
+      description: "Keyset role",
+    });
+    roleId = role.id;
+
+    for (let i = 0; i < 25; i++) {
+      await data.userRoles.create(
+        tenantId,
+        `user-${i.toString().padStart(2, "0")}`,
+        roleId,
+      );
+    }
+    // The same user holding the role under organization scopes must still
+    // appear exactly once in the listing.
+    await data.userRoles.create(tenantId, "user-00", roleId, "org-a");
+    await data.userRoles.create(tenantId, "user-00", roleId, "org-b");
+  });
+
+  it("walks every distinct user exactly once across pages via next", async () => {
+    const seen = new Set<string>();
+    let from: string | undefined;
+    let pages = 0;
+
+    for (;;) {
+      const res = await data.userRoles.listUsers(tenantId, roleId, {
+        take: 10,
+        from,
+      });
+      pages++;
+      for (const userId of res.userIds) {
+        expect(seen.has(userId)).toBe(false); // no duplicates across pages
+        seen.add(userId);
+      }
+      if (!res.next) break;
+      from = res.next;
+      if (pages > 10) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.size).toBe(25);
+    expect(pages).toBe(3); // 10 + 10 + 5
+  });
+
+  it("omits next on the final page", async () => {
+    const res = await data.userRoles.listUsers(tenantId, roleId, {
+      take: 50,
+    });
+    expect(res.userIds).toHaveLength(25);
+    expect(res.next).toBeUndefined();
+  });
+
+  it("counts distinct users in offset mode", async () => {
+    const res = await data.userRoles.listUsers(tenantId, roleId, {
+      page: 0,
+      per_page: 10,
+    });
+    expect(res.userIds).toHaveLength(10);
+    expect(res.length).toBe(25); // org-scoped duplicates collapsed
+  });
+});

--- a/packages/kysely/src/user-roles/adapter.ts
+++ b/packages/kysely/src/user-roles/adapter.ts
@@ -8,6 +8,8 @@ export function createUserRolesAdapter(db: Kysely<Database>): UserRolesAdapter {
   return {
     list: (tenantId, userId, params, organizationId) =>
       repo.list(tenantId, userId, params, organizationId),
+    listUsers: (tenantId, roleId, params) =>
+      repo.listUsers(tenantId, roleId, params),
     create: (tenantId, userId, roleId, organizationId) =>
       repo.create(tenantId, userId, roleId, organizationId),
     remove: (tenantId, userId, roleId, organizationId) =>

--- a/packages/kysely/src/user-roles/index.ts
+++ b/packages/kysely/src/user-roles/index.ts
@@ -1,12 +1,14 @@
 import { Kysely } from "kysely";
 import { Database } from "../db";
 import { list } from "./list";
+import { listUsers } from "./list-users";
 import { create } from "./create";
 import { remove } from "./remove";
 
 export function userRoles(db: Kysely<Database>) {
   return {
     list: list(db),
+    listUsers: listUsers(db),
     create: create(db),
     remove: remove(db),
   };

--- a/packages/kysely/src/user-roles/list-users.ts
+++ b/packages/kysely/src/user-roles/list-users.ts
@@ -1,0 +1,62 @@
+import { Kysely } from "kysely";
+import { Database } from "../db";
+import { ListParams, ListRoleUsersResponse } from "@authhero/adapter-interfaces";
+import { keysetPaginate, isKeysetRequest } from "../helpers/paginate";
+
+export function listUsers(db: Kysely<Database>) {
+  return async (
+    tenant_id: string,
+    role_id: string,
+    params?: ListParams,
+  ): Promise<ListRoleUsersResponse> => {
+    // A user can hold the same role under several organization scopes; the
+    // endpoint lists users, so collapse assignments to distinct user_ids.
+    // user_roles has no surrogate id, so the (unique-after-distinct) user_id
+    // doubles as both sort column and keyset tiebreaker.
+    const query = db
+      .selectFrom("user_roles")
+      .select("user_id")
+      .distinct()
+      .where("tenant_id", "=", tenant_id)
+      .where("role_id", "=", role_id);
+
+    if (isKeysetRequest(params)) {
+      const { rows, limit, next } = await keysetPaginate(query, params, {
+        sortColumn: "user_id",
+        sortOrder: "asc",
+        idColumn: "user_id",
+      });
+      return {
+        userIds: rows.map((row) => row.user_id),
+        start: 0,
+        limit,
+        length: rows.length,
+        next,
+      };
+    }
+
+    const page = params?.page || 0;
+    const per_page = params?.per_page || 50;
+    const offset = page * per_page;
+
+    const results = await query
+      .orderBy("user_id", "asc")
+      .limit(per_page)
+      .offset(offset)
+      .execute();
+
+    const total = await db
+      .selectFrom("user_roles")
+      .select(db.fn.count("user_id").distinct().as("count"))
+      .where("tenant_id", "=", tenant_id)
+      .where("role_id", "=", role_id)
+      .executeTakeFirst();
+
+    return {
+      userIds: results.map((row) => row.user_id),
+      start: offset,
+      limit: per_page,
+      length: Number(total?.count || 0),
+    };
+  };
+}

--- a/packages/kysely/test/keyset-pagination.test.ts
+++ b/packages/kysely/test/keyset-pagination.test.ts
@@ -106,7 +106,7 @@ describe("keyset pagination (from/take)", () => {
 // keyset on user_id itself (user_roles has no surrogate id, and user_id is
 // unique once assignments are collapsed).
 describe("role users keyset pagination (from/take)", () => {
-  let data: any;
+  let data: Awaited<ReturnType<typeof getTestServer>>["data"];
   const tenantId = "keyset-role-users-tenant";
   let roleId: string;
 

--- a/packages/kysely/test/keyset-pagination.test.ts
+++ b/packages/kysely/test/keyset-pagination.test.ts
@@ -102,6 +102,79 @@ describe("keyset pagination (from/take)", () => {
   });
 });
 
+// Role users collapse per-organization assignments to distinct user_ids and
+// keyset on user_id itself (user_roles has no surrogate id, and user_id is
+// unique once assignments are collapsed).
+describe("role users keyset pagination (from/take)", () => {
+  let data: any;
+  const tenantId = "keyset-role-users-tenant";
+  let roleId: string;
+
+  beforeEach(async () => {
+    const server = await getTestServer();
+    data = server.data;
+
+    const role = await data.roles.create(tenantId, {
+      name: "keyset-role",
+      description: "Keyset role",
+    });
+    roleId = role.id;
+
+    for (let i = 0; i < 25; i++) {
+      await data.userRoles.create(
+        tenantId,
+        `user-${i.toString().padStart(2, "0")}`,
+        roleId,
+      );
+    }
+    // The same user holding the role under organization scopes must still
+    // appear exactly once in the listing.
+    await data.userRoles.create(tenantId, "user-00", roleId, "org-a");
+    await data.userRoles.create(tenantId, "user-00", roleId, "org-b");
+  });
+
+  it("walks every distinct user exactly once across pages via next", async () => {
+    const seen = new Set<string>();
+    let from: string | undefined;
+    let pages = 0;
+
+    for (;;) {
+      const res = await data.userRoles.listUsers(tenantId, roleId, {
+        take: 10,
+        from,
+      });
+      pages++;
+      for (const userId of res.userIds) {
+        expect(seen.has(userId)).toBe(false); // no duplicates across pages
+        seen.add(userId);
+      }
+      if (!res.next) break;
+      from = res.next;
+      if (pages > 10) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.size).toBe(25);
+    expect(pages).toBe(3); // 10 + 10 + 5
+  });
+
+  it("omits next on the final page", async () => {
+    const res = await data.userRoles.listUsers(tenantId, roleId, {
+      take: 50,
+    });
+    expect(res.userIds).toHaveLength(25);
+    expect(res.next).toBeUndefined();
+  });
+
+  it("counts distinct users in offset mode", async () => {
+    const res = await data.userRoles.listUsers(tenantId, roleId, {
+      page: 0,
+      per_page: 10,
+    });
+    expect(res.userIds).toHaveLength(10);
+    expect(res.length).toBe(25); // org-scoped duplicates collapsed
+  });
+});
+
 // Logs honor q, date-range filters, and a date asc/desc sort in checkpoint
 // mode (a superset of Auth0, which ignores q/sort under from/take on /logs).
 // The cursor records the sort it was minted under so a token replayed with a


### PR DESCRIPTION
## Summary

Implements `GET /roles/{id}/users` on the management API — the last remaining Category 1 (Auth0 checkpoint) endpoint from #1098. Auth0 supports checkpoint pagination on this endpoint and requires it past 1000 results; authhero didn't have the endpoint at all, so it gets a real keyset cursor from day one with no offset stopgap to migrate later.

## Changes

- **adapter-interfaces**: `UserRolesAdapter` gains `listUsers(tenantId, roleId, params)` returning `{ userIds, start, limit, length, next? }`. Users are the distinct set holding the role — per-organization assignments collapse to one entry.
- **kysely / drizzle**: keyset implementation via the shared paginate helpers. `user_roles` has no surrogate id, so after collapsing to distinct user_ids the `user_id` itself serves as both sort column and tiebreaker (fixed `user_id asc` sort, no `k` in the cursor). Offset mode counts `distinct user_id` for totals.
- **aws**: throws an explicit not-implemented error, mirroring the actions adapters — the DynamoDB key layout indexes user-roles by user, not by role, so listing a role's users would need a scan or a new GSI (same carve-out as #1100/#1105/#1107).
- **authhero route**: `GET /roles/{id}/users` returns Auth0's three shapes: bare array of user summaries (`user_id`, `email`, `name`, `picture`) by default, `{ users, start, limit, length, total }` with `include_totals`, and `{ users, next }` in checkpoint mode. Requires `read:roles`, matching the sibling role endpoints. User summaries are hydrated via `users.get` with the default-avatar fallback, same as org members.

## Tests

- kysely + drizzle: cursor walk visits every distinct user exactly once (10+10+5 pages), `next` omitted on the last page, org-scoped duplicate assignments collapse, offset totals count distinct users.
- authhero: route-level 404, bare-array + include_totals shapes, and a full checkpoint walk via the opaque `next` cursor.

All suites green: adapter-interfaces 25, aws 25, kysely 277, drizzle 85, authhero 1790.

Closes the Category 1 rollout in #1098 (remaining work there is Category 2 opportunistic conversions and the aws cursor pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a management API endpoint to list users assigned to a role.
  * Supports standard pagination, Auth0-style checkpoint pagination, and optional totals.
  * Returns distinct user summaries, collapsing duplicate organization assignments.
  * Added role-user pagination support for SQL-backed adapters.

* **Bug Fixes**
  * Requests for missing roles now return a clear `404` response.
  * Added validation for pagination limits.

* **Breaking Changes**
  * Custom adapters must implement the required role-user listing operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->