### PR TITLE
fix: auth-server self-callback wildcards never matched

### DIFF
--- a/.changeset/fix-self-callback-wildcards.md
+++ b/.changeset/fix-self-callback-wildcards.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Fix the always-allowed auth-server self-callbacks in /authorize and /account. The issuer and universal-login wildcard entries were built by appending "/\*" to bases that already end in "/", producing patterns like `https://domain//*` whose path regex never matches a real pathname — so redirect URIs pointing back at the auth server itself (e.g. the /u2/info test screen on a custom domain or tenant subdomain) were rejected with "Invalid redirect URI". Also stop mutating client.callbacks when appending the wildcards.

--- a/packages/authhero/src/routes/auth-api/account.ts
+++ b/packages/authhero/src/routes/auth-api/account.ts
@@ -8,7 +8,10 @@ import { isCimdClientId } from "../../helpers/cimd";
 import { nanoid } from "nanoid";
 import { UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS } from "../../constants";
 import { stringifyAuth0Client } from "../../utils/client-info";
-import { getIssuer, getUniversalLoginUrl } from "../../variables";
+import {
+  getSelfCallbackWildcards,
+  getUniversalLoginUrl,
+} from "../../variables";
 import { verifyRequestOrigin } from "../../utils/request-origin";
 import { HTTPException } from "hono/http-exception";
 import { isValidRedirectUrl } from "../../utils/is-valid-redirect-url";
@@ -80,12 +83,11 @@ const getRoot = defineRoute({
     }
 
     if (authParams.redirect_uri) {
-      const validCallbacks = client.callbacks || [];
+      // Copy: pushing onto client.callbacks directly would mutate the client
+      const validCallbacks = [...(client.callbacks || [])];
       if (ctx.var.host) {
-        // Allow wildcard for the auth server
-        validCallbacks.push(`${getIssuer(ctx.env, ctx.var.custom_domain)}/*`);
         validCallbacks.push(
-          `${getUniversalLoginUrl(ctx.env, ctx.var.custom_domain)}/*`,
+          ...getSelfCallbackWildcards(ctx.env, ctx.var.custom_domain),
         );
       }
 

--- a/packages/authhero/src/routes/auth-api/authorize.ts
+++ b/packages/authhero/src/routes/auth-api/authorize.ts
@@ -25,7 +25,7 @@ import { resumeLoginSession } from "../../authentication-flows/resume";
 import { getEnrichedClient } from "../../helpers/client";
 import { prefetchClientBundle } from "../../helpers/prefetch-client-bundle";
 import { isCimdClientId } from "../../helpers/cimd";
-import { getIssuer, getUniversalLoginUrl } from "../../variables";
+import { getIssuer, getSelfCallbackWildcards } from "../../variables";
 import { formPostResponse } from "../../utils/form-post";
 import { setTenantId } from "../../helpers/set-tenant-id";
 import { defineRoute } from "../../utils/define-route";
@@ -552,12 +552,11 @@ const getRoot = defineRoute({
     };
 
     if (authParams.redirect_uri) {
-      const validCallbacks = client.callbacks || [];
+      // Copy: pushing onto client.callbacks directly would mutate the client
+      const validCallbacks = [...(client.callbacks || [])];
       if (ctx.var.host) {
-        // Allow wildcard for the auth server
-        validCallbacks.push(`${getIssuer(ctx.env, ctx.var.custom_domain)}/*`);
         validCallbacks.push(
-          `${getUniversalLoginUrl(ctx.env, ctx.var.custom_domain)}/*`,
+          ...getSelfCallbackWildcards(ctx.env, ctx.var.custom_domain),
         );
       }
 

--- a/packages/authhero/src/variables.ts
+++ b/packages/authhero/src/variables.ts
@@ -27,6 +27,23 @@ export function getUniversalLoginUrl(
   return `${env.ISSUER}${prefix}/`;
 }
 
+/**
+ * Wildcard callback entries that always allow redirecting back to the auth
+ * server itself (e.g. the /u/info and /u2/info test screens) without
+ * per-client registration. The bases usually end in "/", so normalize before
+ * appending "*" — a naive `${base}/*` yields a "//*" path whose wildcard
+ * regex never matches a real pathname.
+ */
+export function getSelfCallbackWildcards(
+  env: Bindings,
+  customDomain?: string,
+) {
+  return [
+    getIssuer(env, customDomain),
+    getUniversalLoginUrl(env, customDomain),
+  ].map((base) => `${base}${base.endsWith("/") ? "" : "/"}*`);
+}
+
 export function getAuthUrl(env: Bindings, customDomain?: string) {
   if (customDomain) {
     return `https://${customDomain}/`;

--- a/packages/authhero/test/routes/auth-api/authorize.spec.ts
+++ b/packages/authhero/test/routes/auth-api/authorize.spec.ts
@@ -214,6 +214,67 @@ describe("authorize", () => {
     expect(authorizationUrl.searchParams.get("firstName")).toEqual("firstName");
   });
 
+  describe("auth server self-callbacks", () => {
+    it("allows the auth server's own /u2/info as redirect_uri without client registration", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const oauthClient = testClient(oauthApp, env);
+
+      // Drop the fixture's registered localhost wildcard so the redirect can
+      // only be allowed by the auth server's own always-allowed callbacks.
+      await env.data.clients.update("tenantId", "clientId", {
+        callbacks: ["https://example.com/callback"],
+      });
+
+      // ISSUER is http://localhost:3000/ — /u2/info is not registered on the
+      // client, but redirects back to the auth server itself are always allowed.
+      const response = await oauthClient.authorize.$get({
+        query: {
+          client_id: "clientId",
+          redirect_uri: "http://localhost:3000/u2/info",
+          state: "state",
+          response_type: AuthorizationResponseType.CODE,
+        },
+      });
+
+      expect(response.status).toEqual(302);
+      const location = response.headers.get("location");
+      const redirectUri = new URL(location!, "http://localhost:3000");
+      expect(redirectUri.pathname).toEqual("/u/login/identifier");
+    });
+
+    it("allows /u2/info on a custom domain as redirect_uri without client registration", async () => {
+      const { oauthApp, env } = await getTestServer();
+      const oauthClient = testClient(oauthApp, env);
+
+      await env.data.customDomains.create("tenantId", {
+        domain: "auth.example.com",
+        custom_domain_id: "custom-domain-id",
+        type: "auth0_managed_certs",
+      });
+
+      const response = await oauthClient.authorize.$get(
+        {
+          query: {
+            client_id: "clientId",
+            redirect_uri: "https://auth.example.com/u2/info",
+            state: "state",
+            response_type: AuthorizationResponseType.CODE,
+          },
+        },
+        {
+          headers: {
+            host: "auth.example.com",
+          },
+        },
+      );
+
+      expect(response.status).toEqual(302);
+      const location = response.headers.get("location");
+      const redirectUri = new URL(location!, "https://auth.example.com");
+      expect(redirectUri.pathname).toEqual("/u/login/identifier");
+    });
+  });
+
   it("should redirect to the universal login when the only connection is a database connection with strategy auth0", async () => {
     const { oauthApp, env } = await getTestServer();
     const oauthClient = testClient(oauthApp, env);


### PR DESCRIPTION
## Problem

Using the auth server's own test screen as a callback — e.g. `https://wfp.token.sesamy.dev/u2/info` — fails with `Invalid redirect URI`, even though `/authorize` (and `/account`) are supposed to always allow redirects back to the auth server itself without per-client registration.

## Cause

The always-allowed entries were built by appending `/*` to `getIssuer()` / `getUniversalLoginUrl()`, which already return bases ending in `/`. The result was patterns like `https://domain//*` and `https://domain/u//*`, whose path-wildcard regexes (`^\/\/.*$`, `^\/u\/\/.*$`) only match paths literally starting with `//` — i.e. never. On custom domains and tenant subdomains the issuer always ends in `/`, so the self-callback allowance was effectively dead.

## Fix

- New `getSelfCallbackWildcards()` helper in `variables.ts` normalizes the trailing slash before appending `*`, and both call sites (`authorize.ts`, `account.ts`) use it.
- The call sites also copied `client.callbacks` before pushing — previously they mutated the client object's array on every request.
- Two regression tests: `/u2/info` as redirect_uri on the plain issuer (with the fixture's registered localhost wildcard removed so only the auto-allow can pass it) and on a registered custom domain. Both returned 400 before the fix.

Changeset included (patch, `authhero`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed redirect validation for auth-server self-callback URLs, including wildcard paths and custom domains.
  - Self-referential redirects now correctly proceed to the universal login flow instead of being rejected as invalid.
  - Improved handling of redirect callback entries without altering existing client configuration.

- **Tests**
  - Added coverage for default and custom auth-domain self-callback redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->