### PR TITLE
feat(users): checkpoint pagination (from/take + opaque next) on GET /users; default page size 50

### DIFF
--- a/.changeset/users-checkpoint-pagination.md
+++ b/.changeset/users-checkpoint-pagination.md
@@ -1,0 +1,14 @@
+---
+"authhero": minor
+"@authhero/kysely-adapter": minor
+"@authhero/drizzle": minor
+"@authhero/adapter-interfaces": minor
+---
+
+feat(pagination): checkpoint (from/take + opaque next cursor) on GET /users, and align the default page size with Auth0 (#1098)
+
+- `GET /users` now supports keyset (checkpoint) pagination via `from`/`take`, returning `{ users, next }` with an opaque cursor that is absent on the last page. This is a deliberate superset of Auth0, which only offers offset paging on /users and caps it at 1000 results — full-tenant walks no longer need export jobs. Offset paging (`page`/`per_page` + totals) is unchanged.
+- In checkpoint mode, `q` filters stay in effect and `created_at` asc/desc is sortable (`user_id` is the unique tiebreaker). The cursor records the sort it was minted under; replaying it with a different sort returns 400. Unsupported sort columns return 400.
+- Linked accounts remain folded into their primary user's `identities` during cursor walks and never appear as top-level rows.
+- The default page size for offset pagination is now 50 (was 10), matching Auth0's documented default. Requests that pass an explicit `per_page` are unaffected.
+- kysely: the shared keyset helper now accepts table-qualified sort/id columns for queries with joins.

--- a/packages/adapter-interfaces/src/types/auth0/Query.ts
+++ b/packages/adapter-interfaces/src/types/auth0/Query.ts
@@ -14,10 +14,11 @@ export const auth0QuerySchema = z.object({
     .string()
     .min(1)
     .optional()
-    .default("10")
+    // Auth0's documented default page size is 50 (max 100).
+    .default("50")
     .transform((p) => parseInt(p, 10))
     .openapi({
-      description: "The number of items per page",
+      description: "The number of items per page. Defaults to 50.",
     }),
   include_totals: z
     .string()

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -60,6 +60,14 @@ const usersWithTotalsSchema = totalsSchema.extend({
   users: z.array(auth0UserResponseSchema),
 });
 
+// Checkpoint (keyset) pagination response: items plus an opaque cursor.
+const usersWithNextSchema = z.object({
+  users: z.array(auth0UserResponseSchema),
+  next: z.string().optional().openapi({
+    description: "Opaque cursor for the next page; absent on the last page.",
+  }),
+});
+
 const sessionsWithTotalsSchema = totalsSchema.extend({
   sessions: z.array(sessionSchema),
 });
@@ -112,6 +120,7 @@ const getRoot = defineRoute({
             schema: z.union([
               z.array(auth0UserResponseSchema),
               usersWithTotalsSchema,
+              usersWithNextSchema,
             ]),
           },
         },
@@ -120,7 +129,8 @@ const getRoot = defineRoute({
     },
   }),
   handler: async (ctx) => {
-    const { page, per_page, include_totals, sort, q } = ctx.req.valid("query");
+    const { page, per_page, include_totals, sort, q, from, take } =
+      ctx.req.valid("query");
     const issuer = getIssuer(ctx.env, ctx.var.custom_domain);
 
     // ugly hardcoded switch for now!
@@ -176,11 +186,25 @@ const getRoot = defineRoute({
       include_totals,
       sort: parseSort(sort),
       q: query.join(" "),
+      from,
+      take,
     });
 
     const primarySqlUsers = result.users
       .filter((user) => !user.linked_to)
       .map((user) => withDefaultPicture(user, issuer));
+
+    // Keyset (checkpoint) pagination: return the { items, next } shape so
+    // callers can page past the first page via the opaque cursor. A superset
+    // of Auth0, which only offers offset (capped at 1000 results) on /users.
+    if (from !== undefined || take !== undefined) {
+      return ctx.json(
+        usersWithNextSchema.parse({
+          users: primarySqlUsers,
+          next: result.next,
+        }),
+      );
+    }
 
     if (include_totals) {
       return ctx.json(

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -150,6 +150,10 @@ const getRoot = defineRoute({
       // Assuming there is only one result here. Not very defensive programming!
       const [linkedAccount] = linkedAccounts;
       if (!linkedAccount) {
+        // Keyset callers expect the { users, next } shape even here.
+        if (from !== undefined || take !== undefined) {
+          return ctx.json(usersWithNextSchema.parse({ users: [] }));
+        }
         return ctx.json([]);
       }
 
@@ -167,11 +171,15 @@ const getRoot = defineRoute({
         });
       }
 
-      return ctx.json([
-        auth0UserResponseSchema.parse(
-          withDefaultPicture(primaryAccount, issuer),
-        ),
-      ]);
+      const primaryUser = auth0UserResponseSchema.parse(
+        withDefaultPicture(primaryAccount, issuer),
+      );
+      // Keyset callers expect the { users, next } shape; a single primary
+      // user is always the full result, so no next cursor.
+      if (from !== undefined || take !== undefined) {
+        return ctx.json(usersWithNextSchema.parse({ users: [primaryUser] }));
+      }
+      return ctx.json([primaryUser]);
     }
 
     // Filter out linked users

--- a/packages/authhero/src/types/auth0/Query.ts
+++ b/packages/authhero/src/types/auth0/Query.ts
@@ -14,7 +14,8 @@ export const querySchema = z.object({
     .string()
     .min(1)
     .optional()
-    .default("10")
+    // Auth0's documented default page size is 50 (max 100).
+    .default("50")
     .transform((p) => parseInt(p, 10))
     .openapi({
       description: "Number of results per page. Defaults to 50.",

--- a/packages/authhero/test/adapters/encrypted-adapter.spec.ts
+++ b/packages/authhero/test/adapters/encrypted-adapter.spec.ts
@@ -281,8 +281,11 @@ describe("createEncryptedDataAdapter", () => {
       enabled: true,
       credentials: { api_key: "k1" },
     });
+    // The plaintext must be long enough that random base64 ciphertext can't
+    // contain it by chance — a 2-char secret like "k2" flakes ~1% of runs.
+    const updatedKey = "updated-secret-api-key";
     await ctx.data.emailProviders.update("t1", {
-      credentials: { api_key: "k2" },
+      credentials: { api_key: updatedKey },
     });
 
     const raw = await ctx.db
@@ -290,10 +293,10 @@ describe("createEncryptedDataAdapter", () => {
       .select("credentials")
       .where("tenant_id", "=", "t1")
       .executeTakeFirst();
-    expect(String(raw?.credentials)).not.toContain("k2");
+    expect(String(raw?.credentials)).not.toContain(updatedKey);
     expect(String(raw?.credentials)).toContain(ENC_PREFIX);
     expect((await ctx.data.emailProviders.get("t1"))?.credentials.api_key).toBe(
-      "k2",
+      updatedKey,
     );
   });
 

--- a/packages/authhero/test/routes/management-api/users.spec.ts
+++ b/packages/authhero/test/routes/management-api/users.spec.ts
@@ -1335,6 +1335,75 @@ describe("users management API endpoint", () => {
       expect(body.length).toBe(0);
     });
 
+    // Checkpoint (keyset) pagination — a superset of Auth0, which only
+    // offers offset paging (capped at 1000 results) on /users.
+    it("pages users with take/from and an opaque next cursor", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      const tenantId = "checkpoint-users-tenant";
+      await env.data.tenants.create({
+        id: tenantId,
+        friendly_name: "Checkpoint Users Tenant",
+        audience: "https://example.com",
+        sender_email: "login@example.com",
+        sender_name: "SenderName",
+      });
+      for (let i = 0; i < 12; i++) {
+        await env.data.users.create(tenantId, {
+          user_id: `email|cp-${i.toString().padStart(2, "0")}`,
+          email: `cp-${i.toString().padStart(2, "0")}@example.com`,
+          email_verified: true,
+          connection: "email",
+          provider: "email",
+          is_social: false,
+        });
+      }
+
+      const seen = new Set<string>();
+      let from: string | undefined;
+      let pages = 0;
+
+      for (;;) {
+        const response = await managementClient.users.$get(
+          {
+            query: from ? { take: "5", from } : { take: "5" },
+            header: {
+              "tenant-id": tenantId,
+            },
+          },
+          {
+            headers: {
+              authorization: `Bearer ${token}`,
+            },
+          },
+        );
+        expect(response.status).toBe(200);
+
+        const body = (await response.json()) as {
+          users: { user_id: string }[];
+          next?: string;
+        };
+        pages++;
+        // Checkpoint responses are { users, next }, not a bare array and
+        // not the offset totals shape.
+        expect(Array.isArray(body.users)).toBe(true);
+        expect("start" in body).toBe(false);
+        for (const user of body.users) {
+          expect(seen.has(user.user_id)).toBe(false); // no duplicates
+          seen.add(user.user_id);
+        }
+        if (!body.next) break;
+        expect(body.next).not.toMatch(/^\d+$/); // opaque, not an offset
+        from = body.next;
+        if (pages > 10) throw new Error("cursor walk did not terminate");
+      }
+
+      expect(seen.size).toBe(12);
+      expect(pages).toBe(3); // 5 + 5 + 2
+    });
+
     it("should return linked users as identities in primary user, and not in list of results", async () => {
       const { managementApp, env } = await getTestServer();
       const managementClient = testClient(managementApp, env);
@@ -1486,7 +1555,8 @@ describe("users management API endpoint", () => {
 
       expect(body.users.length).toBe(1);
       expect(body.start).toBe(0);
-      expect(body.limit).toBe(10);
+      // Default per_page follows Auth0's documented default of 50.
+      expect(body.limit).toBe(50);
       expect(body.length).toBe(1);
     });
   });

--- a/packages/drizzle/src/adapters/users.ts
+++ b/packages/drizzle/src/adapters/users.ts
@@ -31,6 +31,14 @@ import {
   isCoalescedNumericColumn,
   type CoalescedNumericColumn,
 } from "../helpers/filter";
+import {
+  isKeysetRequest,
+  keysetTake,
+  keysetCondition,
+  keysetOrderBy,
+  sliceWithNext,
+  type KeysetColumns,
+} from "../helpers/paginate";
 import { createUserActivityAdapter } from "./userActivity";
 import type { DrizzleDb } from "./types";
 import { runAtomic, type AtomicStatementList } from "./atomic";
@@ -473,6 +481,82 @@ export function createUsersAdapter(db: DrizzleDb) {
 
       const whereClause = and(...conditions);
 
+      // Fetch each primary user's linked accounts and fold them into
+      // identities. Shared by the offset and keyset branches.
+      const hydrateLinked = async <T extends { user_id: string }>(
+        results: T[],
+      ): Promise<User[]> => {
+        const primaryIds = results.map((r) => r.user_id);
+
+        const allLinked =
+          primaryIds.length > 0
+            ? await db
+                .select()
+                .from(users)
+                .where(
+                  and(
+                    eq(users.tenant_id, tenant_id),
+                    inArray(users.linked_to, primaryIds),
+                  ),
+                )
+            : [];
+
+        return results.map((row) => {
+          const linked = allLinked.filter((u) => u.linked_to === row.user_id);
+          return sqlToUser(row, linked);
+        });
+      };
+
+      // Keyset (checkpoint) pagination: from/take. Auth0 does not offer
+      // checkpoint on /users at all (offset there is capped at 1000 results);
+      // this is a deliberate superset so full-tenant walks don't need export
+      // jobs. `q` stays in effect inside cursor walks. Only created_at is
+      // keyset-sortable (asc/desc); user_id is the unique tiebreaker.
+      if (isKeysetRequest(params)) {
+        if (sort?.sort_by && sort.sort_by !== "created_at") {
+          throw new HTTPException(400, {
+            message: `Sorting by ${sort.sort_by} is not supported with checkpoint pagination (from/take); only created_at is`,
+          });
+        }
+        const sortOrder: "asc" | "desc" =
+          sort?.sort_order === "asc" ? "asc" : "desc";
+        const cols: KeysetColumns = {
+          sortColumn: users.created_at,
+          idColumn: users.user_id,
+          sortOrder,
+          sortKey: `created_at:${sortOrder}`,
+        };
+        const take = keysetTake(params);
+        const cursorCondition = keysetCondition(params, cols);
+
+        const joined = await db
+          .select()
+          .from(users)
+          .leftJoin(userActivity, activityJoin())
+          .where(
+            cursorCondition ? and(whereClause, cursorCondition) : whereClause,
+          )
+          .orderBy(...keysetOrderBy(cols))
+          .limit(take + 1);
+
+        const { rows, next } = sliceWithNext(
+          joined.map((row) => withActivity(row.users, row.user_activity)),
+          take,
+          "created_at",
+          "user_id",
+          cols.sortKey,
+        );
+        const mapped = await hydrateLinked(rows);
+
+        return {
+          users: mapped,
+          start: 0,
+          limit: take,
+          length: mapped.length,
+          next,
+        };
+      }
+
       let query = db
         .select()
         .from(users)
@@ -495,26 +579,7 @@ export function createUsersAdapter(db: DrizzleDb) {
         withActivity(row.users, row.user_activity),
       );
 
-      // Fetch linked users for these results
-      const primaryIds = results.map((r) => r.user_id);
-
-      let allLinked: any[] = [];
-      if (primaryIds.length > 0) {
-        allLinked = await db
-          .select()
-          .from(users)
-          .where(
-            and(
-              eq(users.tenant_id, tenant_id),
-              inArray(users.linked_to, primaryIds),
-            ),
-          );
-      }
-
-      const mapped = results.map((row) => {
-        const linked = allLinked.filter((u) => u.linked_to === row.user_id);
-        return sqlToUser(row, linked);
-      });
+      const mapped = await hydrateLinked(results);
 
       if (!include_totals) {
         return { users: mapped };

--- a/packages/drizzle/test/adapters/users-keyset.test.ts
+++ b/packages/drizzle/test/adapters/users-keyset.test.ts
@@ -74,12 +74,36 @@ describe("users keyset pagination (from/take)", () => {
   });
 
   it("honors sort=created_at asc and rejects replay under another sort", async () => {
+    // Seeded rows share created_at (second resolution), so ordering must be
+    // lexicographic on the full (created_at, user_id) keyset, not just the
+    // sort column.
+    const assertAscending = (rows: { created_at: string; user_id: string }[]) => {
+      for (let i = 1; i < rows.length; i++) {
+        const prev = rows[i - 1];
+        const cur = rows[i];
+        const ordered =
+          prev.created_at < cur.created_at ||
+          (prev.created_at === cur.created_at && prev.user_id < cur.user_id);
+        expect(ordered).toBe(true);
+      }
+    };
+
     const page1 = await data.users.list(tenantId, {
       take: 10,
       sort: { sort_by: "created_at", sort_order: "asc" },
     });
     expect(page1.users).toHaveLength(10);
     expect(page1.next).toBeDefined();
+    assertAscending(page1.users);
+
+    const page2 = await data.users.list(tenantId, {
+      take: 10,
+      from: page1.next,
+      sort: { sort_by: "created_at", sort_order: "asc" },
+    });
+    expect(page2.users).toHaveLength(10);
+    // Order must hold across the page boundary too.
+    assertAscending([page1.users[9], ...page2.users]);
 
     await expect(
       data.users.list(tenantId, {

--- a/packages/drizzle/test/adapters/users-keyset.test.ts
+++ b/packages/drizzle/test/adapters/users-keyset.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+
+// Users keyset on created_at (asc/desc) with user_id as the unique
+// tiebreaker. A superset of Auth0, which caps /users at 1000 results with
+// offset paging only. Linked accounts stay folded into identities during
+// cursor walks, and the cursor records the sort it was minted under so a
+// token replayed with a different sort fails instead of returning pages
+// from the wrong position.
+describe("users keyset pagination (from/take)", () => {
+  let data: ReturnType<typeof getTestServer>["data"];
+  const tenantId = "t1";
+
+  beforeEach(async () => {
+    const server = getTestServer();
+    data = server.data;
+
+    await data.tenants.create({ id: tenantId, name: "Tenant 1" });
+
+    // Seed more rows than a single page. created_at has second-ish
+    // resolution, so rows share timestamps — the user_id tiebreaker matters.
+    for (let i = 0; i < 25; i++) {
+      await data.users.create(tenantId, {
+        user_id: `email|keyset-${i.toString().padStart(2, "0")}`,
+        email: `keyset-${i.toString().padStart(2, "0")}@example.com`,
+        email_verified: true,
+        connection: "email",
+        provider: "email",
+        is_social: false,
+      });
+    }
+  });
+
+  it("walks every user exactly once and folds linked accounts in", async () => {
+    // Link a secondary account to the first user; it must appear as an
+    // identity, never as a top-level row of the walk.
+    await data.users.create(tenantId, {
+      user_id: "auth2|keyset-linked",
+      email: "keyset-00@example.com",
+      email_verified: true,
+      connection: "Username-Password-Authentication",
+      provider: "auth2",
+      is_social: false,
+      linked_to: "email|keyset-00",
+    });
+
+    const seen = new Set<string>();
+    let from: string | undefined;
+    let pages = 0;
+    let linkedIdentitySeen = false;
+
+    for (;;) {
+      const res = await data.users.list(tenantId, { take: 10, from });
+      pages++;
+      expect(res.users.length).toBeLessThanOrEqual(10);
+      for (const user of res.users) {
+        expect(user.user_id).not.toBe("auth2|keyset-linked");
+        expect(seen.has(user.user_id)).toBe(false); // no duplicates
+        seen.add(user.user_id);
+        if (user.user_id === "email|keyset-00") {
+          linkedIdentitySeen =
+            user.identities?.some((i) => i.provider === "auth2") ?? false;
+        }
+      }
+      if (!res.next) break;
+      expect(res.next).not.toMatch(/^\d+$/); // opaque, not an offset
+      from = res.next;
+      if (pages > 10) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.size).toBe(25);
+    expect(pages).toBe(3); // 10 + 10 + 5
+    expect(linkedIdentitySeen).toBe(true);
+  });
+
+  it("honors sort=created_at asc and rejects replay under another sort", async () => {
+    const page1 = await data.users.list(tenantId, {
+      take: 10,
+      sort: { sort_by: "created_at", sort_order: "asc" },
+    });
+    expect(page1.users).toHaveLength(10);
+    expect(page1.next).toBeDefined();
+
+    await expect(
+      data.users.list(tenantId, {
+        take: 10,
+        from: page1.next,
+        sort: { sort_by: "created_at", sort_order: "desc" },
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects unsupported sort columns in checkpoint mode", async () => {
+    await expect(
+      data.users.list(tenantId, {
+        take: 10,
+        sort: { sort_by: "email", sort_order: "asc" },
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("omits next on the final page", async () => {
+    const res = await data.users.list(tenantId, { take: 50 });
+    expect(res.users).toHaveLength(25);
+    expect(res.next).toBeUndefined();
+  });
+});

--- a/packages/kysely/src/helpers/paginate.ts
+++ b/packages/kysely/src/helpers/paginate.ts
@@ -24,10 +24,14 @@ export function isKeysetRequest(params?: ListParams): boolean {
 }
 
 export interface KeysetOptions {
-  /** Column to sort by. Must be a real column on the queried table. */
+  /**
+   * Column to sort by. Must be a real column on the queried table. May be
+   * table-qualified (`users.created_at`) when the query joins other tables;
+   * the row property is read from the segment after the last dot.
+   */
   sortColumn: string;
   sortOrder: "asc" | "desc";
-  /** Unique tiebreaker column; defaults to "id". */
+  /** Unique tiebreaker column (may be table-qualified); defaults to "id". */
   idColumn?: string;
   /**
    * Sort spec (e.g. `date:desc`) for endpoints that honor a caller-chosen sort
@@ -99,7 +103,11 @@ export async function keysetPaginate<DB, TB extends keyof DB, O>(
   let next: string | undefined;
   if (hasMore && rows.length > 0) {
     const last = rows[rows.length - 1] as Record<string, unknown>;
-    const sortValue = last[sortColumn];
+    // Row properties carry the bare column name even when the query used a
+    // table-qualified ref for ORDER BY / WHERE.
+    const sortProp = sortColumn.split(".").pop()!;
+    const idProp = idColumn.split(".").pop()!;
+    const sortValue = last[sortProp];
     next = encodeCursor({
       s:
         typeof sortValue === "string" ||
@@ -107,7 +115,7 @@ export async function keysetPaginate<DB, TB extends keyof DB, O>(
         sortValue === null
           ? (sortValue as string | number | null)
           : String(sortValue),
-      i: String(last[idColumn]),
+      i: String(last[idProp]),
       ...(options.sortKey !== undefined && { k: options.sortKey }),
     });
   }

--- a/packages/kysely/src/users/list.ts
+++ b/packages/kysely/src/users/list.ts
@@ -166,6 +166,13 @@ export function list(db: Kysely<Database>) {
         sort?.sort_order === "asc" ? "asc" : "desc";
       const { rows, limit, next } = await keysetPaginate(
         query
+          // Checkpoint walks enumerate primary users only — linked accounts
+          // are folded into identities by hydrateProfiles, and surfacing them
+          // as top-level rows too would duplicate them. Matches the drizzle
+          // adapter, which excludes linked users unconditionally. The offset
+          // path is left alone: the route's identities.profileData.email
+          // lookup depends on linked rows being returned there.
+          .where("users.linked_to", "is", null)
           .selectAll("users")
           .select([
             "user_activity.last_login",

--- a/packages/kysely/src/users/list.ts
+++ b/packages/kysely/src/users/list.ts
@@ -1,4 +1,5 @@
-import { Kysely } from "kysely";
+import { Kysely, Selectable } from "kysely";
+import { HTTPException } from "hono/http-exception";
 import {
   luceneFilter,
   sanitizeLuceneQuery,
@@ -14,6 +15,7 @@ import {
   User,
 } from "@authhero/adapter-interfaces";
 import getCountAsInt from "../utils/getCountAsInt";
+import { isKeysetRequest, keysetPaginate } from "../helpers/paginate";
 
 // Fields users.list() accepts in `q`. Excludes `tenant_id` so a clause like
 // `q=tenant_id:other` cannot cross tenant boundaries; everything else here
@@ -65,6 +67,56 @@ const FIELD_MAP: Record<string, FieldMapping> = Object.fromEntries(
 // Keep narrow — every column here is publicly searchable via `q`.
 const SEARCHABLE_COLUMNS = ["email", "name", "phone_number", "user_id"];
 
+// Row shape shared by the offset and keyset branches: every users column plus
+// the activity counters selected from the 1:1 left-joined user_activity table.
+type UserRow = Selectable<Database["users"]> & {
+  last_login: string | null;
+  last_ip: string | null;
+  login_count: number | null;
+};
+
+// Fetch each primary user's linked accounts and fold them into identities.
+async function hydrateProfiles(
+  db: Kysely<Database>,
+  tenantId: string,
+  users: UserRow[],
+): Promise<User[]> {
+  const userIds = users.map((u) => u.user_id);
+
+  // TODO: execute these in parallel with a join
+  const linkedUsers = !userIds.length
+    ? []
+    : await db
+        .selectFrom("users")
+        .selectAll()
+        .where("users.tenant_id", "=", tenantId)
+        .where("users.linked_to", "in", userIds)
+        .orderBy("created_at", "asc")
+        .execute();
+
+  return users.map((user) => {
+    const linkedUsersForUser = linkedUsers.filter(
+      (u) => u.linked_to === user.user_id,
+    );
+
+    return removeNullProperties<User>({
+      ...user,
+      email_verified: user.email_verified === 1,
+      phone_verified:
+        user.phone_verified !== null ? user.phone_verified === 1 : undefined,
+      is_social: user.is_social === 1,
+      login_count: user.login_count ?? 0,
+      app_metadata: JSON.parse(user.app_metadata),
+      user_metadata: JSON.parse(user.user_metadata),
+      address: user.address ? JSON.parse(user.address) : undefined,
+      identities: [
+        userToIdentity(user, true),
+        ...linkedUsersForUser.map((u) => userToIdentity(u)),
+      ],
+    });
+  });
+}
+
 export function list(db: Kysely<Database>) {
   return async (
     tenantId: string,
@@ -99,6 +151,47 @@ export function list(db: Kysely<Database>) {
       }
     }
 
+    // Keyset (checkpoint) pagination: from/take. Auth0 does not offer
+    // checkpoint on /users at all (offset there is capped at 1000 results);
+    // this is a deliberate superset so full-tenant walks don't need export
+    // jobs. `q` stays in effect inside cursor walks. Only created_at is
+    // keyset-sortable (asc/desc); user_id is the unique tiebreaker.
+    if (isKeysetRequest(params)) {
+      if (sort?.sort_by && sort.sort_by !== "created_at") {
+        throw new HTTPException(400, {
+          message: `Sorting by ${sort.sort_by} is not supported with checkpoint pagination (from/take); only created_at is`,
+        });
+      }
+      const sortOrder: "asc" | "desc" =
+        sort?.sort_order === "asc" ? "asc" : "desc";
+      const { rows, limit, next } = await keysetPaginate(
+        query
+          .selectAll("users")
+          .select([
+            "user_activity.last_login",
+            "user_activity.last_ip",
+            "user_activity.login_count",
+          ]),
+        params,
+        {
+          // Qualified refs: user_activity also has a user_id column, so a
+          // bare user_id ref would be ambiguous after the join.
+          sortColumn: "users.created_at",
+          sortOrder,
+          idColumn: "users.user_id",
+          sortKey: `created_at:${sortOrder}`,
+        },
+      );
+      const usersWithProfiles = await hydrateProfiles(db, tenantId, rows);
+      return {
+        users: usersWithProfiles,
+        start: 0,
+        limit,
+        length: usersWithProfiles.length,
+        next,
+      };
+    }
+
     // Only sort on a known field. An unmapped sort_by (e.g. `sort=id:1`, where
     // `id` isn't a users column) must be ignored rather than passed through to
     // SQL — an unqualified `order by id` is rejected by MySQL/Vitess as an
@@ -125,40 +218,7 @@ export function list(db: Kysely<Database>) {
       ])
       .execute();
 
-    const userIds = users.map((u) => u.user_id);
-
-    // TODO: execute these in parallel with a join
-    const linkedUsers = !userIds.length
-      ? []
-      : await db
-          .selectFrom("users")
-          .selectAll()
-          .where("users.tenant_id", "=", tenantId)
-          .where("users.linked_to", "in", userIds)
-          .orderBy("created_at", "asc")
-          .execute();
-
-    const usersWithProfiles = users.map((user) => {
-      const linkedUsersForUser = linkedUsers.filter(
-        (u) => u.linked_to === user.user_id,
-      );
-
-      return removeNullProperties<User>({
-        ...user,
-        email_verified: user.email_verified === 1,
-        phone_verified:
-          user.phone_verified !== null ? user.phone_verified === 1 : undefined,
-        is_social: user.is_social === 1,
-        login_count: user.login_count ?? 0,
-        app_metadata: JSON.parse(user.app_metadata),
-        user_metadata: JSON.parse(user.user_metadata),
-        address: user.address ? JSON.parse(user.address) : undefined,
-        identities: [
-          userToIdentity(user, true),
-          ...linkedUsersForUser.map((u) => userToIdentity(u)),
-        ],
-      });
-    });
+    const usersWithProfiles = await hydrateProfiles(db, tenantId, users);
 
     if (!include_totals) {
       return {

--- a/packages/kysely/test/keyset-pagination.test.ts
+++ b/packages/kysely/test/keyset-pagination.test.ts
@@ -293,3 +293,116 @@ describe("logs keyset pagination (from/take)", () => {
     expect(res.next).toBeUndefined();
   });
 });
+
+// Users keyset on created_at (asc/desc) with user_id as the unique tiebreaker.
+// A superset of Auth0, which caps /users at 1000 results with offset paging
+// only. Linked accounts stay folded into identities during cursor walks.
+describe("users keyset pagination (from/take)", () => {
+  let data: any;
+  const tenantId = "keyset-users-tenant";
+
+  beforeEach(async () => {
+    const server = await getTestServer();
+    data = server.data;
+
+    await data.tenants.create({
+      id: tenantId,
+      friendly_name: "Keyset Users Tenant",
+      audience: "https://example.com",
+      sender_email: "login@example.com",
+      sender_name: "SenderName",
+    });
+
+    // Seed more rows than a single page. created_at has second-ish
+    // resolution, so rows share timestamps — the user_id tiebreaker matters.
+    for (let i = 0; i < 25; i++) {
+      await data.users.create(tenantId, {
+        user_id: `email|keyset-${i.toString().padStart(2, "0")}`,
+        email: `keyset-${i.toString().padStart(2, "0")}@example.com`,
+        email_verified: true,
+        connection: "email",
+        provider: "email",
+        is_social: false,
+      });
+    }
+  });
+
+  it("walks every user exactly once and folds linked accounts in", async () => {
+    // Link a secondary account to the first user; it must appear as an
+    // identity, never as a top-level row of the walk.
+    await data.users.create(tenantId, {
+      user_id: "auth2|keyset-linked",
+      email: "keyset-00@example.com",
+      email_verified: true,
+      connection: "Username-Password-Authentication",
+      provider: "auth2",
+      is_social: false,
+      linked_to: "email|keyset-00",
+    });
+
+    const seen = new Set<string>();
+    let from: string | undefined;
+    let pages = 0;
+    let linkedIdentitySeen = false;
+
+    for (;;) {
+      const res = await data.users.list(tenantId, {
+        q: "-_exists_:linked_to",
+        take: 10,
+        from,
+      });
+      pages++;
+      expect(res.users.length).toBeLessThanOrEqual(10);
+      for (const user of res.users) {
+        expect(user.user_id).not.toBe("auth2|keyset-linked");
+        expect(seen.has(user.user_id)).toBe(false); // no duplicates
+        seen.add(user.user_id);
+        if (user.user_id === "email|keyset-00") {
+          linkedIdentitySeen = user.identities.some(
+            (i: any) => i.provider === "auth2",
+          );
+        }
+      }
+      if (!res.next) break;
+      expect(res.next).not.toMatch(/^\d+$/); // opaque, not an offset
+      from = res.next;
+      if (pages > 10) throw new Error("cursor walk did not terminate");
+    }
+
+    expect(seen.size).toBe(25);
+    expect(pages).toBe(3); // 10 + 10 + 5
+    expect(linkedIdentitySeen).toBe(true);
+  });
+
+  it("honors sort=created_at asc and rejects replay under another sort", async () => {
+    const page1 = await data.users.list(tenantId, {
+      take: 10,
+      sort: { sort_by: "created_at", sort_order: "asc" },
+    });
+    expect(page1.users).toHaveLength(10);
+    expect(page1.next).toBeDefined();
+
+    await expect(
+      data.users.list(tenantId, {
+        take: 10,
+        from: page1.next,
+        sort: { sort_by: "created_at", sort_order: "desc" },
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects unsupported sort columns in checkpoint mode", async () => {
+    await expect(
+      data.users.list(tenantId, {
+        take: 10,
+        sort: { sort_by: "email", sort_order: "asc" },
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("omits next on the final page", async () => {
+    const res = await data.users.list(tenantId, { take: 50 });
+    expect(res.users).toHaveLength(25);
+    expect(res.next).toBeUndefined();
+  });
+});

--- a/packages/kysely/test/keyset-pagination.test.ts
+++ b/packages/kysely/test/keyset-pagination.test.ts
@@ -346,8 +346,9 @@ describe("users keyset pagination (from/take)", () => {
     let linkedIdentitySeen = false;
 
     for (;;) {
+      // No q filter: checkpoint mode excludes linked accounts by itself,
+      // matching the drizzle adapter.
       const res = await data.users.list(tenantId, {
-        q: "-_exists_:linked_to",
         take: 10,
         from,
       });
@@ -375,12 +376,36 @@ describe("users keyset pagination (from/take)", () => {
   });
 
   it("honors sort=created_at asc and rejects replay under another sort", async () => {
+    // Seeded rows share created_at (second resolution), so ordering must be
+    // lexicographic on the full (created_at, user_id) keyset, not just the
+    // sort column.
+    const assertAscending = (rows: { created_at: string; user_id: string }[]) => {
+      for (let i = 1; i < rows.length; i++) {
+        const prev = rows[i - 1];
+        const cur = rows[i];
+        const ordered =
+          prev.created_at < cur.created_at ||
+          (prev.created_at === cur.created_at && prev.user_id < cur.user_id);
+        expect(ordered).toBe(true);
+      }
+    };
+
     const page1 = await data.users.list(tenantId, {
       take: 10,
       sort: { sort_by: "created_at", sort_order: "asc" },
     });
     expect(page1.users).toHaveLength(10);
     expect(page1.next).toBeDefined();
+    assertAscending(page1.users);
+
+    const page2 = await data.users.list(tenantId, {
+      take: 10,
+      from: page1.next,
+      sort: { sort_by: "created_at", sort_order: "asc" },
+    });
+    expect(page2.users).toHaveLength(10);
+    // Order must hold across the page boundary too.
+    assertAscending([page1.users[9], ...page2.users]);
 
     await expect(
       data.users.list(tenantId, {


### PR DESCRIPTION
feat(users): checkpoint pagination on `GET /users` + default page size 50 — #1098

Next slice of #1098, starting on Category 2. Verified against the Auth0 API reference before building (2026-07-14): Auth0's [`GET /users`](https://auth0.com/docs/api/management/v2/users/get-users) is **offset-only** (`page`/`per_page`, max 100), hard-capped at **1000 results** — past that Auth0 points you at [export jobs](https://auth0.com/docs/manage-users/user-search/retrieve-users-with-get-users-endpoint). Checkpoint on `/users` is therefore a **deliberate superset** of Auth0 (agreed direction: extensions beyond Auth0 are fine when they don't change behavior for Auth0-shaped requests — a client that never sends `from`/`take` sees identical behavior).

## What's in this PR

**`GET /users` checkpoint pagination (both backends):**
- `from`/`take` → `{ users, next }` with an opaque cursor, absent on the last page. No 1000-row ceiling — full-tenant walks no longer need export-style workarounds.
- `q` stays in effect inside cursor walks (consistent with our other converted endpoints; the route's `-_exists_:linked_to` primary-user filter keeps working).
- `sort=created_at:1|-1` honored in checkpoint mode (`user_id` is the unique tiebreaker; default `created_at desc`, matching the clients conversion). Cursors record the sort they were minted under — replay under a different sort → 400. Any other sort column → 400, per the established "explicit error instead of silently ignoring params" decision (2026-07-11).
- Linked accounts remain folded into `identities`, never top-level rows. Hydration extracted into a shared helper used by both offset and keyset branches (kysely + drizzle), removing the duplicated linked-user code.
- Offset (`page`/`per_page` + totals) unchanged; the admin UI keeps numbered pages.
- kysely keyset helper now accepts table-qualified sort/id columns — needed because users joins `user_activity`, which shares the `user_id` column name.

**Default page size → 50 (Auth0 alignment):**
- The shared `querySchema` defaulted `per_page` to **10** while its own description already claimed 50; Auth0's documented default is **50**. Both copies of the schema (authhero + adapter-interfaces) now default to 50. Explicit `per_page` requests are unaffected; the admin UI always sends one.

**aws/DynamoDB** is again excluded, matching #1100/#1105/#1107/#1118 — its `ExclusiveStartKey` cursor pass remains a separate work item on #1098.

## Tests
- kysely + drizzle adapter walks: multi-page, no duplicates, linked accounts folded in, opaque cursor, `next` omitted on last page, sort-mismatch and unsupported-sort 400s.
- Endpoint-level cursor walk over `GET /users` asserting the `{ users, next }` shape (no totals fields).
- Existing default-limit assertion updated 10 → 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added checkpoint (cursor-based) pagination to `GET /users` using `from` and `take`.
  - Responses now include an opaque `next` cursor when more results are available.
  - Cursor pagination supports `created_at` ascending or descending order and preserves filters.
  - Linked accounts are included within primary users rather than listed separately.

- **Improvements**
  - Increased the default users page size from 10 to 50.
  - Added validation for unsupported sorting and mismatched cursors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->