### PR TITLE
fix: management API user creation 403s when token azp is not a client in the target tenant

### DIFF
--- a/.changeset/mgmt-user-create-azp-client.md
+++ b/.changeset/mgmt-user-create-azp-client.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Fix management API user creation returning 403 "Client not found" when the token's `azp` claim names a client that doesn't exist in the target tenant (e.g. control-plane dashboard tokens against WFP tenants). A non-resolving `client_id` is now treated as a management call — signup validation only runs when the client actually exists in the tenant, matching Auth0's behavior of bypassing signup restrictions for management API user creation.

--- a/packages/authhero/src/hooks/user-registration.ts
+++ b/packages/authhero/src/hooks/user-registration.ts
@@ -45,20 +45,33 @@ export function createUserHooks(
   data: DataAdapters,
 ) {
   return async (tenant_id: string, user: User) => {
-    // Get the client_id from context if available (auth flows)
-    // Management API calls won't have client_id, so skip validation in that case
+    // `ctx.var.client_id` is set by auth flows (after validating the client)
+    // but also by the management authentication middleware from the token's
+    // `azp` claim, which names a client in the issuing tenant — one that may
+    // not exist in the target tenant (#1123). Only treat it as an auth-flow
+    // signup when the client actually resolves in this tenant; a miss means
+    // a management call, which skips signup validation (matching Auth0).
     if (ctx.var.client_id) {
-      const client = await getEnrichedClient(
-        ctx.env,
-        ctx.var.client_id,
-        ctx.var.tenant_id,
-      );
+      const tenantClient = await data.clients.get(tenant_id, ctx.var.client_id);
+      if (tenantClient) {
+        const client = await getEnrichedClient(
+          ctx.env,
+          ctx.var.client_id,
+          ctx.var.tenant_id,
+        );
 
-      // Call preUserSignupHook BEFORE any user creation logic
-      // This ensures ALL signup methods (email, code, social) are checked
-      // Only validate email-based signups (skip SMS/phone-based signups)
-      if (user.email) {
-        await preUserSignupHook(ctx, client, data, user.email, user.connection);
+        // Call preUserSignupHook BEFORE any user creation logic
+        // This ensures ALL signup methods (email, code, social) are checked
+        // Only validate email-based signups (skip SMS/phone-based signups)
+        if (user.email) {
+          await preUserSignupHook(
+            ctx,
+            client,
+            data,
+            user.email,
+            user.connection,
+          );
+        }
       }
     }
 

--- a/packages/authhero/test/helpers/token.ts
+++ b/packages/authhero/test/helpers/token.ts
@@ -34,6 +34,10 @@ export interface CreateTokenParams {
   scope?: string;
   permissions?: string[];
   aud?: string;
+  // Authorized party — the client the token was issued to. Auth0 sets this
+  // on client-credentials tokens; the management middleware copies it into
+  // ctx.var.client_id.
+  azp?: string;
   // OIDC Core 5.5 — list of claim names the original /authorize request
   // asked for under `claims.userinfo`. Tests use this to exercise the
   // `requested_userinfo_claims` access-token slot end-to-end.
@@ -53,6 +57,7 @@ export async function createToken(params?: CreateTokenParams) {
       sub: params?.user_id || "userId",
       iss: "http://localhost:3000/",
       tenant_id: params?.tenant_id,
+      ...(params?.azp ? { azp: params.azp } : {}),
       ...(params?.requested_userinfo_claims
         ? { requested_userinfo_claims: params.requested_userinfo_claims }
         : {}),
@@ -165,9 +170,10 @@ const ADMIN_PERMISSIONS = [
   "update:users",
 ];
 
-export async function getAdminToken() {
+export async function getAdminToken(overrides?: Partial<CreateTokenParams>) {
   return createToken({
     permissions: ADMIN_PERMISSIONS,
     aud: MANAGEMENT_API_AUDIENCE,
+    ...overrides,
   });
 }

--- a/packages/authhero/test/routes/management-api/users.spec.ts
+++ b/packages/authhero/test/routes/management-api/users.spec.ts
@@ -81,6 +81,38 @@ describe("users management API endpoint", () => {
       expect(duplicatedCreateUserRequest.status).toBe(409);
     });
 
+    it("should create a user when the token's azp is not a client in the target tenant", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+
+      // Management tokens carry the calling application in `azp` (Auth0's
+      // client-credentials shape). That client lives in the issuing tenant —
+      // e.g. a dashboard client on the control plane — and may not exist in
+      // the target tenant. This used to 403 with "Client not found" (#1123).
+      const token = await getAdminToken({ azp: "client-from-another-tenant" });
+
+      const createUserResponse = await managementClient.users.$post(
+        {
+          json: {
+            email: "azp-user@example.com",
+            connection: "email",
+          },
+          header: {
+            "tenant-id": "tenantId",
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      expect(createUserResponse.status).toBe(201);
+      const newUser = await createUserResponse.json();
+      expect(newUser.email).toBe("azp-user@example.com");
+    });
+
     it("should create a new user for an empty tenant", async () => {
       const token = await getAdminToken();
 


### PR DESCRIPTION
## Summary

Fixes #1123.

`POST /api/v2/users` failed with `403 {"message":"Client not found"}` on any tenant that doesn't contain a client whose id equals the management token's `azp` claim — which broke user creation on all WFP (per-tenant D1) tenants, since their clients have generated ids.

The management authentication middleware copies the token's `azp` into `ctx.var.client_id`, but `createUserHooks` assumed a set `client_id` meant an auth flow and passed it to `getEnrichedClient`, which hard-fails when the client doesn't exist in the target tenant. The `azp` of a management token names a client in the *issuing* tenant (e.g. a control-plane dashboard client), so that assumption is wrong by construction.

## Fix

Resolve the client tolerantly with `clients.get` first and only run `getEnrichedClient` + `preUserSignupHook` when the client actually exists in the target tenant:

- **Management calls** whose `azp` doesn't resolve now skip signup validation (matching Auth0, where management API user creation bypasses signup restrictions).
- **Auth flows are unaffected**: every auth flow validates its client before setting `ctx.var.client_id`, so the lookup always resolves there and signup validation runs exactly as before (covered by the existing `signup-validation.spec.ts` suite).
- This mirrors the tolerant pattern `builtInUserLinkingEnabled` already uses a few lines below.

Note: on tenants where a management token's `azp` *does* coincidentally resolve to a tenant client (e.g. legacy tenants with vendor-named clients), signup validation still runs — deciding whether management calls should bypass it entirely is left as a follow-up.

## Testing

- New regression test: management token with `azp` not present in the target tenant → user creation returns 201 (fails with 403 before the fix).
- `users.spec.ts`, `signup-validation.spec.ts`, `on-pre-user-registration.spec.ts`, `account-linking.spec.ts` all pass (66 tests).
- Test helper `createToken` gained an optional `azp` param; `getAdminToken` accepts overrides.

Includes a patch changeset for `authhero`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed management API user creation returning a 403 “Client not found” error when the access token references a client from another tenant.
  - User creation now succeeds in this scenario while preserving signup validation for valid tenant clients.

- **Tests**
  - Added coverage confirming successful email-user creation with an external client reference in the access token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->