### PR TITLE
feat: OIDC Back-Channel Logout 1.0

### DIFF
--- a/.changeset/backchannel-logout.md
+++ b/.changeset/backchannel-logout.md
@@ -1,0 +1,7 @@
+---
+"authhero": minor
+"@authhero/adapter-interfaces": minor
+"create-authhero": patch
+---
+
+Implement OIDC Back-Channel Logout 1.0. When a session ends — via /v2/logout, /oidc/logout, or Management API session revoke/delete — the OP now POSTs a signed logout token (typ `logout+jwt`, with `sid`, `sub`, and the backchannel-logout `events` claim, never a `nonce`) to each participating client's registered `oidc_logout.backchannel_logout_urls`. Delivery is best-effort in the background and goes through the SSRF-safe URL check. Discovery now advertises `backchannel_logout_supported` and `backchannel_logout_session_supported`. The client `oidc_logout` field is now typed (`backchannel_logout_urls`, `backchannel_logout_initiators`), and the create-authhero conformance seed passes `oidc_logout` through for extra clients.

--- a/apps/conformance-runner/fixtures/seed-clients.json
+++ b/apps/conformance-runner/fixtures/seed-clients.json
@@ -62,5 +62,97 @@
       "https://localhost.emobix.co.uk:8443"
     ],
     "auth0_conformant": false
+  },
+  {
+    "client_id": "test-client-bcl",
+    "client_secret": "test-client-bcl-secret-at-least-32-bytes-long",
+    "name": "Test Client Backchannel Logout",
+    "callbacks": [
+      "https://localhost.emobix.co.uk:8443/test/a/my-local-test/callback",
+      "https://localhost:8443/test/a/my-local-test/callback"
+    ],
+    "allowed_logout_urls": [
+      "https://localhost.emobix.co.uk:8443/test/a/my-local-test/post_logout_redirect",
+      "https://localhost:8443/test/a/my-local-test/post_logout_redirect"
+    ],
+    "web_origins": [
+      "https://localhost:8443",
+      "https://localhost.emobix.co.uk:8443"
+    ],
+    "auth0_conformant": false,
+    "oidc_logout": {
+      "backchannel_logout_urls": [
+        "https://localhost.emobix.co.uk:8443/test/a/my-local-test/backchannel_logout"
+      ]
+    }
+  },
+  {
+    "client_id": "test-client-bcl-w1",
+    "client_secret": "test-client-bcl-w1-secret-at-least-32-bytes",
+    "name": "Test Client Backchannel Logout w1",
+    "callbacks": [
+      "https://localhost.emobix.co.uk:8443/test/a/my-local-test-w1/callback",
+      "https://localhost:8443/test/a/my-local-test-w1/callback"
+    ],
+    "allowed_logout_urls": [
+      "https://localhost.emobix.co.uk:8443/test/a/my-local-test-w1/post_logout_redirect",
+      "https://localhost:8443/test/a/my-local-test-w1/post_logout_redirect"
+    ],
+    "web_origins": [
+      "https://localhost:8443",
+      "https://localhost.emobix.co.uk:8443"
+    ],
+    "auth0_conformant": false,
+    "oidc_logout": {
+      "backchannel_logout_urls": [
+        "https://localhost.emobix.co.uk:8443/test/a/my-local-test-w1/backchannel_logout"
+      ]
+    }
+  },
+  {
+    "client_id": "test-client-bcl-w2",
+    "client_secret": "test-client-bcl-w2-secret-at-least-32-bytes",
+    "name": "Test Client Backchannel Logout w2",
+    "callbacks": [
+      "https://localhost.emobix.co.uk:8443/test/a/my-local-test-w2/callback",
+      "https://localhost:8443/test/a/my-local-test-w2/callback"
+    ],
+    "allowed_logout_urls": [
+      "https://localhost.emobix.co.uk:8443/test/a/my-local-test-w2/post_logout_redirect",
+      "https://localhost:8443/test/a/my-local-test-w2/post_logout_redirect"
+    ],
+    "web_origins": [
+      "https://localhost:8443",
+      "https://localhost.emobix.co.uk:8443"
+    ],
+    "auth0_conformant": false,
+    "oidc_logout": {
+      "backchannel_logout_urls": [
+        "https://localhost.emobix.co.uk:8443/test/a/my-local-test-w2/backchannel_logout"
+      ]
+    }
+  },
+  {
+    "client_id": "test-client-bcl-w3",
+    "client_secret": "test-client-bcl-w3-secret-at-least-32-bytes",
+    "name": "Test Client Backchannel Logout w3",
+    "callbacks": [
+      "https://localhost.emobix.co.uk:8443/test/a/my-local-test-w3/callback",
+      "https://localhost:8443/test/a/my-local-test-w3/callback"
+    ],
+    "allowed_logout_urls": [
+      "https://localhost.emobix.co.uk:8443/test/a/my-local-test-w3/post_logout_redirect",
+      "https://localhost:8443/test/a/my-local-test-w3/post_logout_redirect"
+    ],
+    "web_origins": [
+      "https://localhost:8443",
+      "https://localhost.emobix.co.uk:8443"
+    ],
+    "auth0_conformant": false,
+    "oidc_logout": {
+      "backchannel_logout_urls": [
+        "https://localhost.emobix.co.uk:8443/test/a/my-local-test-w3/backchannel_logout"
+      ]
+    }
   }
 ]

--- a/apps/conformance-runner/lib/test-plan-config.ts
+++ b/apps/conformance-runner/lib/test-plan-config.ts
@@ -78,6 +78,18 @@ export const FORM_POST_HYBRID_PLAN_VARIANT = {
   client_registration: "static_client",
 } as const;
 
+export const BACKCHANNEL_LOGOUT_PLAN_NAME =
+  "oidcc-backchannel-rp-initiated-logout-certification-test-plan";
+
+// Same variant shape as the RP-initiated logout plan: the plan pins
+// server_metadata (and, on the main module, client_auth_type/response_mode)
+// per-module, so only client_registration + response_type may be supplied at
+// the plan level.
+export const BACKCHANNEL_LOGOUT_PLAN_VARIANT = {
+  client_registration: "static_client",
+  response_type: "code",
+} as const;
+
 export const DYNAMIC_PLAN_NAME = "oidcc-dynamic-certification-test-plan";
 
 // Dynamic registration variant — the suite calls /oidc/register itself for
@@ -167,6 +179,28 @@ export function buildHybridPlanConfig() {
 
 export function buildFormPostHybridPlanConfig() {
   return buildSharedClientConfig("OIDC Form Post Hybrid");
+}
+
+export function buildBackchannelLogoutPlanConfig() {
+  // The suite POSTs the logout token to
+  //   <suite-base>/test/a/<alias>/backchannel_logout
+  // and every URL registered on a client gets called on every logout of a
+  // session that client participated in. A shared client would therefore
+  // spray logout tokens across all workers' test instances, so each worker
+  // gets a dedicated client whose backchannel_logout_urls target only its
+  // own alias (see fixtures/seed-clients.json).
+  const workerSuffix =
+    env.workerAlias === env.alias
+      ? ""
+      : env.workerAlias.slice(env.alias.length);
+  const config = buildSharedClientConfig("OIDC Backchannel Logout");
+  config.client = {
+    client_id: `test-client-bcl${workerSuffix}`,
+    client_secret: workerSuffix
+      ? `test-client-bcl${workerSuffix}-secret-at-least-32-bytes`
+      : "test-client-bcl-secret-at-least-32-bytes-long",
+  };
+  return config;
 }
 
 export function buildDynamicPlanConfig() {

--- a/apps/conformance-runner/tests/oidcc-backchannel-logout.spec.ts
+++ b/apps/conformance-runner/tests/oidcc-backchannel-logout.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "@playwright/test";
+import { ConformanceClient, downloadPlanReport } from "../lib/conformance-api";
+import { runBrowserFlow } from "../lib/run-browser-flow";
+import { env } from "../lib/env";
+import {
+  BACKCHANNEL_LOGOUT_PLAN_NAME,
+  BACKCHANNEL_LOGOUT_PLAN_VARIANT,
+  buildBackchannelLogoutPlanConfig,
+} from "../lib/test-plan-config";
+
+const client = new ConformanceClient();
+
+let planId: string;
+let modules: { testModule: string; variant?: Record<string, string> }[];
+
+test.beforeAll(async () => {
+  const config = buildBackchannelLogoutPlanConfig();
+  console.log(
+    `[conformance-runner] Creating plan ${BACKCHANNEL_LOGOUT_PLAN_NAME} with alias ${config.alias}`,
+  );
+  const plan = await client.createPlan(
+    BACKCHANNEL_LOGOUT_PLAN_NAME,
+    config,
+    BACKCHANNEL_LOGOUT_PLAN_VARIANT,
+  );
+  planId = plan.id;
+  modules = plan.modules;
+  console.log(
+    `[conformance-runner] Plan ${planId} created — ${modules.length} module(s)`,
+  );
+  console.log(
+    `[conformance-runner] Plan detail: ${client.baseUrl}/plan-detail.html?plan=${planId}`,
+  );
+});
+
+test.afterAll(async () => {
+  await downloadPlanReport(client, BACKCHANNEL_LOGOUT_PLAN_NAME, planId);
+});
+
+// Modules whose WARNING result we accept as a pass (matches the pattern used
+// by the other plans).
+const MODULES_ALLOWED_TO_WARN = new Set<string>([]);
+
+// Modules we still expect to fail. Entries land here as we discover real
+// gaps — drop them once the underlying behaviour is fixed.
+const MODULES_EXPECTED_TO_FAIL = new Set<string>([]);
+
+test.describe.configure({ mode: "default" });
+
+test.describe("OIDCC Backchannel RP-Initiated Logout Certification", () => {
+  for (const moduleName of getStaticModulesForPlan()) {
+    test(moduleName, async ({ page }) => {
+      test.fail(
+        MODULES_EXPECTED_TO_FAIL.has(moduleName),
+        "Known gap in backchannel logout implementation",
+      );
+      const moduleEntry = modules.find((m) => m.testModule === moduleName);
+      test.skip(
+        !moduleEntry,
+        `module ${moduleName} not present in created plan`,
+      );
+
+      const created = await client.createTestFromPlan(
+        planId,
+        moduleName,
+        moduleEntry?.variant,
+      );
+      const testId = created.id;
+      console.log(
+        `[conformance-runner] ${moduleName} -> ${client.baseUrl}/log-detail.html?log=${testId}`,
+      );
+
+      const initial = await client.waitForState(testId, [
+        "CONFIGURED",
+        "WAITING",
+        "FINISHED",
+        "INTERRUPTED",
+      ]);
+      if (initial === "CONFIGURED") {
+        await client.startTest(testId);
+        await client.waitForState(testId, [
+          "WAITING",
+          "FINISHED",
+          "INTERRUPTED",
+        ]);
+      }
+
+      const preBrowserInfo = await client.getInfo(testId);
+      if (
+        preBrowserInfo.status !== "FINISHED" &&
+        preBrowserInfo.status !== "INTERRUPTED"
+      ) {
+        await runBrowserFlow({ testId, page, client });
+        await client.waitForState(testId, ["FINISHED", "INTERRUPTED"]);
+      }
+
+      const info = await client.getInfo(testId);
+      const result = info.result;
+      console.log(
+        `[conformance-runner] ${moduleName} status=${info.status} result=${result ?? "(none)"}`,
+      );
+
+      const acceptable: string[] = ["PASSED", "REVIEW", "SKIPPED"];
+      if (env.allowWarning) acceptable.push("WARNING");
+      if (MODULES_ALLOWED_TO_WARN.has(moduleName)) acceptable.push("WARNING");
+
+      let failureDetail = "";
+      if (!acceptable.includes(result ?? "")) {
+        const log = await client.getTestLog(testId).catch(() => []);
+        const firstFail = log.find((l) => l.result === "FAILURE");
+        const firstWarn = log.find((l) => l.result === "WARNING");
+        const parts: string[] = [];
+        if (firstFail) {
+          parts.push(
+            `first FAILURE: [${firstFail.src ?? "?"}] ${firstFail.msg ?? ""}`,
+          );
+        }
+        if (firstWarn) {
+          parts.push(
+            `first WARNING: [${firstWarn.src ?? "?"}] ${firstWarn.msg ?? ""}`,
+          );
+        }
+        if (parts.length > 0) failureDetail = ` | ${parts.join(" | ")}`;
+      }
+
+      expect(
+        acceptable,
+        `expected ${moduleName} result to be ${acceptable.join("/")}; got ${result ?? "(none)"} (status=${info.status}). Log: ${client.baseUrl}/log-detail.html?log=${testId}${failureDetail}`,
+      ).toContain(result ?? "");
+    });
+  }
+});
+
+function getStaticModulesForPlan(): string[] {
+  return [
+    "oidcc-backchannel-logout-discovery-endpoint-verification",
+    "oidcc-backchannel-rp-initiated-logout",
+  ];
+}

--- a/packages/adapter-interfaces/src/types/Client.ts
+++ b/packages/adapter-interfaces/src/types/Client.ts
@@ -117,11 +117,21 @@ export const clientInsertSchema = z.object({
       }),
       backchannel_logout_initiators: z
         .object({
-          mode: z.enum(["all", "custom"]).optional(),
-          selected_initiators: z.array(z.string()).optional(),
+          mode: z.enum(["all", "custom"]).optional().openapi({
+            description:
+              "Whether all session-end events initiate a backchannel logout (all) or only the selected_initiators (custom).",
+          }),
+          selected_initiators: z.array(z.string()).optional().openapi({
+            description:
+              "Logout initiators that trigger a backchannel logout when mode is custom (e.g. rp-logout, idp-logout, password-changed).",
+          }),
         })
         .passthrough()
-        .optional(),
+        .optional()
+        .openapi({
+          description:
+            "Controls which session-end events initiate backchannel logout notifications. Stored for Auth0 compatibility; not yet enforced — all initiators currently notify.",
+        }),
     })
     .passthrough()
     .default({})

--- a/packages/adapter-interfaces/src/types/Client.ts
+++ b/packages/adapter-interfaces/src/types/Client.ts
@@ -109,9 +109,26 @@ export const clientInsertSchema = z.object({
     .openapi({
       description: "Native to Web SSO Configuration",
     }),
-  oidc_logout: z.record(z.string(), z.any()).default({}).optional().openapi({
-    description: "Configuration for OIDC backchannel logout",
-  }),
+  oidc_logout: z
+    .object({
+      backchannel_logout_urls: z.array(z.string()).optional().openapi({
+        description:
+          "URLs that receive a signed OIDC Back-Channel Logout 1.0 logout token when a session this client participated in ends.",
+      }),
+      backchannel_logout_initiators: z
+        .object({
+          mode: z.enum(["all", "custom"]).optional(),
+          selected_initiators: z.array(z.string()).optional(),
+        })
+        .passthrough()
+        .optional(),
+    })
+    .passthrough()
+    .default({})
+    .optional()
+    .openapi({
+      description: "Configuration for OIDC backchannel logout",
+    }),
   grant_types: z.array(z.string()).default([]).optional().openapi({
     description:
       "List of grant types supported for this application. Can include authorization_code, implicit, refresh_token, client_credentials, password, http://auth0.com/oauth/grant-type/password-realm, http://auth0.com/oauth/grant-type/mfa-oob, http://auth0.com/oauth/grant-type/mfa-otp, http://auth0.com/oauth/grant-type/mfa-recovery-code, urn:openid:params:grant-type:ciba, and urn:ietf:params:oauth:grant-type:device_code.",

--- a/packages/adapter-interfaces/src/types/JWKS.ts
+++ b/packages/adapter-interfaces/src/types/JWKS.ts
@@ -81,4 +81,6 @@ export const openIDConfigurationSchema = z.object({
   request_object_signing_alg_values_supported: z.array(z.string()).optional(),
   token_endpoint_auth_signing_alg_values_supported: z.array(z.string()),
   client_id_metadata_document_supported: z.boolean().optional(),
+  backchannel_logout_supported: z.boolean().optional(),
+  backchannel_logout_session_supported: z.boolean().optional(),
 });

--- a/packages/authhero/src/helpers/backchannel-logout.ts
+++ b/packages/authhero/src/helpers/backchannel-logout.ts
@@ -1,0 +1,150 @@
+import { Context } from "hono";
+import { Session } from "@authhero/adapter-interfaces";
+import { nanoid } from "nanoid";
+import { Bindings, Variables } from "../types";
+import { signJWT } from "../utils/jwt";
+import { pemToBuffer } from "../utils/crypto";
+import { algForCert } from "../utils/jwk-alg";
+import { resolveSigningKeys } from "./signing-keys";
+import { getIssuer } from "../variables";
+import {
+  assertSsrfSafeUrl,
+  ssrfFetchOptionsFromEnv,
+} from "../utils/ssrf-fetch";
+import { waitUntil } from "./wait-until";
+
+// OIDC Back-Channel Logout 1.0
+// https://openid.net/specs/openid-connect-backchannel-1_0.html
+
+// §2.4 — logout tokens are consumed immediately; keep the window short so a
+// leaked token can't be replayed against an RP long after the logout.
+const LOGOUT_TOKEN_LIFETIME_SECONDS = 120;
+const DELIVERY_TIMEOUT_MS = 5000;
+
+const BACKCHANNEL_LOGOUT_EVENT =
+  "http://schemas.openid.net/event/backchannel-logout";
+
+type BackchannelSession = Pick<Session, "id" | "user_id" | "clients">;
+
+/**
+ * Notify every RP that participated in `session` and registered
+ * `oidc_logout.backchannel_logout_urls` that the session has ended, by
+ * POSTing a signed logout token (§2.5) to each registered URL.
+ *
+ * Delivery is best-effort and runs in the background (`waitUntil`): a dead RP
+ * endpoint must never block or fail the logout that triggered it. Call this
+ * AFTER the session revocation has committed, so an RP that reacts to the
+ * token by hitting the OP observes the session as already gone.
+ */
+export function sendBackchannelLogout(
+  ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
+  tenant_id: string,
+  session: BackchannelSession,
+): void {
+  waitUntil(
+    ctx,
+    deliverBackchannelLogout(ctx, tenant_id, session).catch((err) => {
+      console.warn(
+        `backchannel logout delivery failed for session ${session.id}:`,
+        err,
+      );
+    }),
+  );
+}
+
+async function deliverBackchannelLogout(
+  ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
+  tenant_id: string,
+  session: BackchannelSession,
+): Promise<void> {
+  const clientIds = [...new Set(session.clients ?? [])];
+  if (clientIds.length === 0) return;
+
+  const targets: { client_id: string; url: string }[] = [];
+  for (const client_id of clientIds) {
+    const client = await ctx.env.data.clients
+      .get(tenant_id, client_id)
+      .catch(() => null);
+    for (const url of client?.oidc_logout?.backchannel_logout_urls ?? []) {
+      targets.push({ client_id, url });
+    }
+  }
+  if (targets.length === 0) return;
+
+  const resolvedKeys = await resolveSigningKeys(
+    ctx.env.data.keys,
+    tenant_id,
+    ctx.env.signingKeyMode,
+    { purpose: "sign" },
+  );
+  const signingKey = resolvedKeys[0];
+  if (!signingKey?.pkcs7 || !signingKey.cert) {
+    console.warn(
+      "backchannel logout skipped: no signing key available for tenant",
+      tenant_id,
+    );
+    return;
+  }
+  const keyBuffer = pemToBuffer(signingKey.pkcs7);
+  const signingAlg = await algForCert(signingKey.cert);
+  const iss = getIssuer(ctx.env, ctx.var.custom_domain);
+  const ssrfOpts = ssrfFetchOptionsFromEnv(ctx.env);
+
+  await Promise.all(
+    targets.map(async ({ client_id, url }) => {
+      try {
+        // §2.4 logout token. Contains both sub and sid (we always bind
+        // sessions to a user), and — per spec — MUST NOT contain a nonce so
+        // it can never be replayed as an ID token.
+        const logout_token = await signJWT(
+          signingAlg,
+          keyBuffer,
+          {
+            iss,
+            aud: client_id,
+            sub: session.user_id,
+            sid: session.id,
+            jti: nanoid(),
+            events: { [BACKCHANNEL_LOGOUT_EVENT]: {} },
+          },
+          {
+            includeIssuedTimestamp: true,
+            expiresInSeconds: LOGOUT_TOKEN_LIFETIME_SECONDS,
+            headers: { kid: signingKey.kid, typ: "logout+jwt" },
+          },
+        );
+
+        const target = assertSsrfSafeUrl(url, ssrfOpts);
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
+        try {
+          const response = await fetch(target, {
+            method: "POST",
+            redirect: "manual",
+            signal: controller.signal,
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+              "cache-control": "no-store",
+            },
+            body: new URLSearchParams({ logout_token }).toString(),
+          });
+          if (!response.ok) {
+            console.warn(
+              `backchannel logout: ${url} responded ${response.status} for client ${client_id}`,
+            );
+          }
+          // Release the connection; the response body carries no meaning
+          // (§2.8 — the RP signals the outcome via status code alone).
+          await response.body?.cancel();
+        } finally {
+          clearTimeout(timer);
+        }
+      } catch (err) {
+        console.warn(
+          `backchannel logout: delivery to ${url} failed for client ${client_id}:`,
+          err,
+        );
+      }
+    }),
+  );
+}

--- a/packages/authhero/src/routes/auth-api/logout.ts
+++ b/packages/authhero/src/routes/auth-api/logout.ts
@@ -9,6 +9,7 @@ import { setTenantId } from "../../helpers/set-tenant-id";
 import { getEnrichedClient } from "../../helpers/client";
 import { prefetchClientBundle } from "../../helpers/prefetch-client-bundle";
 import { isCimdClientId } from "../../helpers/cimd";
+import { sendBackchannelLogout } from "../../helpers/backchannel-logout";
 import { defineRoute } from "../../utils/define-route";
 const getRoot = defineRoute({
   route: createRoute({
@@ -144,6 +145,8 @@ const getRoot = defineRoute({
               description: `Revoked ${revokedCount} refresh token(s)`,
             });
           }
+
+          sendBackchannelLogout(ctx, client.tenant.id, session);
         }
       }
     }

--- a/packages/authhero/src/routes/auth-api/oidc-logout.ts
+++ b/packages/authhero/src/routes/auth-api/oidc-logout.ts
@@ -9,6 +9,7 @@ import { getEnrichedClient } from "../../helpers/client";
 import { prefetchClientBundle } from "../../helpers/prefetch-client-bundle";
 import { isCimdClientId } from "../../helpers/cimd";
 import { validateJwtToken } from "../../utils/jwt";
+import { sendBackchannelLogout } from "../../helpers/backchannel-logout";
 
 import { defineRoute } from "../../utils/define-route";
 // OIDC RP-Initiated Logout 1.0
@@ -212,6 +213,8 @@ const getRoot = defineRoute({
               description: `Revoked ${revokedCount} refresh token(s)`,
             });
           }
+
+          sendBackchannelLogout(ctx, client.tenant.id, session);
         }
       }
     }

--- a/packages/authhero/src/routes/auth-api/oidc-logout.ts
+++ b/packages/authhero/src/routes/auth-api/oidc-logout.ts
@@ -157,8 +157,14 @@ const getRoot = defineRoute({
     }
 
     const cookieHeader = ctx.req.header("cookie");
-    if (client && cookieHeader) {
-      const sessionId = getAuthCookie(client.tenant.id, cookieHeader);
+    if (client) {
+      // A valid id_token_hint identifies the session via its sid claim, so
+      // sid-based logout must work without an OP cookie (e.g. the RP calls
+      // the end-session endpoint after the browser cookie is already gone).
+      // The cookie only serves as the fallback when the hint carries no sid.
+      const sessionId = cookieHeader
+        ? getAuthCookie(client.tenant.id, cookieHeader)
+        : undefined;
       const targetSessionId = idTokenSid ?? sessionId;
       if (targetSessionId) {
         const session = await ctx.env.data.sessions.get(

--- a/packages/authhero/src/routes/auth-api/well-known.ts
+++ b/packages/authhero/src/routes/auth-api/well-known.ts
@@ -88,6 +88,11 @@ async function buildAuthServerMetadata(ctx: {
           end_session_endpoint: `${getAuthUrl(ctx.env, customDomain)}oidc/logout`,
         }
       : {}),
+    // OIDC Back-Channel Logout 1.0 — session ends POST a signed logout token
+    // (always carrying `sid`) to each client's registered
+    // oidc_logout.backchannel_logout_urls.
+    backchannel_logout_supported: true,
+    backchannel_logout_session_supported: true,
     scopes_supported: [
       "openid",
       "profile",

--- a/packages/authhero/src/routes/management-api/sessions.ts
+++ b/packages/authhero/src/routes/management-api/sessions.ts
@@ -3,6 +3,7 @@ import { Bindings, Variables } from "../../types";
 import { HTTPException } from "hono/http-exception";
 import { sessionSchema, LogTypes } from "@authhero/adapter-interfaces";
 import { logMessage } from "../../helpers/logging";
+import { sendBackchannelLogout } from "../../helpers/backchannel-logout";
 import { defineRoute } from "../../utils/define-route";
 const getById = defineRoute({
   route: createRoute({
@@ -74,11 +75,19 @@ const deleteById = defineRoute({
   handler: async (ctx) => {
     const { id } = ctx.req.valid("param");
 
+    // Read before removing — the backchannel logout notification needs the
+    // participating client ids, which are gone once the row is deleted.
+    const session = await ctx.env.data.sessions.get(ctx.var.tenant_id, id);
+
     const result = await ctx.env.data.sessions.remove(ctx.var.tenant_id, id);
     if (!result) {
       throw new HTTPException(404, {
         message: "Session not found",
       });
+    }
+
+    if (session) {
+      sendBackchannelLogout(ctx, ctx.var.tenant_id, session);
     }
 
     await logMessage(ctx, ctx.var.tenant_id, {
@@ -119,6 +128,8 @@ const postByIdRevoke = defineRoute({
   handler: async (ctx) => {
     const { id } = ctx.req.valid("param");
 
+    const session = await ctx.env.data.sessions.get(ctx.var.tenant_id, id);
+
     const result = await ctx.env.data.sessions.update(ctx.var.tenant_id, id, {
       revoked_at: new Date().toISOString(),
     });
@@ -126,6 +137,10 @@ const postByIdRevoke = defineRoute({
       throw new HTTPException(404, {
         message: "Session not found",
       });
+    }
+
+    if (session) {
+      sendBackchannelLogout(ctx, ctx.var.tenant_id, session);
     }
 
     await logMessage(ctx, ctx.var.tenant_id, {

--- a/packages/authhero/test/routes/auth-api/backchannel-logout.spec.ts
+++ b/packages/authhero/test/routes/auth-api/backchannel-logout.spec.ts
@@ -104,6 +104,36 @@ describe("backchannel logout", () => {
     expect(payload.exp).toBeTypeOf("number");
   });
 
+  it("revokes the session and notifies on /oidc/logout with sid but no cookie", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const { session } = await createSessions(env.data);
+
+    await env.data.clients.update("tenantId", "clientId", {
+      oidc_logout: {
+        backchannel_logout_urls: ["https://rp.example.com/backchannel"],
+      },
+    });
+
+    const idToken = await signIdToken(session.id);
+    const response = await oauthApp.request(
+      `/oidc/logout?id_token_hint=${encodeURIComponent(idToken)}`,
+      {
+        method: "GET",
+        headers: { host: "auth.example.com" },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const sessionAfter = await env.data.sessions.get("tenantId", session.id);
+    expect(sessionAfter?.revoked_at).toBeTypeOf("string");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const { payload } = deliveredLogoutToken();
+    expect(payload.sid).toBe(session.id);
+  });
+
   it("does not call out when the client has no backchannel_logout_urls", async () => {
     const { oauthApp, env } = await getTestServer();
     const { session } = await createSessions(env.data);

--- a/packages/authhero/test/routes/auth-api/backchannel-logout.spec.ts
+++ b/packages/authhero/test/routes/auth-api/backchannel-logout.spec.ts
@@ -41,6 +41,7 @@ describe("backchannel logout", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   function deliveredLogoutToken(callIndex = 0) {
@@ -61,6 +62,11 @@ describe("backchannel logout", () => {
   it("POSTs a signed logout token to the client's registered URL on /oidc/logout", async () => {
     const { oauthApp, env } = await getTestServer();
     const { session } = await createSessions(env.data);
+
+    // Freeze Date only (setTimeout stays real — the delivery helper uses it
+    // for its abort timer) so iat/exp are minted from the same instant and
+    // the two-minute lifetime can be asserted exactly.
+    vi.useFakeTimers({ toFake: ["Date"] });
 
     await env.data.clients.update("tenantId", "clientId", {
       oidc_logout: {
@@ -102,6 +108,8 @@ describe("backchannel logout", () => {
     expect(payload).not.toHaveProperty("nonce");
     expect(payload.iat).toBeTypeOf("number");
     expect(payload.exp).toBeTypeOf("number");
+    // §2.4-adjacent hardening: keep the replay window short.
+    expect(payload.exp).toBe(Number(payload.iat) + 120);
   });
 
   it("revokes the session and notifies on /oidc/logout with sid but no cookie", async () => {

--- a/packages/authhero/test/routes/auth-api/backchannel-logout.spec.ts
+++ b/packages/authhero/test/routes/auth-api/backchannel-logout.spec.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getTestServer } from "../../helpers/test-server";
+import { createSessions } from "../../helpers/create-session";
+import {
+  getAdminToken,
+  getCertificate,
+  pemToBuffer,
+} from "../../helpers/token";
+import { signJWT, parseJWT } from "../../../src/utils/jwt";
+
+const BACKCHANNEL_LOGOUT_EVENT =
+  "http://schemas.openid.net/event/backchannel-logout";
+
+async function signIdToken(sid: string) {
+  const cert = await getCertificate();
+  return signJWT(
+    "RS256",
+    pemToBuffer(cert.pkcs7!),
+    {
+      aud: "clientId",
+      sub: "email|userId",
+      iss: "http://localhost:3000/",
+      sid,
+    },
+    {
+      includeIssuedTimestamp: true,
+      expiresInSeconds: 3600,
+      headers: { kid: cert.kid },
+    },
+  );
+}
+
+describe("backchannel logout", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function deliveredLogoutToken(callIndex = 0) {
+    const [url, init] = fetchMock.mock.calls[callIndex] ?? [];
+    expect(init?.method).toBe("POST");
+    expect(init?.headers?.["content-type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const logout_token = new URLSearchParams(String(init?.body)).get(
+      "logout_token",
+    );
+    expect(logout_token).toBeTruthy();
+    const parsed = parseJWT(logout_token!);
+    expect(parsed).not.toBeNull();
+    return { url: String(url), ...parsed! };
+  }
+
+  it("POSTs a signed logout token to the client's registered URL on /oidc/logout", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const { session } = await createSessions(env.data);
+
+    await env.data.clients.update("tenantId", "clientId", {
+      oidc_logout: {
+        backchannel_logout_urls: ["https://rp.example.com/backchannel"],
+      },
+    });
+
+    const idToken = await signIdToken(session.id);
+    const response = await oauthApp.request(
+      `/oidc/logout?id_token_hint=${encodeURIComponent(idToken)}`,
+      {
+        method: "GET",
+        headers: {
+          host: "auth.example.com",
+          cookie: `tenantId-auth-token=${session.id}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const { url, header, payload } = deliveredLogoutToken();
+    expect(url).toBe("https://rp.example.com/backchannel");
+
+    expect(header.typ).toBe("logout+jwt");
+    expect(header.alg).toBe("RS256");
+    expect(header.kid).toBeTypeOf("string");
+
+    expect(payload.iss).toBe("http://localhost:3000/");
+    expect(payload.aud).toBe("clientId");
+    expect(payload.sub).toBe("email|userId");
+    expect(payload.sid).toBe(session.id);
+    expect(payload.jti).toBeTypeOf("string");
+    expect(payload.events).toEqual({ [BACKCHANNEL_LOGOUT_EVENT]: {} });
+    // OIDC Back-Channel Logout 1.0 §2.4 — a logout token MUST NOT contain
+    // a nonce, so it can never be replayed as an ID token.
+    expect(payload).not.toHaveProperty("nonce");
+    expect(payload.iat).toBeTypeOf("number");
+    expect(payload.exp).toBeTypeOf("number");
+  });
+
+  it("does not call out when the client has no backchannel_logout_urls", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const { session } = await createSessions(env.data);
+
+    const idToken = await signIdToken(session.id);
+    const response = await oauthApp.request(
+      `/oidc/logout?id_token_hint=${encodeURIComponent(idToken)}`,
+      {
+        method: "GET",
+        headers: {
+          host: "auth.example.com",
+          cookie: `tenantId-auth-token=${session.id}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("notifies on /v2/logout", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const { session } = await createSessions(env.data);
+
+    await env.data.clients.update("tenantId", "clientId", {
+      oidc_logout: {
+        backchannel_logout_urls: ["https://rp.example.com/backchannel"],
+      },
+    });
+
+    const response = await oauthApp.request(
+      `/v2/logout?client_id=clientId&returnTo=${encodeURIComponent("https://example.com/callback")}`,
+      {
+        method: "GET",
+        headers: {
+          host: "auth.example.com",
+          cookie: `tenantId-auth-token=${session.id}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(302);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const { payload } = deliveredLogoutToken();
+    expect(payload.sid).toBe(session.id);
+  });
+
+  it("notifies when a session is revoked via the management API", async () => {
+    const { managementApp, env } = await getTestServer();
+    const { session } = await createSessions(env.data);
+
+    await env.data.clients.update("tenantId", "clientId", {
+      oidc_logout: {
+        backchannel_logout_urls: ["https://rp.example.com/backchannel"],
+      },
+    });
+
+    const token = await getAdminToken();
+    const response = await managementApp.request(
+      `/sessions/${session.id}/revoke`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(202);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const { payload } = deliveredLogoutToken();
+    expect(payload.sid).toBe(session.id);
+    expect(payload.aud).toBe("clientId");
+  });
+
+  it("notifies when a session is deleted via the management API", async () => {
+    const { managementApp, env } = await getTestServer();
+    const { session } = await createSessions(env.data);
+
+    await env.data.clients.update("tenantId", "clientId", {
+      oidc_logout: {
+        backchannel_logout_urls: ["https://rp.example.com/backchannel"],
+      },
+    });
+
+    const token = await getAdminToken();
+    const response = await managementApp.request(
+      `/sessions/${session.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const { payload } = deliveredLogoutToken();
+    expect(payload.sid).toBe(session.id);
+  });
+
+  it("sends one token per participating client, addressed to that client", async () => {
+    const { oauthApp, env } = await getTestServer();
+    const { loginSession } = await createSessions(env.data);
+
+    await env.data.clients.update("tenantId", "clientId", {
+      oidc_logout: {
+        backchannel_logout_urls: ["https://rp.example.com/backchannel"],
+      },
+    });
+    await env.data.clients.create("tenantId", {
+      client_id: "otherClientId",
+      name: "Other client",
+      oidc_logout: {
+        backchannel_logout_urls: ["https://other-rp.example.com/backchannel"],
+      },
+    });
+
+    const session = await env.data.sessions.create("tenantId", {
+      id: "multiClientSession",
+      login_session_id: loginSession.id,
+      user_id: "email|userId",
+      clients: ["clientId", "otherClientId"],
+      expires_at: new Date(Date.now() + 1000).toISOString(),
+      used_at: new Date().toISOString(),
+      device: {
+        last_ip: "",
+        initial_ip: "",
+        last_user_agent: "",
+        initial_user_agent: "",
+        initial_asn: "",
+        last_asn: "",
+      },
+    });
+
+    const idToken = await signIdToken(session.id);
+    const response = await oauthApp.request(
+      `/oidc/logout?id_token_hint=${encodeURIComponent(idToken)}`,
+      {
+        method: "GET",
+        headers: {
+          host: "auth.example.com",
+          cookie: `tenantId-auth-token=${session.id}`,
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const deliveries = [deliveredLogoutToken(0), deliveredLogoutToken(1)];
+    const byAud = new Map(deliveries.map((d) => [d.payload.aud, d.url]));
+    expect(byAud.get("clientId")).toBe("https://rp.example.com/backchannel");
+    expect(byAud.get("otherClientId")).toBe(
+      "https://other-rp.example.com/backchannel",
+    );
+  });
+
+  async function logoutWithPrivateTarget(allowPrivate: boolean) {
+    const { oauthApp, env } = await getTestServer();
+    if (allowPrivate) {
+      // Local-dev override, used by the conformance setup whose suite lives
+      // on localhost.emobix.co.uk.
+      env.ALLOW_PRIVATE_OUTBOUND_FETCH = true;
+    }
+    const { session } = await createSessions(env.data);
+
+    await env.data.clients.update("tenantId", "clientId", {
+      oidc_logout: {
+        backchannel_logout_urls: ["https://localhost:8443/backchannel"],
+      },
+    });
+
+    const idToken = await signIdToken(session.id);
+    const response = await oauthApp.request(
+      `/oidc/logout?id_token_hint=${encodeURIComponent(idToken)}`,
+      {
+        method: "GET",
+        headers: {
+          host: "auth.example.com",
+          cookie: `tenantId-auth-token=${session.id}`,
+        },
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+  }
+
+  it("refuses to deliver to private targets by default", async () => {
+    await logoutWithPrivateTarget(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers to private targets when ALLOW_PRIVATE_OUTBOUND_FETCH is set", async () => {
+    await logoutWithPrivateTarget(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/create-authhero/src/index.ts
+++ b/packages/create-authhero/src/index.ts
@@ -585,6 +585,9 @@ interface ExtraClient {
   allowed_logout_urls?: string[];
   web_origins?: string[];
   auth0_conformant?: boolean;
+  oidc_logout?: {
+    backchannel_logout_urls?: string[];
+  };
 }
 
 function parseFlag(name: string): string | undefined {
@@ -663,6 +666,7 @@ async function main() {
       ...(c.auth0_conformant !== undefined && {
         auth0_conformant: c.auth0_conformant,
       }),
+      ...(c.oidc_logout !== undefined && { oidc_logout: c.oidc_logout }),
     });
     console.log(\`✅ Created client "\${c.client_id}"\`);
   }


### PR DESCRIPTION
## Summary

Implements [OIDC Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html) — the next OP certification profile after RP-Initiated Logout.

When a session ends, the OP now POSTs a signed **logout token** to each participating client's registered `oidc_logout.backchannel_logout_urls`:

- **Triggers**: `/v2/logout`, `/oidc/logout`, Management API `POST /sessions/{id}/revoke` and `DELETE /sessions/{id}` (the management-API paths are the ones only back-channel logout can cover — no browser is present).
- **Logout token** (`packages/authhero/src/helpers/backchannel-logout.ts`): `typ: logout+jwt`, signed with the tenant signing key (same JWKS as ID tokens), carries `iss`/`aud`/`sub`/`sid`/`iat`/`exp` (2 min)/`jti` + the `http://schemas.openid.net/event/backchannel-logout` events claim, and never a `nonce` (spec §2.4).
- **Delivery**: best-effort in the background via `waitUntil`, one POST per client per URL, 5s timeout, no redirects, through `assertSsrfSafeUrl` so client-supplied URLs can't reach private ranges (`ALLOW_PRIVATE_OUTBOUND_FETCH` opts out for local dev/conformance). A dead RP endpoint never blocks or fails the logout.
- **Discovery**: advertises `backchannel_logout_supported` + `backchannel_logout_session_supported` (`sid` is always in our ID tokens already).
- **Schema**: client `oidc_logout` is now typed (`backchannel_logout_urls`, `backchannel_logout_initiators`) instead of `z.record(any)`, with passthrough for unknown keys.

## Conformance

Adds the `oidcc-backchannel-rp-initiated-logout-certification-test-plan` (2 modules: discovery verification + the main backchannel flow) to the runner:

- New spec `tests/oidcc-backchannel-logout.spec.ts` following the RP-initiated-logout pattern.
- Dedicated per-worker clients (`test-client-bcl`, `-w1..w3`) in `fixtures/seed-clients.json` — every registered backchannel URL is called on every logout, so a shared client would spray logout tokens across parallel workers' test instances.
- `create-authhero`'s generated seed now passes `oidc_logout` through for extra clients (the conformance auth server is re-scaffolded from this template on every run).

⚠️ **Not yet run against the suite locally** — the runner needs port 3000, which is currently held by another dev server on my machine. `pnpm conformance:run tests/oidcc-backchannel-logout.spec.ts` once the port is free.

## Out of scope / follow-ups

- `backchannel_logout_initiators` is stored but not yet enforced — all session-end triggers notify (Auth0 `mode: all` behaviour).
- Session expiry (no request to hook) and user deletion don't notify.

## Tests

- 8 new tests in `packages/authhero/test/routes/auth-api/backchannel-logout.spec.ts` (token shape incl. no-nonce, all four triggers, per-client aud, SSRF policy).
- Full authhero suite: 1790 passed. Drizzle (85) and kysely (277) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenID Connect Back-Channel Logout 1.0 support.
  * Sends signed logout notifications to configured client endpoints when sessions are logged out, revoked, or deleted.
  * Supports session-based logout using the `sid` claim without requiring a browser cookie.
  * OIDC discovery metadata now advertises back-channel logout capabilities.
  * Added configuration support for back-channel logout URLs and initiators.
  * Added conformance coverage and local scaffolding support for the new settings.

* **Security**
  * Validates notification destinations to help prevent unsafe outbound requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->