### PR TITLE
fix(saml): migrate fast-xml-parser from v4 to v5

### DIFF
--- a/.changeset/saml-fast-xml-parser-v5.md
+++ b/.changeset/saml-fast-xml-parser-v5.md
@@ -1,0 +1,5 @@
+---
+"@authhero/saml": patch
+---
+
+Migrate from fast-xml-parser v4 to v5 (^5.7.0). Resolves the remaining Dependabot alert (XMLBuilder XML comment/CDATA injection via unescaped delimiters), which is only patched on the v5 line. No API changes: parser options and the preserveOrder builder structures are unchanged between v4 and v5.

--- a/packages/saml/package.json
+++ b/packages/saml/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@authhero/adapter-interfaces": "workspace:*",
-    "fast-xml-parser": "^4.5.5",
+    "fast-xml-parser": "^5.7.0",
     "nanoid": "^5.1.11"
   },
   "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1162,8 +1162,8 @@ importers:
         specifier: workspace:*
         version: link:../adapter-interfaces
       fast-xml-parser:
-        specifier: ^4.5.5
-        version: 4.5.7
+        specifier: ^5.7.0
+        version: 5.10.0
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11
@@ -5250,9 +5250,6 @@ packages:
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
 
-  '@types/node@20.19.43':
-    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
-
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
@@ -7080,10 +7077,6 @@ packages:
 
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
-
-  fast-xml-parser@4.5.7:
-    resolution: {integrity: sha512-a6Qh1RMCNbSrU1+sAyAAZH3rTe+OaWJbNZIq0S+ifZciUUOQtlVxBJwoTUE2bYhysmG/RYyI5WJFIKdBahJdrQ==}
-    hasBin: true
 
   fast-xml-parser@5.10.0:
     resolution: {integrity: sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==}
@@ -10085,9 +10078,6 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
-  strnum@1.1.2:
-    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
   strnum@2.4.1:
     resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
@@ -15075,11 +15065,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@20.19.43':
-    dependencies:
-      undici-types: 6.21.0
-    optional: true
-
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
@@ -16022,7 +16007,7 @@ snapshots:
 
   bun-types@1.3.5:
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 22.19.19
     optional: true
 
   bundle-name@4.1.0:
@@ -17367,10 +17352,6 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.6.2
       xml-naming: 0.3.0
-
-  fast-xml-parser@4.5.7:
-    dependencies:
-      strnum: 1.1.2
 
   fast-xml-parser@5.10.0:
     dependencies:
@@ -21124,8 +21105,6 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
-
-  strnum@1.1.2: {}
 
   strnum@2.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

Migrates `@authhero/saml` from fast-xml-parser `^4.5.5` to `^5.7.0` (resolves to 5.10.0), closing #1126.

PR #1125 cleared the critical/high alerts on the v4 line, but one medium Dependabot alert remained: **XMLBuilder XML Comment and CDATA Injection via Unescaped Delimiters**, which is only patched in fast-xml-parser 5.7.0 — there is no fix on 4.x.

## Why this is safe

- The v5.0.0 changelog states the major bump added ESM support with **no change in functionality, syntax, APIs, or options**; later 5.x releases add the sanitization hardening we want (5.7.0 sanitizes malicious CDATA/comment content, 5.8.0 sanitizes invalid tag names).
- The package's usage surface is small: one `XMLParser` (SAML request parsing in `parseSamlRequestQuery`) and two `XMLBuilder`s (metadata build, `preserveOrder` response build) in `packages/saml/src/helpers.ts`. All options used are unchanged in v5.
- The core `authhero` package already uses fast-xml-parser `^5.7.0`.

## Verification

- `@authhero/saml` unit tests (metadata + response building, attribute structure): **6/6 passed**
- `packages/authhero` SAML integration spec `test/routes/saml/samlp.spec.ts` (exercises request parsing end-to-end): **5/5 passed**
- Package builds cleanly (all four bundle configs + dts)

Changeset included (patch, `@authhero/saml`).

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the XML parsing library to address a security vulnerability involving comment and CDATA injection.
  * No API changes; existing parser options and behavior remain compatible.

* **Chores**
  * Released a patch update for the SAML package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->