### PR TITLE
feat(admin): expose more user fields as toggleable columns in users list

### DIFF
--- a/.changeset/users-list-more-columns.md
+++ b/.changeset/users-list-more-columns.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": minor
+---
+
+Expose more user fields as toggleable columns in the users list. The table previously offered only email, phone number, connection, login count and last login; it now also defines user_id, name, username, given/family name, nickname, email verified, provider, locale, birthdate, address, last IP, created_at and updated_at. The new columns are hidden by default and can be enabled per user via the existing Columns button. birthdate and address are not sortable because the management API's user sort allowlist does not include them.

--- a/apps/admin/src/resources/users/list.tsx
+++ b/apps/admin/src/resources/users/list.tsx
@@ -1,6 +1,13 @@
-import { List, DataTable, TextInput } from "@/components/admin";
+import {
+  List,
+  DataTable,
+  TextInput,
+  DateField,
+  BooleanField,
+} from "@/components/admin";
 import { useRecordContext } from "ra-core";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { Address } from "@authhero/adapter-interfaces";
 
 const filters = [
   <TextInput key="email" source="email" label="Email" />,
@@ -28,10 +35,46 @@ function UserAvatarCell() {
   );
 }
 
+function AddressCell() {
+  const record = useRecordContext<{ address?: Address }>();
+  const address = record?.address;
+  if (!address) return null;
+  return (
+    address.formatted ||
+    [
+      address.street_address,
+      address.postal_code,
+      address.locality,
+      address.region,
+      address.country,
+    ]
+      .filter(Boolean)
+      .join(", ")
+  );
+}
+
+// Columns hidden by default; users opt in via the Columns selector.
+const DEFAULT_HIDDEN_COLUMNS = [
+  "user_id",
+  "name",
+  "username",
+  "given_name",
+  "family_name",
+  "nickname",
+  "email_verified",
+  "provider",
+  "locale",
+  "birthdate",
+  "address",
+  "last_ip",
+  "created_at",
+  "updated_at",
+];
+
 export function UsersList() {
   return (
     <List filters={filters} sort={{ field: "user_id", order: "DESC" }}>
-      <DataTable rowClick="edit">
+      <DataTable rowClick="edit" hiddenColumns={DEFAULT_HIDDEN_COLUMNS}>
         <DataTable.Col label="">
           <UserAvatarCell />
         </DataTable.Col>
@@ -40,6 +83,30 @@ export function UsersList() {
         <DataTable.Col source="connection" />
         <DataTable.Col source="login_count" />
         <DataTable.Col source="last_login" label="Last login" />
+        <DataTable.Col source="user_id" label="User ID" />
+        <DataTable.Col source="name" />
+        <DataTable.Col source="username" />
+        <DataTable.Col source="given_name" label="Given name" />
+        <DataTable.Col source="family_name" label="Family name" />
+        <DataTable.Col source="nickname" />
+        <DataTable.Col source="email_verified" label="Email verified">
+          <BooleanField source="email_verified" />
+        </DataTable.Col>
+        <DataTable.Col source="provider" />
+        <DataTable.Col source="locale" />
+        {/* birthdate and address are not in the adapters' ALLOWED_Q_FIELDS,
+            so the API cannot sort on them */}
+        <DataTable.Col source="birthdate" disableSort />
+        <DataTable.Col source="address" disableSort>
+          <AddressCell />
+        </DataTable.Col>
+        <DataTable.Col source="last_ip" label="Last IP" />
+        <DataTable.Col source="created_at" label="Created">
+          <DateField source="created_at" showTime />
+        </DataTable.Col>
+        <DataTable.Col source="updated_at" label="Updated">
+          <DateField source="updated_at" showTime />
+        </DataTable.Col>
       </DataTable>
     </List>
   );


### PR DESCRIPTION
## Summary

The users list in the admin UI only rendered six columns (avatar, email, phone number, connection, login count, last login), even though the management API returns the full user object.

- Add `user_id`, `name`, `username`, `given_name`, `family_name`, `nickname`, `email_verified`, `provider`, `locale`, `birthdate`, `address`, `last_ip`, `created_at` and `updated_at` as columns.
- All new columns are hidden by default and toggled via the Columns button already in the list toolbar (same pattern as the logs table); the selection persists per browser via the ra-core store.
- `created_at`/`updated_at` render with `DateField showTime`, `email_verified` with `BooleanField`, and `address` via a small cell that shows the OIDC `formatted` value or composes the address parts.
- `birthdate` and `address` are marked `disableSort` since they are not in the users `ALLOWED_Q_FIELDS` sort allowlist in either the drizzle or kysely adapter. All other columns sort server-side.

Includes a minor changeset for `@authhero/admin`.

## Test plan

- `tsc --noEmit` passes in `apps/admin`.
- Full pre-commit suite: 1795 tests passed; the only failure was the terraform-provider smoke test, which failed on a registry download timeout (external network flake, unrelated to this change).
- Manual: open the users list, click the Columns button, enable e.g. Created/Updated, and verify sorting works on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)