### PR TITLE
fix(admin): removing an organization member hit /organizations/org/members (404)

### DIFF
--- a/.changeset/admin-org-member-remove-404.md
+++ b/.changeset/admin-org-member-remove-404.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": patch
+---
+
+Fix removing an organization member failing with a 404. The data provider split the delete record id on `_` to recover a composite `<orgId>_<userId>` id, but organization ids themselves start with `org_`, so the request was sent to `/organizations/org/members` with a mangled user id. The organization id and member ids are now always resolved from the record fields in `previousData`.

--- a/apps/admin/src/auth0DataProvider.ts
+++ b/apps/admin/src/auth0DataProvider.ts
@@ -6,6 +6,7 @@ import {
   EMAIL_TEMPLATE_DEFINITIONS,
   getTemplateLabel,
 } from "./resources/email-templates/template-names";
+import { resolveOrganizationMemberDeletion } from "./utils/organizationMembers";
 
 function isNotFoundError(err: unknown): boolean {
   return (
@@ -2383,25 +2384,8 @@ export default (
 
       // Organization members
       if (resource === "organization-members") {
-        let organization_id, user_ids;
-
-        if (params.previousData?.members) {
-          organization_id = params.id;
-          user_ids = params.previousData.members;
-        } else if (typeof params.id === "string" && params.id.includes("_")) {
-          [organization_id, ...user_ids] = params.id.split("_");
-        } else if (params.previousData) {
-          organization_id = params.previousData.organization_id || params.id;
-          user_ids = params.previousData.user_ids || [
-            params.previousData.user_id,
-          ];
-        }
-
-        if (!organization_id || !user_ids || user_ids.length === 0) {
-          throw new Error(
-            "Missing organization_id or user_id(s) for organization member deletion",
-          );
-        }
+        const { organization_id, user_ids } =
+          resolveOrganizationMemberDeletion(params);
 
         const res = await del(`organizations/${organization_id}/members`, {
           members: user_ids,

--- a/apps/admin/src/utils/organizationMembers.test.ts
+++ b/apps/admin/src/utils/organizationMembers.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { resolveOrganizationMemberDeletion } from "./organizationMembers";
+
+describe("resolveOrganizationMemberDeletion", () => {
+  it("uses organization_id and user_ids from previousData", () => {
+    // The members tab passes the org id both as `id` and in `previousData`.
+    expect(
+      resolveOrganizationMemberDeletion({
+        id: "org_ugr0po77ljtd2il57",
+        previousData: {
+          organization_id: "org_ugr0po77ljtd2il57",
+          user_id: "google-oauth2|108791004671072817794",
+          user_ids: ["google-oauth2|108791004671072817794"],
+        },
+      }),
+    ).toEqual({
+      organization_id: "org_ugr0po77ljtd2il57",
+      user_ids: ["google-oauth2|108791004671072817794"],
+    });
+  });
+
+  it("does not split an org_-prefixed id on underscores", () => {
+    // Regression: org ids start with `org_`, so an id-splitting heuristic
+    // turned `org_6hse0jwqa0utzacrh` into organization `org` + user
+    // `6hse0jwqa0utzacrh`, producing DELETE /organizations/org/members (404).
+    expect(
+      resolveOrganizationMemberDeletion({
+        id: "org_6hse0jwqa0utzacrh",
+        previousData: {
+          organization_id: "org_6hse0jwqa0utzacrh",
+          user_ids: ["auth0|user1"],
+        },
+      }),
+    ).toEqual({
+      organization_id: "org_6hse0jwqa0utzacrh",
+      user_ids: ["auth0|user1"],
+    });
+  });
+
+  it("prefers an explicit members list", () => {
+    expect(
+      resolveOrganizationMemberDeletion({
+        id: "org_abc",
+        previousData: {
+          members: ["auth0|user1", "auth0|user2"],
+          user_id: "auth0|ignored",
+        },
+      }),
+    ).toEqual({
+      organization_id: "org_abc",
+      user_ids: ["auth0|user1", "auth0|user2"],
+    });
+  });
+
+  it("falls back to a single user_id", () => {
+    expect(
+      resolveOrganizationMemberDeletion({
+        id: "org_abc",
+        previousData: { user_id: "auth0|user1" },
+      }),
+    ).toEqual({
+      organization_id: "org_abc",
+      user_ids: ["auth0|user1"],
+    });
+  });
+
+  it("throws when no user ids can be resolved", () => {
+    expect(() =>
+      resolveOrganizationMemberDeletion({
+        id: "org_abc",
+        previousData: {},
+      }),
+    ).toThrow(/Missing organization_id or user_id/);
+  });
+});

--- a/apps/admin/src/utils/organizationMembers.ts
+++ b/apps/admin/src/utils/organizationMembers.ts
@@ -1,0 +1,43 @@
+function stringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => typeof item === "string")
+    ? value
+    : undefined;
+}
+
+/**
+ * Resolves the organization id and member user ids for a
+ * `dataProvider.delete("organization-members", ...)` call.
+ *
+ * The record id is never parsed: member list records use a
+ * `${organization_id}_${user_id}` composite id, but organization ids
+ * themselves contain underscores (`org_...`), so splitting on `_` shreds the
+ * organization id (e.g. `org_abc` became organization `org` + user `abc`,
+ * yielding a 404). The record fields in `previousData` are authoritative.
+ */
+export function resolveOrganizationMemberDeletion(params: {
+  id: string | number;
+  previousData?: Record<string, unknown>;
+}): { organization_id: string; user_ids: string[] } {
+  const previous = params.previousData;
+
+  const organization_id =
+    typeof previous?.organization_id === "string" && previous.organization_id
+      ? previous.organization_id
+      : String(params.id);
+  const user_ids =
+    stringArray(previous?.members) ??
+    stringArray(previous?.user_ids) ??
+    (typeof previous?.user_id === "string" && previous.user_id
+      ? [previous.user_id]
+      : []);
+
+  if (!organization_id || user_ids.length === 0) {
+    throw new Error(
+      "Missing organization_id or user_id(s) for organization member deletion",
+    );
+  }
+
+  return { organization_id, user_ids };
+}


### PR DESCRIPTION
## Problem

Removing a member from an organization in the admin UI always failed with a 404. The request left the browser as:

```
DELETE /api/v2/organizations/org/members
{"members":["6hse0jwqa0utzacrh"]}
```

The data provider's `organization-members` delete branch tried to recover a composite `<orgId>_<userId>` record id by splitting `params.id` on `_` — before checking `previousData`. Since every organization id starts with `org_`, the split always matched and shredded the real org id (`org_6hse0jwqa0utzacrh` → organization `org` + "user" `6hse0jwqa0utzacrh`). The server correctly 404s on organization `org`; even if it hadn't, the request would have targeted the wrong user id.

## Fix

- Resolve the organization id and member user ids from the record fields in `previousData`, which every caller supplies (the members tab passes `organization_id`/`user_ids`, and member list records include both fields). The id-splitting heuristic is removed — it can never distinguish an org id from a composite id given the `org_` prefix.
- Extract the resolution into a pure helper (`src/utils/organizationMembers.ts`) with unit tests, including a regression test for the `org_`-prefix case.

No server-side changes; `DELETE /organizations/{id}/members` was working all along.

## Testing

- `pnpm admin test` — 30 passed (5 new)
- `tsc --noEmit` clean in `apps/admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed organization-member deletion failures, including cases involving organization IDs with underscores.
  - Improved member identification during deletion when records contain explicit organization or member details.

- **Security**
  - Updated security-sensitive dependencies to address XML parsing, serialization, SQL injection, denial-of-service, and CORS-related issues.

- **Tests**
  - Added coverage for organization-member deletion data resolution and regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->