### PR TITLE
fix: apply q filter to totals count in drizzle tenants list

### DIFF
--- a/.changeset/drizzle-tenants-count-respects-q.md
+++ b/.changeset/drizzle-tenants-count-respects-q.md
@@ -1,0 +1,5 @@
+---
+"@authhero/drizzle": patch
+---
+
+Apply the `q` filter to the totals count in the tenants adapter's list method. Previously `include_totals` returned the full table count even when `q` filtered the rows.

--- a/packages/drizzle/src/adapters/tenants.ts
+++ b/packages/drizzle/src/adapters/tenants.ts
@@ -135,12 +135,13 @@ export function createTenantsAdapter(db: DrizzleDb) {
         q,
       } = params || {};
 
+      const filter = q
+        ? buildLuceneFilter(tenants, q, ["friendly_name"])
+        : undefined;
+
       let query = db.select().from(tenants).$dynamic();
 
-      if (q) {
-        const filter = buildLuceneFilter(tenants, q, ["friendly_name"]);
-        if (filter) query = query.where(filter);
-      }
+      if (filter) query = query.where(filter);
 
       if (sort?.sort_by) {
         const col = (tenants as any)[sort.sort_by];
@@ -158,7 +159,14 @@ export function createTenantsAdapter(db: DrizzleDb) {
         return { tenants: mappedTenants };
       }
 
-      const [countResult] = await db.select({ count: countFn() }).from(tenants);
+      let countQuery = db
+        .select({ count: countFn() })
+        .from(tenants)
+        .$dynamic();
+
+      if (filter) countQuery = countQuery.where(filter);
+
+      const [countResult] = await countQuery;
 
       return {
         tenants: mappedTenants,

--- a/packages/drizzle/test/adapters/tenants.test.ts
+++ b/packages/drizzle/test/adapters/tenants.test.ts
@@ -33,6 +33,42 @@ describe("tenants adapter", () => {
     expect(result.tenants.length).toBe(2);
   });
 
+  it("should apply the q filter to totals", async () => {
+    await data.tenants.create({
+      id: "t1",
+      name: "Tenant 1",
+      friendly_name: "Acme",
+    });
+    await data.tenants.create({
+      id: "t2",
+      name: "Tenant 2",
+      friendly_name: "Acme Corp",
+    });
+    await data.tenants.create({
+      id: "t3",
+      name: "Tenant 3",
+      friendly_name: "Other",
+    });
+
+    const freeText = await data.tenants.list({
+      page: 0,
+      per_page: 1,
+      include_totals: true,
+      q: "Acme",
+    });
+    expect(freeText.tenants.length).toBe(1);
+    expect(freeText.length).toBe(2);
+
+    const excludeId = await data.tenants.list({
+      page: 0,
+      per_page: 10,
+      include_totals: true,
+      q: "-id:t3",
+    });
+    expect(excludeId.tenants.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
+    expect(excludeId.length).toBe(2);
+  });
+
   it("should update a tenant", async () => {
     await data.tenants.create({ id: "t1", name: "Original" });
     await data.tenants.update("t1", { name: "Updated" });


### PR DESCRIPTION
## Summary

The `include_totals` count in the drizzle tenants adapter's `list()` counted the whole table regardless of `q`, so filtered lists returned the unfiltered total. This builds the Lucene filter once and applies it to both the row query and the count query, matching the pattern the organizations adapter already uses.

No sanitization was added: the tenants table has no tenant-boundary column to protect, and field-qualified clauses like `-id:...` are legitimately useful for consumers that need to exclude a seeded control-plane row at query level.

## Changes

- `packages/drizzle/src/adapters/tenants.ts` — build the filter once, apply it to both the row query and the totals count
- `packages/drizzle/test/adapters/tenants.test.ts` — new test covering free-text `q` totals and `-id:` exclusion (rows + totals)
- changeset: patch for `@authhero/drizzle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant list totals now respect search filters when totals are requested.
  * Result counts accurately reflect the filtered tenant list, including exclusions.

* **Tests**
  * Added coverage for matching and exclusion-based tenant searches with filtered totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->