### PR TITLE
feat(tenant-members): let tenant admins manage their own team (#1137)

### DIFF
--- a/.changeset/tenant-self-manage-team.md
+++ b/.changeset/tenant-self-manage-team.md
@@ -26,3 +26,11 @@ Admin UI: a new **Team** page in the per-tenant admin lets tenant admins invite
 colleagues by email, remove admins, and edit each admin's roles. The invitation
 client is resolved server-side, fixing the control-plane page's "invite UI
 silently disappears when the client id isn't in local storage" foot-gun.
+
+Also adds an optional `proxyControlPlane.isTrustedIssuer(iss)` predicate (#1139)
+that widens the accepted control-plane token issuers to a deployment's own
+Workers-for-Platforms tenant subdomains — needed so a shard whose tokens are
+signed by its own key (issuer `https://{tenant}.{host}/`) can authenticate the
+write-through to the control plane. It is consulted before any JWKS fetch, so
+the SSRF guarantee holds, and applies to every mounted resource (custom-domains,
+tenant-members, sync).

--- a/.changeset/tenant-self-manage-team.md
+++ b/.changeset/tenant-self-manage-team.md
@@ -1,0 +1,28 @@
+---
+"authhero": minor
+"@authhero/admin": minor
+---
+
+Let tenant admins manage their own team (#1137). A tenant's administrators are
+control-plane organization members — rows a tenant shard cannot write — so this
+adds a `TenantMembersBackend` seam with two implementations: a local one
+(`createLocalTenantMembersBackend`) that resolves the org and mutates the
+control-plane database directly (single-instance / control-plane deployments),
+and a control-plane-backed one (`createControlPlaneTenantMembersAdapter`) that
+delegates over the shared control-plane client for Workers-for-Platforms shards.
+
+Server-side:
+- New `/api/v2/tenant-members` management resource (list/add/remove members,
+  member roles, and invitations). Every request is pinned to the caller's
+  `org_name` claim server-side — a tenant-A admin cannot manage tenant B by
+  swapping the `tenant-id` header.
+- New authoritative `/api/v2/proxy/control-plane/tenant-members` resource
+  (gated by the `controlplane:tenant_members` scope), which re-pins the org
+  from the verified service token's `tenant_id` claim — a second, independent
+  check. Enable it via `proxyControlPlane.tenantMembers`; enable the tenant
+  resource via the top-level `tenantMembers` config.
+
+Admin UI: a new **Team** page in the per-tenant admin lets tenant admins invite
+colleagues by email, remove admins, and edit each admin's roles. The invitation
+client is resolved server-side, fixing the control-plane page's "invite UI
+silently disappears when the client id isn't in local storage" foot-gun.

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -22,6 +22,7 @@ import {
   Type,
   UserCog,
   Users,
+  UsersRound,
   Webhook,
   Workflow,
 } from "lucide-react";
@@ -90,6 +91,7 @@ import { RoleList, RoleCreate, RoleEdit } from "./resources/roles";
 import { Dashboard } from "./resources/dashboard/Dashboard";
 import { AnalyticsPage } from "./resources/analytics/AnalyticsPage";
 import { TenantDataPage } from "./resources/tenant-data/TenantDataPage";
+import { TeamPage } from "./resources/team/TeamPage";
 
 interface AppProps {
   tenantId: string;
@@ -394,6 +396,12 @@ export function App({ tenantId, initialDomain, onAuthComplete }: AppProps) {
           icon={Database}
           list={TenantDataPage}
           options={{ label: "Import / Export", menuGroup: "Settings" }}
+        />
+        <Resource
+          name="team"
+          icon={UsersRound}
+          list={TeamPage}
+          options={{ label: "Team", menuGroup: "Settings" }}
         />
       </Admin>
     </TenantProvider>

--- a/apps/admin/src/auth0DataProvider.ts
+++ b/apps/admin/src/auth0DataProvider.ts
@@ -364,6 +364,61 @@ export interface AuthHeroDataProvider extends DataProvider {
     tenantId: string,
     kind: "upgrade" | "seed" | "backup",
   ) => Promise<TenantOperationRecord>;
+
+  /**
+   * Tenant-team self-management (#1137). These hit `/api/v2/tenant-members`,
+   * which manages who administers THIS tenant — control-plane organization
+   * membership + org-scoped roles + invitations — not the tenant's end users.
+   * The server pins the org to the caller's token, so no organization id is
+   * passed. Available only when the server enables the resource (404 / 403
+   * otherwise).
+   */
+  listTeamMembers: (params?: {
+    page?: number;
+    perPage?: number;
+    q?: string;
+  }) => Promise<{
+    members: TeamMemberRecord[];
+    start: number;
+    limit: number;
+    total: number;
+  }>;
+  addTeamMembers: (userIds: string[]) => Promise<void>;
+  removeTeamMembers: (userIds: string[]) => Promise<void>;
+  assignTeamMemberRoles: (userId: string, roleIds: string[]) => Promise<void>;
+  removeTeamMemberRoles: (userId: string, roleIds: string[]) => Promise<void>;
+  listAssignableTeamRoles: (q?: string) => Promise<TeamRoleRecord[]>;
+  listTeamInvitations: () => Promise<TeamInvitationRecord[]>;
+  createTeamInvitation: (input: {
+    email: string;
+    inviterName?: string;
+    roles?: string[];
+    sendInvitationEmail?: boolean;
+  }) => Promise<TeamInvitationRecord>;
+  revokeTeamInvitation: (invitationId: string) => Promise<void>;
+}
+
+export interface TeamRoleRecord {
+  id: string;
+  name?: string;
+  description?: string;
+}
+
+export interface TeamMemberRecord {
+  user_id: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+  roles: TeamRoleRecord[];
+}
+
+export interface TeamInvitationRecord {
+  id: string;
+  organization_id: string;
+  invitee?: { email?: string };
+  inviter?: { name?: string };
+  created_at?: string;
+  expires_at?: string;
 }
 
 // Wire shapes of the tenant-operations management API (issue #1026).
@@ -2587,6 +2642,93 @@ export default (
         },
       );
       return res.json;
+    },
+
+    // --- Tenant-team self-management (#1137) ---
+    listTeamMembers: async (params) => {
+      const query = stringify({
+        page: params?.page,
+        per_page: params?.perPage,
+        q: params?.q || undefined,
+      });
+      const res = await httpClient(
+        `${apiUrl}/api/v2/tenant-members${query ? `?${query}` : ""}`,
+        { headers: createHeaders(tenantId) },
+      );
+      return res.json;
+    },
+    addTeamMembers: async (userIds) => {
+      const headers = createHeaders(tenantId);
+      headers.set("content-type", "application/json");
+      await httpClient(`${apiUrl}/api/v2/tenant-members`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ user_ids: userIds }),
+      });
+    },
+    removeTeamMembers: async (userIds) => {
+      const headers = createHeaders(tenantId);
+      headers.set("content-type", "application/json");
+      await httpClient(`${apiUrl}/api/v2/tenant-members`, {
+        method: "DELETE",
+        headers,
+        body: JSON.stringify({ user_ids: userIds }),
+      });
+    },
+    assignTeamMemberRoles: async (userId, roleIds) => {
+      const headers = createHeaders(tenantId);
+      headers.set("content-type", "application/json");
+      await httpClient(
+        `${apiUrl}/api/v2/tenant-members/${encodeURIComponent(userId)}/roles`,
+        { method: "POST", headers, body: JSON.stringify({ roles: roleIds }) },
+      );
+    },
+    removeTeamMemberRoles: async (userId, roleIds) => {
+      const headers = createHeaders(tenantId);
+      headers.set("content-type", "application/json");
+      await httpClient(
+        `${apiUrl}/api/v2/tenant-members/${encodeURIComponent(userId)}/roles`,
+        { method: "DELETE", headers, body: JSON.stringify({ roles: roleIds }) },
+      );
+    },
+    listAssignableTeamRoles: async (q) => {
+      const query = stringify({ q: q || undefined, per_page: 100 });
+      const res = await httpClient(
+        `${apiUrl}/api/v2/tenant-members/roles${query ? `?${query}` : ""}`,
+        { headers: createHeaders(tenantId) },
+      );
+      return res.json;
+    },
+    listTeamInvitations: async () => {
+      const res = await httpClient(
+        `${apiUrl}/api/v2/tenant-members/invitations`,
+        { headers: createHeaders(tenantId) },
+      );
+      return res.json;
+    },
+    createTeamInvitation: async (input) => {
+      const headers = createHeaders(tenantId);
+      headers.set("content-type", "application/json");
+      const res = await httpClient(
+        `${apiUrl}/api/v2/tenant-members/invitations`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            invitee: { email: input.email.trim() },
+            inviter: input.inviterName ? { name: input.inviterName } : {},
+            roles: input.roles,
+            send_invitation_email: input.sendInvitationEmail,
+          }),
+        },
+      );
+      return res.json;
+    },
+    revokeTeamInvitation: async (invitationId) => {
+      await httpClient(
+        `${apiUrl}/api/v2/tenant-members/invitations/${encodeURIComponent(invitationId)}`,
+        { method: "DELETE", headers: createHeaders(tenantId) },
+      );
     },
 
     revokeSigningKey: async (kid: string) => {

--- a/apps/admin/src/resources/team/TeamPage.tsx
+++ b/apps/admin/src/resources/team/TeamPage.tsx
@@ -1,0 +1,482 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useDataProvider,
+  useGetIdentity,
+  useNotify,
+} from "ra-core";
+import { Loader2, Mail, Pencil, Plus, Trash2 } from "lucide-react";
+import type {
+  AuthHeroDataProvider,
+  TeamInvitationRecord,
+  TeamMemberRecord,
+  TeamRoleRecord,
+} from "../../auth0DataProvider";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+/**
+ * Per-tenant "Team" page (#1137). Lets a tenant admin manage who administers
+ * this tenant — invite colleagues by email, remove admins, and edit each
+ * admin's roles — without a control-plane login.
+ *
+ * A tenant's team is a control-plane organization, so its members are
+ * control-plane users, not this tenant's end users. That is why there is no
+ * "add an existing user" search here (the tenant shard can't enumerate
+ * control-plane users): the way in is an email invitation, which provisions the
+ * control-plane user on acceptance. Everything talks to `/api/v2/tenant-members`,
+ * where the server pins the organization to the caller's token.
+ */
+export function TeamPage() {
+  const dataProvider = useDataProvider<AuthHeroDataProvider>();
+  const notify = useNotify();
+
+  const [members, setMembers] = useState<TeamMemberRecord[]>([]);
+  const [invitations, setInvitations] = useState<TeamInvitationRecord[]>([]);
+  const [assignableRoles, setAssignableRoles] = useState<TeamRoleRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<TeamMemberRecord | null>(null);
+  const [inviteOpen, setInviteOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [memberResult, invites, roles] = await Promise.all([
+        dataProvider.listTeamMembers({ page: 0, perPage: 100 }),
+        dataProvider.listTeamInvitations().catch(() => []),
+        dataProvider.listAssignableTeamRoles().catch(() => []),
+      ]);
+      setMembers(memberResult.members);
+      setInvitations(invites);
+      setAssignableRoles(roles);
+    } catch {
+      notify("Unable to load the team for this tenant", { type: "error" });
+    } finally {
+      setLoading(false);
+    }
+  }, [dataProvider, notify]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleRemove = async (member: TeamMemberRecord) => {
+    if (
+      !window.confirm(
+        `Remove ${member.email || member.name || member.user_id} from this tenant's team?`,
+      )
+    ) {
+      return;
+    }
+    try {
+      await dataProvider.removeTeamMembers([member.user_id]);
+      notify("Member removed", { type: "success" });
+      void load();
+    } catch {
+      notify("Error removing member", { type: "error" });
+    }
+  };
+
+  const handleRevoke = async (invitation: TeamInvitationRecord) => {
+    try {
+      await dataProvider.revokeTeamInvitation(invitation.id);
+      notify("Invitation revoked", { type: "success" });
+      void load();
+    } catch {
+      notify("Error revoking invitation", { type: "error" });
+    }
+  };
+
+  return (
+    <div className="space-y-6 p-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Team</CardTitle>
+            <CardDescription>
+              People who can administer this tenant.
+            </CardDescription>
+          </div>
+          <Button type="button" onClick={() => setInviteOpen(true)}>
+            <Mail className="mr-1 h-4 w-4" />
+            Invite member
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading…
+            </div>
+          ) : members.length === 0 ? (
+            <p className="p-4 text-sm text-muted-foreground">
+              No team members yet. Invite someone to get started.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Member</TableHead>
+                  <TableHead>Roles</TableHead>
+                  <TableHead className="w-24 text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {members.map((member) => (
+                  <TableRow key={member.user_id}>
+                    <TableCell>
+                      <div className="flex items-center gap-3">
+                        <Avatar className="h-8 w-8">
+                          {member.picture ? (
+                            <AvatarImage src={member.picture} alt="" />
+                          ) : null}
+                          <AvatarFallback>
+                            {(member.email || member.name || "?")
+                              .charAt(0)
+                              .toUpperCase()}
+                          </AvatarFallback>
+                        </Avatar>
+                        <div>
+                          <div className="text-sm font-medium">
+                            {member.name || member.email || member.user_id}
+                          </div>
+                          {member.email && member.name ? (
+                            <div className="text-xs text-muted-foreground">
+                              {member.email}
+                            </div>
+                          ) : null}
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {member.roles.length === 0 ? (
+                          <span className="text-xs text-muted-foreground">
+                            No roles
+                          </span>
+                        ) : (
+                          member.roles.map((role) => (
+                            <Badge key={role.id} variant="secondary">
+                              {role.name || role.id}
+                            </Badge>
+                          ))
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Edit roles"
+                        onClick={() => setEditing(member)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Remove member"
+                        onClick={() => handleRemove(member)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {invitations.length > 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Pending invitations</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="divide-y">
+              {invitations.map((invitation) => (
+                <li
+                  key={invitation.id}
+                  className="flex items-center justify-between py-2"
+                >
+                  <div className="text-sm">
+                    {invitation.invitee?.email || invitation.id}
+                    {invitation.expires_at ? (
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        expires{" "}
+                        {new Date(invitation.expires_at).toLocaleDateString()}
+                      </span>
+                    ) : null}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Revoke invitation"
+                    onClick={() => handleRevoke(invitation)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {editing ? (
+        <EditRolesDialog
+          member={editing}
+          assignableRoles={assignableRoles}
+          onClose={() => setEditing(null)}
+          onSaved={() => {
+            setEditing(null);
+            void load();
+          }}
+        />
+      ) : null}
+
+      <InviteDialog
+        open={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+        onInvited={() => {
+          setInviteOpen(false);
+          void load();
+        }}
+      />
+    </div>
+  );
+}
+
+function EditRolesDialog({
+  member,
+  assignableRoles,
+  onClose,
+  onSaved,
+}: {
+  member: TeamMemberRecord;
+  assignableRoles: TeamRoleRecord[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const dataProvider = useDataProvider<AuthHeroDataProvider>();
+  const notify = useNotify();
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(member.roles.map((r) => r.id)),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    const before = new Set(member.roles.map((r) => r.id));
+    const toAdd = [...selected].filter((id) => !before.has(id));
+    const toRemove = [...before].filter((id) => !selected.has(id));
+    try {
+      if (toAdd.length) {
+        await dataProvider.assignTeamMemberRoles(member.user_id, toAdd);
+      }
+      if (toRemove.length) {
+        await dataProvider.removeTeamMemberRoles(member.user_id, toRemove);
+      }
+      notify("Roles updated", { type: "success" });
+      onSaved();
+    } catch {
+      notify("Error updating roles", { type: "error" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(o) => (o ? undefined : onClose())}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Roles for {member.name || member.email || member.user_id}
+          </DialogTitle>
+        </DialogHeader>
+        {assignableRoles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No roles are available to assign.
+          </p>
+        ) : (
+          <ul className="max-h-72 space-y-1 overflow-auto">
+            {assignableRoles.map((role) => (
+              <li key={role.id} className="flex items-start gap-2 p-1">
+                <Checkbox
+                  id={`role-${role.id}`}
+                  checked={selected.has(role.id)}
+                  onCheckedChange={() => toggle(role.id)}
+                />
+                <label
+                  htmlFor={`role-${role.id}`}
+                  className="flex-1 cursor-pointer"
+                >
+                  <div className="text-sm font-medium">
+                    {role.name || role.id}
+                  </div>
+                  {role.description ? (
+                    <div className="text-xs text-muted-foreground">
+                      {role.description}
+                    </div>
+                  ) : null}
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={saving}>
+            {saving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function InviteDialog({
+  open,
+  onClose,
+  onInvited,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onInvited: () => void;
+}) {
+  const dataProvider = useDataProvider<AuthHeroDataProvider>();
+  const notify = useNotify();
+  const { identity } = useGetIdentity();
+  const [email, setEmail] = useState("");
+  const [sendEmail, setSendEmail] = useState(true);
+  const [busy, setBusy] = useState(false);
+  // Synchronous in-flight lock: a rapid second Enter can re-enter before the
+  // `busy` state settles, and invitation create is not idempotent.
+  const inFlight = useRef(false);
+
+  const reset = () => {
+    setEmail("");
+    setSendEmail(true);
+  };
+
+  const handleInvite = async () => {
+    if (inFlight.current || busy || !email.trim()) return;
+    inFlight.current = true;
+    setBusy(true);
+    try {
+      await dataProvider.createTeamInvitation({
+        email,
+        inviterName: identity?.fullName,
+        sendInvitationEmail: sendEmail,
+      });
+      notify(`Invitation sent to ${email.trim()}`, { type: "success" });
+      reset();
+      onInvited();
+    } catch {
+      notify("Error sending invitation", { type: "error" });
+    } finally {
+      setBusy(false);
+      inFlight.current = false;
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) {
+          reset();
+          onClose();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite a team member</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="invite-email">Email</Label>
+            <Input
+              id="invite-email"
+              type="email"
+              placeholder="colleague@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleInvite();
+                }
+              }}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch
+              id="invite-send-email"
+              checked={sendEmail}
+              onCheckedChange={setSendEmail}
+            />
+            <Label htmlFor="invite-send-email">Send invitation email</Label>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleInvite}
+            disabled={busy || !email.trim()}
+          >
+            {busy ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Plus className="mr-1 h-4 w-4" />}
+            Send invitation
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/docs/customization/multi-tenancy/control-plane.md
+++ b/apps/docs/customization/multi-tenancy/control-plane.md
@@ -691,6 +691,97 @@ Tokens for this resource must carry the `controlplane:custom_domains` scope; the
 
 **Without `CONTROL_PLANE_URL`, a tenant shard refuses custom-domain writes** (`501`) rather than writing a local row that Cloudflare never hears about. Reads keep working, so any domain already mirrored there still resolves.
 
+## Tenant team: self-service member management
+
+A tenant's **team** — the people who administer it — is not the tenant's users. It is an [organization](#organizations-control-plane-vs-child-tenants) on the control-plane tenant whose `name` equals the tenant id, its members are control-plane users, and their access is an org membership plus an org-scoped role. **A tenant shard cannot write those rows.** Putting administrators in the tenant's own `users` table would be a category error, and letting the org-scoped token call the control-plane `organizations/{id}/members` endpoints directly is unsafe — those routes are permission-gated but not scoped to the caller's own organization, so a tenant admin could edit _other_ tenants' teams by changing the id in the URL.
+
+This is the same shape as custom domains — an authoritative side effect the shard can't perform — but with **no read-cache mirror**: nothing in the tenant's request path ever reads "who administers me" (authorization already happens against the `org_name`/`org_id` claim the control plane put in the token). So it is a pure pass-through delegation, not write-through-plus-cache.
+
+```
+tenant admin → GET/POST/DELETE /api/v2/tenant-members        (on the shard)
+  → pin: token org_name must equal the request tenant  ── else 403
+  → createControlPlaneTenantMembersAdapter
+      → …/api/v2/proxy/control-plane/tenant-members          (on the control plane)
+          → pin again: act on the verified token's tenant_id ── else 403
+          → resolve org (name == tenant_id), then read/write
+            membership · org-scoped roles · invitations
+```
+
+**Two independent org pins.** The shard's `/api/v2/tenant-members` resource requires the token's `org_name` claim to equal the request tenant, so a tenant-A admin cannot manage tenant B by swapping the `tenant-id` header. The control-plane resource then re-pins to the verified service token's `tenant_id` claim. A request that names a different tenant is refused with `403` at both hops. Tokens for the control-plane resource carry the `controlplane:tenant_members` scope.
+
+### Tenant shard
+
+Enable the resource with `tenantMembers.getBackend`, returning a control-plane-backed adapter that reuses the **same `client`** as custom domains:
+
+```typescript
+import { createControlPlaneTenantMembersAdapter } from "authhero";
+
+export default init({
+  dataAdapter,
+  // `client` is the createControlPlaneClient from the custom-domains wiring above.
+  tenantMembers: {
+    getBackend: () => createControlPlaneTenantMembersAdapter({ client }),
+  },
+});
+```
+
+### Control plane
+
+Mount the authoritative resource with `proxyControlPlane.tenantMembers`. Its backend resolves the org and mutates the control-plane database directly:
+
+```typescript
+import { createLocalTenantMembersBackend } from "authhero";
+
+export default init({
+  dataAdapter,
+  proxyControlPlane: {
+    resolveHost: createProxyDataAdapter(db).resolveHost,
+    tenantMembers: {
+      getBackend: (c) =>
+        createLocalTenantMembersBackend({
+          data: c.env.data, // control-plane adapters
+          controlPlaneTenantId: CONTROL_PLANE_TENANT_ID,
+          issuer, // builds invitation acceptance links + default avatars
+          invitationClientId: env.INVITATION_CLIENT_ID,
+          // Optional: any async sender. Omit it and the invitation is still
+          // created and returned; only email delivery is skipped (like Auth0).
+          sendInvitationEmail: async ({ to, invitationUrl }) =>
+            deliverEmail(c, to, invitationUrl),
+        }),
+    },
+  },
+});
+```
+
+### Single-instance deployments
+
+When the control plane and the tenants share one database, there is no hop: wire the **local** backend straight into `tenantMembers.getBackend` (the same `createLocalTenantMembersBackend`) and omit `proxyControlPlane.tenantMembers`. The shard's `/api/v2/tenant-members` resource then resolves the org against the same database it already holds.
+
+### Admin UI
+
+The per-tenant admin ships a **Team** page (Settings → Team) that drives this resource: invite colleagues by email, remove administrators, and edit each administrator's roles. The invitation client is resolved server-side, so — unlike the control-plane-only `/tenants/:id/members` page — it does not depend on a client id being present in local storage. Because members are control-plane users (which a shard can't enumerate), the way to add someone is an email invitation, not a user search; the control-plane page remains the place for global admins to add existing control-plane users directly.
+
+## Accepting WFP tenant-subdomain issuers
+
+The control-plane resources above verify the caller's service token against the issuer's published JWKS, allowing `iss` to be either `env.ISSUER` or the host the request arrived on. A Workers-for-Platforms shard, however, signs with **its own** key and issuer (`https://{tenant}.{host}/`), which is neither — so by default such a token is rejected as an issuer mismatch.
+
+Opt those issuers in with `proxyControlPlane.isTrustedIssuer`, a predicate that widens the accepted issuer set to a deployment's own tenant subdomains:
+
+```typescript
+export default init({
+  proxyControlPlane: {
+    // …customDomains / tenantMembers / resolveHost as above.
+    isTrustedIssuer: (iss) => isOwnTenantSubdomain(iss), // e.g. *.auth.example.com
+  },
+});
+```
+
+It is consulted **before** any JWKS fetch — so it still constrains where verifying keys are fetched from — the signature must still verify against the resolved key, and `tenant_id` is still pinned. Return `true` only for issuer hosts you actually serve. The predicate applies to every mounted resource (custom-domains, tenant-members, sync).
+
+::: tip Verifying without reaching the shard
+Pair `isTrustedIssuer` with a `proxyControlPlane.jwksFetch` that resolves each tenant's control-plane-comm public key from a local registry instead of the network, so the control plane never has to fetch keys from — or dispatch to — the shard at verify time. Provisioning the per-tenant credential and registry is deployment wiring; see [issue #1139](https://github.com/markusahlstrand/authhero/issues/1139).
+:::
+
 ## Proxy entity sync
 
 `proxy_routes` are tenant-owned data that the control plane needs for host resolution, so they still replicate **upward** over the outbox. (Custom domains used to travel this way too — that is exactly what left them registered nowhere. They now write through the control plane instead, as described above.)

--- a/packages/authhero/src/index.ts
+++ b/packages/authhero/src/index.ts
@@ -73,12 +73,44 @@ export {
 export {
   CONTROL_PLANE_SYNC_SCOPE,
   CONTROL_PLANE_CUSTOM_DOMAINS_SCOPE,
+  CONTROL_PLANE_TENANT_MEMBERS_SCOPE,
 } from "./routes/proxy-control-plane/scopes";
 export {
   createControlPlaneCustomDomainsAdapter,
   CONTROL_PLANE_CUSTOM_DOMAINS_PATH,
   type ControlPlaneCustomDomainsOptions,
 } from "./adapters/control-plane-custom-domains";
+// Tenant-team self-management (#1137): the backend seam + its two
+// implementations, plus the control-plane resource wiring.
+export {
+  createTenantMembersControlPlaneApp,
+  type TenantMembersControlPlaneOptions,
+} from "./routes/proxy-control-plane/tenant-members";
+export {
+  createTenantMembersRoutes,
+  type GetTenantMembersBackend,
+} from "./routes/management-api/tenant-members";
+export {
+  createLocalTenantMembersBackend,
+  type LocalTenantMembersBackendOptions,
+} from "./tenant-members/local-backend";
+export {
+  createControlPlaneTenantMembersAdapter,
+  type ControlPlaneTenantMembersOptions,
+} from "./tenant-members/remote-backend";
+export { CONTROL_PLANE_TENANT_MEMBERS_PATH } from "./tenant-members/wire";
+export {
+  type TenantMembersBackend,
+  type TenantMember,
+  type TenantMembersListResult,
+  type TenantInvitation,
+  type TenantInvitationInput,
+  type TenantRole,
+  type TenantMembersPageParams,
+  TenantMembersNotFoundError,
+  TenantOrganizationNotFoundError,
+  TenantInvitationNotFoundError,
+} from "./tenant-members/types";
 export {
   createServiceTokenCore,
   type CreateServiceTokenCoreParams,

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -65,6 +65,7 @@ import { ticketsRoutes } from "./tickets";
 import { proxyRoutesRoutes } from "./proxy-routes";
 import { operationRoutes, tenantOperationsRoutes } from "./tenant-operations";
 import { tenantExportImportRoutes } from "./tenant-export-import";
+import { createTenantMembersRoutes } from "./tenant-members";
 import { DataAdapters } from "@authhero/adapter-interfaces";
 import { outboxMiddleware } from "../../middlewares/outbox";
 import { LogsDestination } from "../../helpers/outbox-destinations/logs";
@@ -595,6 +596,17 @@ export default function create(config: AuthHeroConfig) {
   // Only mount core tenant routes if no extension overrides /tenants
   if (!extensionPaths.has("/tenants")) {
     managementApp.route("/tenants", tenantRoutes);
+  }
+
+  // Tenant-team self-management (#1137). Lets a tenant admin manage who
+  // administers the tenant (control-plane organization membership + roles +
+  // invitations) from the per-tenant admin UI, delegating to a backend that
+  // either resolves the org locally or hops to the control plane.
+  if (config.tenantMembers && !extensionPaths.has("/tenant-members")) {
+    managementApp.route(
+      "/tenant-members",
+      createTenantMembersRoutes(config.tenantMembers.getBackend),
+    );
   }
 
   // Mount proxy-routes management when the data adapter exposes one. The

--- a/packages/authhero/src/routes/management-api/tenant-members.test.ts
+++ b/packages/authhero/src/routes/management-api/tenant-members.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import { Hono } from "hono";
+import { createTenantMembersRoutes } from "./tenant-members";
+import type { TenantMembersBackend } from "../../tenant-members/types";
+
+function recordingBackend(): TenantMembersBackend {
+  return {
+    listMembers: vi.fn(async () => ({ members: [], start: 0, limit: 25, total: 0 })),
+    addMembers: vi.fn(async () => {}),
+    removeMembers: vi.fn(async () => {}),
+    listMemberRoles: vi.fn(async () => []),
+    assignMemberRoles: vi.fn(async () => {}),
+    removeMemberRoles: vi.fn(async () => {}),
+    listRoles: vi.fn(async () => []),
+    listInvitations: vi.fn(async () => []),
+    createInvitation: vi.fn(async () => ({}) as never),
+    revokeInvitation: vi.fn(async () => {}),
+  };
+}
+
+/**
+ * Mount the routes behind a middleware that injects the token-derived vars the
+ * real auth middleware would set, so we can exercise the org-claim pin without
+ * a full JWT/data-adapter harness.
+ */
+function makeApp(
+  vars: { tenant_id?: string; org_name?: string },
+  backend: TenantMembersBackend,
+) {
+  const app = new Hono();
+  app.use(async (c, next) => {
+    if (vars.tenant_id) c.set("tenant_id" as never, vars.tenant_id as never);
+    if (vars.org_name) c.set("org_name" as never, vars.org_name as never);
+    await next();
+  });
+  app.route("/tenant-members", createTenantMembersRoutes(() => backend));
+  return app;
+}
+
+describe("/api/v2/tenant-members org-claim pin", () => {
+  it("delegates when org_name matches the tenant", async () => {
+    const backend = recordingBackend();
+    const app = makeApp({ tenant_id: "acme", org_name: "acme" }, backend);
+    const res = await app.fetch(new Request("http://x/tenant-members"));
+    expect(res.status).toBe(200);
+    expect(backend.listMembers).toHaveBeenCalledWith(
+      "acme",
+      expect.any(Object),
+    );
+  });
+
+  it("matches org_name case-insensitively", async () => {
+    const backend = recordingBackend();
+    const app = makeApp({ tenant_id: "acme", org_name: "ACME" }, backend);
+    const res = await app.fetch(new Request("http://x/tenant-members"));
+    expect(res.status).toBe(200);
+  });
+
+  it("forbids a token whose org_name is a different tenant", async () => {
+    const backend = recordingBackend();
+    const app = makeApp({ tenant_id: "acme", org_name: "evil" }, backend);
+    const res = await app.fetch(new Request("http://x/tenant-members"));
+    expect(res.status).toBe(403);
+    expect(backend.listMembers).not.toHaveBeenCalled();
+  });
+
+  it("forbids a token with no org_name (e.g. a plain control-plane token)", async () => {
+    const backend = recordingBackend();
+    const app = makeApp({ tenant_id: "acme" }, backend);
+    const res = await app.fetch(new Request("http://x/tenant-members"));
+    expect(res.status).toBe(403);
+  });
+
+  it("pins writes too — a mismatched org_name cannot invite", async () => {
+    const backend = recordingBackend();
+    const app = makeApp({ tenant_id: "acme", org_name: "evil" }, backend);
+    const res = await app.fetch(
+      new Request("http://x/tenant-members/invitations", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ invitee: { email: "x@acme.com" } }),
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(backend.createInvitation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/authhero/src/routes/management-api/tenant-members.ts
+++ b/packages/authhero/src/routes/management-api/tenant-members.ts
@@ -1,0 +1,362 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { inviteSchema, roleSchema } from "@authhero/adapter-interfaces";
+import { Bindings, Variables } from "../../types";
+import { defineRoute } from "../../utils/define-route";
+import { requireTenantId } from "./helpers";
+import {
+  TenantMembersBackend,
+  TenantMembersNotFoundError,
+  tenantInvitationInputSchema,
+  tenantMemberSchema,
+  tenantMembersListSchema,
+} from "../../tenant-members/types";
+
+type Ctx = Context<{ Bindings: Bindings; Variables: Variables }>;
+
+/** Build the request's backend (local org resolution, or a control-plane hop). */
+export type GetTenantMembersBackend = (
+  ctx: Ctx,
+) => TenantMembersBackend | Promise<TenantMembersBackend>;
+
+/**
+ * Pin the tenant to the caller's verified organization claim. A tenant's team
+ * is an org on the control plane whose `name` equals the tenant id, and access
+ * is granted by the token's `org_name` claim matching that name. Requiring
+ * `org_name === tenant_id` here — server-side, from the token, NOT from the URL
+ * — is what stops a tenant-A admin from managing tenant B by swapping the
+ * `tenant-id` header. (The remote backend independently re-pins the org from
+ * the service token's `tenant_id` claim on the control plane, so this is one of
+ * two independent checks.)
+ */
+function pinnedTenantId(ctx: Ctx): string {
+  const tenantId = requireTenantId(ctx);
+  const orgName = ctx.var.org_name;
+  if (!orgName || orgName.toLowerCase() !== tenantId.toLowerCase()) {
+    throw new HTTPException(403, {
+      message:
+        "Managing this tenant's team requires an organization token whose org_name matches the tenant.",
+    });
+  }
+  return tenantId;
+}
+
+/** Map the backend's "not there" signal to Auth0's 404. */
+async function orNotFound<T>(op: () => Promise<T>): Promise<T> {
+  try {
+    return await op();
+  } catch (err) {
+    if (err instanceof TenantMembersNotFoundError) {
+      throw new HTTPException(404, { message: "Not found" });
+    }
+    throw err;
+  }
+}
+
+const pageQuerySchema = z.object({
+  page: z.coerce.number().int().min(0).optional(),
+  per_page: z.coerce.number().int().min(1).max(100).optional(),
+  q: z.string().optional(),
+});
+
+const userIdsBodySchema = z.object({
+  user_ids: z.array(z.string()).min(1),
+});
+
+const rolesBodySchema = z.object({
+  roles: z.array(z.string()).min(1),
+});
+
+/**
+ * `GET/POST/DELETE /api/v2/tenant-members` — lets a tenant admin manage who
+ * administers their tenant, from the per-tenant admin UI, without a
+ * control-plane login. The heavy lifting (resolving the control-plane org,
+ * writing membership/roles/invitations) is delegated to a
+ * {@link TenantMembersBackend}; this layer only pins the tenant to the token's
+ * org claim and shapes responses.
+ */
+export function createTenantMembersRoutes(getBackend: GetTenantMembersBackend) {
+  const listMembers = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "get",
+      path: "/",
+      request: {
+        query: pageQuerySchema,
+        headers: z.object({ "tenant-id": z.string().optional() }),
+      },
+      security: [{ Bearer: ["read:organizations"] }],
+      responses: {
+        200: {
+          content: { "application/json": { schema: tenantMembersListSchema } },
+          description: "The tenant's team members",
+        },
+      },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const { page, per_page, q } = ctx.req.valid("query");
+      const backend = await getBackend(ctx);
+      const result = await orNotFound(() =>
+        backend.listMembers(tenantId, { page, per_page, q }),
+      );
+      return ctx.json(result);
+    },
+  });
+
+  const addMembers = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "post",
+      path: "/",
+      request: {
+        headers: z.object({ "tenant-id": z.string().optional() }),
+        body: {
+          content: { "application/json": { schema: userIdsBodySchema } },
+        },
+      },
+      security: [{ Bearer: ["update:organizations"] }],
+      responses: { 204: { description: "Members added" } },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const { user_ids } = ctx.req.valid("json");
+      const backend = await getBackend(ctx);
+      await orNotFound(() => backend.addMembers(tenantId, user_ids));
+      return ctx.body(null, 204);
+    },
+  });
+
+  const removeMembers = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "delete",
+      path: "/",
+      request: {
+        headers: z.object({ "tenant-id": z.string().optional() }),
+        body: {
+          content: { "application/json": { schema: userIdsBodySchema } },
+        },
+      },
+      security: [{ Bearer: ["update:organizations"] }],
+      responses: { 204: { description: "Members removed" } },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const { user_ids } = ctx.req.valid("json");
+      const backend = await getBackend(ctx);
+      await orNotFound(() => backend.removeMembers(tenantId, user_ids));
+      return ctx.body(null, 204);
+    },
+  });
+
+  const listMemberRoles = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "get",
+      path: "/{user_id}/roles",
+      request: {
+        params: z.object({ user_id: z.string() }),
+        headers: z.object({ "tenant-id": z.string().optional() }),
+      },
+      security: [{ Bearer: ["read:organization_member_roles"] }],
+      responses: {
+        200: {
+          content: { "application/json": { schema: z.array(roleSchema) } },
+          description: "The member's roles in the tenant",
+        },
+      },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const { user_id } = ctx.req.valid("param");
+      const backend = await getBackend(ctx);
+      const roles = await orNotFound(() =>
+        backend.listMemberRoles(tenantId, user_id),
+      );
+      return ctx.json(roles);
+    },
+  });
+
+  const assignMemberRoles = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "post",
+      path: "/{user_id}/roles",
+      request: {
+        params: z.object({ user_id: z.string() }),
+        headers: z.object({ "tenant-id": z.string().optional() }),
+        body: { content: { "application/json": { schema: rolesBodySchema } } },
+      },
+      security: [{ Bearer: ["create:organization_member_roles"] }],
+      responses: { 204: { description: "Roles assigned" } },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const { user_id } = ctx.req.valid("param");
+      const { roles } = ctx.req.valid("json");
+      const backend = await getBackend(ctx);
+      await orNotFound(() =>
+        backend.assignMemberRoles(tenantId, user_id, roles),
+      );
+      return ctx.body(null, 204);
+    },
+  });
+
+  const removeMemberRoles = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "delete",
+      path: "/{user_id}/roles",
+      request: {
+        params: z.object({ user_id: z.string() }),
+        headers: z.object({ "tenant-id": z.string().optional() }),
+        body: { content: { "application/json": { schema: rolesBodySchema } } },
+      },
+      security: [{ Bearer: ["delete:organization_member_roles"] }],
+      responses: { 204: { description: "Roles removed" } },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const { user_id } = ctx.req.valid("param");
+      const { roles } = ctx.req.valid("json");
+      const backend = await getBackend(ctx);
+      await orNotFound(() =>
+        backend.removeMemberRoles(tenantId, user_id, roles),
+      );
+      return ctx.body(null, 204);
+    },
+  });
+
+  const listRoles = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "get",
+      path: "/roles",
+      request: {
+        query: pageQuerySchema,
+        headers: z.object({ "tenant-id": z.string().optional() }),
+      },
+      security: [{ Bearer: ["read:roles"] }],
+      responses: {
+        200: {
+          content: { "application/json": { schema: z.array(roleSchema) } },
+          description: "Roles that can be granted to a team member",
+        },
+      },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const { page, per_page, q } = ctx.req.valid("query");
+      const backend = await getBackend(ctx);
+      const roles = await orNotFound(() =>
+        backend.listRoles(tenantId, { page, per_page, q }),
+      );
+      return ctx.json(roles);
+    },
+  });
+
+  const listInvitations = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "get",
+      path: "/invitations",
+      request: {
+        query: pageQuerySchema,
+        headers: z.object({ "tenant-id": z.string().optional() }),
+      },
+      security: [{ Bearer: ["read:organizations"] }],
+      responses: {
+        200: {
+          content: { "application/json": { schema: z.array(inviteSchema) } },
+          description: "Pending team invitations",
+        },
+      },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const { page, per_page } = ctx.req.valid("query");
+      const backend = await getBackend(ctx);
+      const invites = await orNotFound(() =>
+        backend.listInvitations(tenantId, { page, per_page }),
+      );
+      return ctx.json(invites);
+    },
+  });
+
+  const createInvitation = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "post",
+      path: "/invitations",
+      request: {
+        headers: z.object({ "tenant-id": z.string().optional() }),
+        body: {
+          content: {
+            "application/json": { schema: tenantInvitationInputSchema },
+          },
+        },
+      },
+      security: [{ Bearer: ["update:organizations"] }],
+      responses: {
+        201: {
+          content: { "application/json": { schema: inviteSchema } },
+          description: "The created invitation",
+        },
+      },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const input = ctx.req.valid("json");
+      const backend = await getBackend(ctx);
+      const invite = await orNotFound(() =>
+        backend.createInvitation(tenantId, input),
+      );
+      return ctx.json(invite, 201);
+    },
+  });
+
+  const revokeInvitation = defineRoute({
+    route: createRoute({
+      tags: ["tenant-members"],
+      method: "delete",
+      path: "/invitations/{invitation_id}",
+      request: {
+        params: z.object({ invitation_id: z.string() }),
+        headers: z.object({ "tenant-id": z.string().optional() }),
+      },
+      security: [{ Bearer: ["update:organizations"] }],
+      responses: { 204: { description: "Invitation revoked" } },
+    }),
+    handler: async (ctx) => {
+      const tenantId = pinnedTenantId(ctx);
+      const { invitation_id } = ctx.req.valid("param");
+      const backend = await getBackend(ctx);
+      await orNotFound(() =>
+        backend.revokeInvitation(tenantId, invitation_id),
+      );
+      return ctx.body(null, 204);
+    },
+  });
+
+  return new OpenAPIHono<{
+    Bindings: Bindings;
+    Variables: Variables;
+  }>().openapiRoutes([
+    // More specific literal paths before the `/{user_id}` param routes so
+    // `/roles` and `/invitations` are not swallowed by `/{user_id}/roles`.
+    listRoles,
+    listInvitations,
+    createInvitation,
+    revokeInvitation,
+    listMembers,
+    addMembers,
+    removeMembers,
+    listMemberRoles,
+    assignMemberRoles,
+    removeMemberRoles,
+  ] as const);
+}
+
+export { tenantMemberSchema };

--- a/packages/authhero/src/routes/proxy-control-plane/index.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/index.ts
@@ -12,8 +12,13 @@ import { SyncEvent } from "../../helpers/control-plane-sync-events";
 import { Bindings } from "../../types";
 import { createCustomDomainsControlPlaneApp } from "./custom-domains";
 import {
+  createTenantMembersControlPlaneApp,
+  type TenantMembersControlPlaneOptions,
+} from "./tenant-members";
+import {
   CONTROL_PLANE_CUSTOM_DOMAINS_SCOPE,
   CONTROL_PLANE_SYNC_SCOPE,
+  CONTROL_PLANE_TENANT_MEMBERS_SCOPE,
   PROXY_RESOLVE_HOST_SCOPE,
 } from "./scopes";
 import {
@@ -78,6 +83,19 @@ export interface ProxyControlPlaneOptions {
    * login.acme.com" needs a view across every tenant that only exists here.
    */
   customDomains?: CustomDomainsAdapter;
+
+  /**
+   * The authoritative tenant-team resource. When set, mounts
+   * `/api/v2/proxy/control-plane/tenant-members` — the resource tenant shards
+   * call through `createControlPlaneTenantMembersAdapter` to let their admins
+   * manage who administers the tenant (control-plane organization membership +
+   * org-scoped roles + invitations), rows the shard itself cannot write.
+   *
+   * Wire the backend to the control-plane database (see
+   * `createLocalTenantMembersBackend`); the org is pinned from the verified
+   * token, never the request.
+   */
+  tenantMembers?: TenantMembersControlPlaneOptions;
 }
 
 function extractBearerToken(request: Request): string | null {
@@ -178,6 +196,18 @@ export function createProxyControlPlaneApp(
       createCustomDomainsControlPlaneApp({
         customDomains: options.customDomains,
         authenticate: authenticateWithScope(CONTROL_PLANE_CUSTOM_DOMAINS_SCOPE),
+      }),
+    );
+  }
+
+  if (options.tenantMembers) {
+    app.route(
+      "/tenant-members",
+      createTenantMembersControlPlaneApp({
+        getBackend: options.tenantMembers.getBackend,
+        authenticate: authenticateWithScope(
+          CONTROL_PLANE_TENANT_MEMBERS_SCOPE,
+        ),
       }),
     );
   }

--- a/packages/authhero/src/routes/proxy-control-plane/index.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/index.ts
@@ -56,6 +56,17 @@ export interface ProxyControlPlaneOptions {
   jwksFetch?: (url: string) => Promise<Response>;
 
   /**
+   * Optional predicate that widens the set of accepted token issuers beyond
+   * `env.ISSUER` and the inbound host — specifically to a deployment's own
+   * Workers-for-Platforms tenant subdomains, whose per-tenant control-plane
+   * credential `jwksFetch` resolves locally (see #1139). Consulted before any
+   * JWKS fetch, so it still constrains where keys are fetched from; return
+   * `true` only for issuer hosts you serve. Applies to every mounted resource
+   * (custom-domains, tenant-members, sync).
+   */
+  isTrustedIssuer?: (iss: string) => boolean;
+
+  /**
    * Optional handler for `POST /sync` — receives `controlplane.sync.*` events
    * emitted by tenant shards via `ControlPlaneSyncDestination` and replicates
    * the mutation into the control-plane data store. When omitted, the
@@ -165,6 +176,7 @@ export function createProxyControlPlaneApp(
       jwksFetch: options.jwksFetch,
       expectedIssuers,
       requiredScope,
+      isTrustedIssuer: options.isTrustedIssuer,
     });
   }
 

--- a/packages/authhero/src/routes/proxy-control-plane/scopes.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/scopes.ts
@@ -13,4 +13,12 @@ export const CONTROL_PLANE_SYNC_SCOPE = "controlplane:sync";
  */
 export const CONTROL_PLANE_CUSTOM_DOMAINS_SCOPE = "controlplane:custom_domains";
 
+/**
+ * Scope required by the authoritative `/tenant-members` resource on the control
+ * plane — a tenant's team (organization membership + org-scoped roles +
+ * invitations) that only the control plane can write. Tenant shards mint a
+ * token with this scope through `createControlPlaneTenantMembersAdapter`.
+ */
+export const CONTROL_PLANE_TENANT_MEMBERS_SCOPE = "controlplane:tenant_members";
+
 export { PROXY_RESOLVE_HOST_SCOPE };

--- a/packages/authhero/src/routes/proxy-control-plane/tenant-members.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/tenant-members.ts
@@ -1,0 +1,264 @@
+import { Hono, type Context } from "hono";
+import { Bindings } from "../../types";
+import {
+  TenantMembersBackend,
+  TenantMembersNotFoundError,
+} from "../../tenant-members/types";
+import {
+  createInvitationBodySchema,
+  memberRolesBodySchema,
+  membersMutationBodySchema,
+} from "../../tenant-members/wire";
+import type { AuthenticateControlPlane } from "./custom-domains";
+
+type TenantVars = { tenantId: string };
+
+/** Context seen by the control-plane resource: env + the pinned tenant id. */
+type CpCtx = Context<{ Bindings: Bindings; Variables: TenantVars }>;
+
+export interface TenantMembersControlPlaneOptions {
+  /**
+   * Build the backend for a request. Bound to the control-plane database
+   * (`c.env.data`) and, optionally, an email sender at wire-up time. The tenant
+   * is pinned separately from the verified token, so the factory does not need
+   * it.
+   */
+  getBackend: (
+    c: CpCtx,
+  ) => TenantMembersBackend | Promise<TenantMembersBackend>;
+  authenticate: AuthenticateControlPlane;
+}
+
+/**
+ * The authoritative `tenant-members` resource. Tenant shards reach it through
+ * `createControlPlaneTenantMembersAdapter`; it manages the control-plane
+ * organization that models a tenant's team — rows the shard cannot write.
+ *
+ * Every operation is bound to the `tenant_id` claim of the verified token. The
+ * scope alone is not authorization: each shard holds it, so a request-supplied
+ * tenant id would let any shard read or edit any other tenant's team. Mount
+ * under `/api/v2/proxy/control-plane/tenant-members`.
+ */
+export function createTenantMembersControlPlaneApp(
+  options: TenantMembersControlPlaneOptions,
+): Hono<{ Bindings: Bindings; Variables: TenantVars }> {
+  const app = new Hono<{ Bindings: Bindings; Variables: TenantVars }>();
+  const { getBackend, authenticate } = options;
+
+  app.use("*", async (c, next) => {
+    const result = await authenticate(c);
+    if (!result.ok) {
+      console.warn(
+        `[proxy/control-plane/tenant-members] authentication failed: ${result.reason}`,
+      );
+      return c.text("Unauthorized", 401, { "WWW-Authenticate": "Bearer" });
+    }
+    // Fail closed: a token with no tenant binding cannot act on any team.
+    if (!result.tenantId) {
+      console.warn(
+        "[proxy/control-plane/tenant-members] token carries no tenant_id claim",
+      );
+      return c.text("Forbidden", 403);
+    }
+    c.set("tenantId", result.tenantId);
+    return next();
+  });
+
+  /**
+   * Refuse a request that names a tenant other than the one it authenticated
+   * as, instead of silently acting on the authenticated tenant.
+   */
+  function claimedMismatch(tenantId: string, claimed: string | undefined) {
+    return claimed !== undefined && claimed !== tenantId;
+  }
+
+  async function readJson(c: CpCtx): Promise<unknown | undefined> {
+    try {
+      return await c.req.json();
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Map the backend's "not there" signal to 404; everything else propagates to
+  // the app's onError.
+  async function run<T>(
+    c: CpCtx,
+    op: () => Promise<T>,
+  ): Promise<Response | T> {
+    try {
+      return await op();
+    } catch (err) {
+      if (err instanceof TenantMembersNotFoundError) {
+        return c.text("Not found", 404);
+      }
+      throw err;
+    }
+  }
+
+  app.get("/members", async (c) => {
+    const tenantId = c.get("tenantId");
+    if (claimedMismatch(tenantId, c.req.query("tenant_id"))) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const page = c.req.query("page");
+    const perPage = c.req.query("per_page");
+    const result = await run(c, () =>
+      backend.listMembers(tenantId, {
+        page: page ? Number(page) : undefined,
+        per_page: perPage ? Number(perPage) : undefined,
+        q: c.req.query("q") || undefined,
+      }),
+    );
+    return result instanceof Response ? result : c.json(result);
+  });
+
+  app.post("/members", async (c) => {
+    const tenantId = c.get("tenantId");
+    const parsed = membersMutationBodySchema.safeParse(await readJson(c));
+    if (!parsed.success) {
+      return c.json({ error: "invalid_request", details: parsed.error.issues }, 400);
+    }
+    if (claimedMismatch(tenantId, parsed.data.tenant_id)) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const r = await run(c, () =>
+      backend.addMembers(tenantId, parsed.data.user_ids),
+    );
+    return r instanceof Response ? r : c.body(null, 204);
+  });
+
+  app.delete("/members", async (c) => {
+    const tenantId = c.get("tenantId");
+    const parsed = membersMutationBodySchema.safeParse(await readJson(c));
+    if (!parsed.success) {
+      return c.json({ error: "invalid_request", details: parsed.error.issues }, 400);
+    }
+    if (claimedMismatch(tenantId, parsed.data.tenant_id)) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const r = await run(c, () =>
+      backend.removeMembers(tenantId, parsed.data.user_ids),
+    );
+    return r instanceof Response ? r : c.body(null, 204);
+  });
+
+  app.get("/members/:user_id/roles", async (c) => {
+    const tenantId = c.get("tenantId");
+    if (claimedMismatch(tenantId, c.req.query("tenant_id"))) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const r = await run(c, () =>
+      backend.listMemberRoles(tenantId, c.req.param("user_id")),
+    );
+    return r instanceof Response ? r : c.json(r);
+  });
+
+  app.post("/members/:user_id/roles", async (c) => {
+    const tenantId = c.get("tenantId");
+    const parsed = memberRolesBodySchema.safeParse(await readJson(c));
+    if (!parsed.success) {
+      return c.json({ error: "invalid_request", details: parsed.error.issues }, 400);
+    }
+    if (claimedMismatch(tenantId, parsed.data.tenant_id)) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const r = await run(c, () =>
+      backend.assignMemberRoles(
+        tenantId,
+        c.req.param("user_id"),
+        parsed.data.roles,
+      ),
+    );
+    return r instanceof Response ? r : c.body(null, 204);
+  });
+
+  app.delete("/members/:user_id/roles", async (c) => {
+    const tenantId = c.get("tenantId");
+    const parsed = memberRolesBodySchema.safeParse(await readJson(c));
+    if (!parsed.success) {
+      return c.json({ error: "invalid_request", details: parsed.error.issues }, 400);
+    }
+    if (claimedMismatch(tenantId, parsed.data.tenant_id)) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const r = await run(c, () =>
+      backend.removeMemberRoles(
+        tenantId,
+        c.req.param("user_id"),
+        parsed.data.roles,
+      ),
+    );
+    return r instanceof Response ? r : c.body(null, 204);
+  });
+
+  app.get("/roles", async (c) => {
+    const tenantId = c.get("tenantId");
+    if (claimedMismatch(tenantId, c.req.query("tenant_id"))) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const page = c.req.query("page");
+    const perPage = c.req.query("per_page");
+    const r = await run(c, () =>
+      backend.listRoles(tenantId, {
+        page: page ? Number(page) : undefined,
+        per_page: perPage ? Number(perPage) : undefined,
+        q: c.req.query("q") || undefined,
+      }),
+    );
+    return r instanceof Response ? r : c.json(r);
+  });
+
+  app.get("/invitations", async (c) => {
+    const tenantId = c.get("tenantId");
+    if (claimedMismatch(tenantId, c.req.query("tenant_id"))) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const page = c.req.query("page");
+    const perPage = c.req.query("per_page");
+    const r = await run(c, () =>
+      backend.listInvitations(tenantId, {
+        page: page ? Number(page) : undefined,
+        per_page: perPage ? Number(perPage) : undefined,
+      }),
+    );
+    return r instanceof Response ? r : c.json(r);
+  });
+
+  app.post("/invitations", async (c) => {
+    const tenantId = c.get("tenantId");
+    const parsed = createInvitationBodySchema.safeParse(await readJson(c));
+    if (!parsed.success) {
+      return c.json({ error: "invalid_request", details: parsed.error.issues }, 400);
+    }
+    const { tenant_id: claimed, ...input } = parsed.data;
+    if (claimedMismatch(tenantId, claimed)) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const r = await run(c, () => backend.createInvitation(tenantId, input));
+    return r instanceof Response ? r : c.json(r, 201);
+  });
+
+  app.delete("/invitations/:id", async (c) => {
+    const tenantId = c.get("tenantId");
+    if (claimedMismatch(tenantId, c.req.query("tenant_id"))) {
+      return c.text("Forbidden", 403);
+    }
+    const backend = await getBackend(c);
+    const r = await run(c, () =>
+      backend.revokeInvitation(tenantId, c.req.param("id")),
+    );
+    return r instanceof Response ? r : c.body(null, 204);
+  });
+
+  return app;
+}

--- a/packages/authhero/src/routes/proxy-control-plane/verify.test.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/verify.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { verifyControlPlaneToken } from "./verify";
+
+/** Craft an (unsigned) compact JWT the verifier can `decode()` for its header/iss. */
+function makeToken(header: object, payload: object): string {
+  const b64 = (o: object) =>
+    Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64(header)}.${b64(payload)}.sig`;
+}
+
+const CP_ISSUER = "https://cp.example.com/";
+const TENANT_ISSUER = "https://acme.cp.example.com/";
+
+describe("verifyControlPlaneToken issuer allow-list", () => {
+  const header = { alg: "RS256", kid: "k1" };
+  const payload = {
+    iss: TENANT_ISSUER,
+    scope: "controlplane:tenant_members",
+    tenant_id: "acme",
+  };
+
+  it("rejects a WFP tenant-subdomain issuer with issuer mismatch (before any fetch)", async () => {
+    const jwksFetch = vi.fn(async () => new Response("{}"));
+    const result = await verifyControlPlaneToken({
+      token: makeToken(header, payload),
+      jwksFetch,
+      expectedIssuers: [CP_ISSUER],
+      requiredScope: "controlplane:tenant_members",
+    });
+    expect(result).toEqual({ ok: false, reason: "issuer mismatch" });
+    // The SSRF guard: no key fetch happens for a disallowed issuer.
+    expect(jwksFetch).not.toHaveBeenCalled();
+  });
+
+  it("passes the issuer gate when isTrustedIssuer accepts the subdomain, then fetches its JWKS", async () => {
+    // Return an empty key set so verification fails AFTER the issuer gate — we
+    // only care that the gate let it through and the fetch targeted the
+    // tenant-subdomain JWKS.
+    const jwksFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ keys: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const isTrustedIssuer = vi.fn(
+      (iss: string) => iss === TENANT_ISSUER,
+    );
+
+    const result = await verifyControlPlaneToken({
+      token: makeToken(header, payload),
+      jwksFetch,
+      expectedIssuers: [CP_ISSUER],
+      requiredScope: "controlplane:tenant_members",
+      isTrustedIssuer,
+    });
+
+    expect(isTrustedIssuer).toHaveBeenCalledWith(TENANT_ISSUER);
+    expect(jwksFetch).toHaveBeenCalledWith(
+      "https://acme.cp.example.com/.well-known/jwks.json",
+    );
+    // Gate passed; failure is now "unknown kid" (empty key set), not issuer.
+    expect(result).toEqual({ ok: false, reason: "unknown kid" });
+  });
+
+  it("does not consult isTrustedIssuer for an issuer already in expectedIssuers", async () => {
+    const jwksFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ keys: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const isTrustedIssuer = vi.fn(() => false);
+    await verifyControlPlaneToken({
+      token: makeToken(header, { ...payload, iss: CP_ISSUER }),
+      jwksFetch,
+      expectedIssuers: [CP_ISSUER],
+      requiredScope: "controlplane:tenant_members",
+      isTrustedIssuer,
+    });
+    // expectedIssuers matched first; the predicate short-circuits.
+    expect(isTrustedIssuer).not.toHaveBeenCalled();
+  });
+
+  it("still rejects an untrusted issuer when the predicate returns false", async () => {
+    const jwksFetch = vi.fn(async () => new Response("{}"));
+    const result = await verifyControlPlaneToken({
+      token: makeToken(header, { ...payload, iss: "https://evil.example.com/" }),
+      jwksFetch,
+      expectedIssuers: [CP_ISSUER],
+      requiredScope: "controlplane:tenant_members",
+      isTrustedIssuer: (iss) => iss === TENANT_ISSUER,
+    });
+    expect(result).toEqual({ ok: false, reason: "issuer mismatch" });
+    expect(jwksFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/authhero/src/routes/proxy-control-plane/verify.test.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/verify.test.ts
@@ -79,6 +79,21 @@ describe("verifyControlPlaneToken issuer allow-list", () => {
     expect(isTrustedIssuer).not.toHaveBeenCalled();
   });
 
+  it("rejects (does not throw) when isTrustedIssuer accepts a malformed issuer URL", async () => {
+    const jwksFetch = vi.fn(async () => new Response("{}"));
+    const result = await verifyControlPlaneToken({
+      token: makeToken(header, { ...payload, iss: "not a url" }),
+      jwksFetch,
+      expectedIssuers: [CP_ISSUER],
+      requiredScope: "controlplane:tenant_members",
+      // A permissive predicate lets an unparseable issuer past the allow-list;
+      // deriving its JWKS URL must fail closed, not throw.
+      isTrustedIssuer: () => true,
+    });
+    expect(result).toEqual({ ok: false, reason: "malformed issuer url" });
+    expect(jwksFetch).not.toHaveBeenCalled();
+  });
+
   it("still rejects an untrusted issuer when the predicate returns false", async () => {
     const jwksFetch = vi.fn(async () => new Response("{}"));
     const result = await verifyControlPlaneToken({

--- a/packages/authhero/src/routes/proxy-control-plane/verify.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/verify.ts
@@ -147,7 +147,16 @@ export async function verifyControlPlaneToken(
   }
   const iss = issRaw;
 
-  const jwksUrl = deriveJwksUrl(iss);
+  // `expectedIssuers` matches parse `iss` as a URL, but a custom
+  // `isTrustedIssuer` might accept a string that isn't a valid absolute URL —
+  // in which case `deriveJwksUrl` (`new URL(...)`) throws. Reject gracefully
+  // rather than letting a TypeError escape.
+  let jwksUrl: string;
+  try {
+    jwksUrl = deriveJwksUrl(iss);
+  } catch {
+    return { ok: false, reason: "malformed issuer url" };
+  }
   const fetchFn = jwksFetch ?? fetch;
   let jwksRes: Response;
   try {

--- a/packages/authhero/src/routes/proxy-control-plane/verify.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/verify.ts
@@ -71,6 +71,20 @@ export interface VerifyControlPlaneTokenOptions {
    * `proxy:resolve_host`.
    */
   requiredScope?: string | string[];
+  /**
+   * Optional predicate consulted IN ADDITION to `expectedIssuers`, for issuers
+   * that can't be enumerated ahead of time — specifically a deployment's own
+   * Workers-for-Platforms tenant subdomains (`https://{tenant}.{host}/`), whose
+   * per-tenant control-plane credential the accompanying `jwksFetch` resolves
+   * locally (see #1139).
+   *
+   * Like `expectedIssuers`, it runs BEFORE the JWKS fetch, so it still gates
+   * where the verifier will fetch keys from: return `true` only for issuer
+   * hosts you actually serve. The signature must still verify against the
+   * resolved key, so this does not broaden trust beyond "a caller holding that
+   * tenant's registered private key."
+   */
+  isTrustedIssuer?: (iss: string) => boolean;
 }
 
 function deriveJwksUrl(iss: string): string {
@@ -118,15 +132,20 @@ export async function verifyControlPlaneToken(
 
   // Allow-list the issuer BEFORE fetching anything: this is what prevents a
   // forged token from steering the JWKS fetch to an attacker-controlled host.
+  // The optional `isTrustedIssuer` predicate widens the allow-list to a
+  // deployment's own WFP tenant subdomains, but is still consulted here — ahead
+  // of the fetch — so the SSRF guarantee holds.
+  const issRaw = unverifiedPayload.iss;
   if (
-    typeof unverifiedPayload.iss !== "string" ||
-    !expectedIssuers.some((expected) =>
-      isAllowedIssuer(unverifiedPayload.iss as string, expected),
+    typeof issRaw !== "string" ||
+    !(
+      expectedIssuers.some((expected) => isAllowedIssuer(issRaw, expected)) ||
+      options.isTrustedIssuer?.(issRaw) === true
     )
   ) {
     return { ok: false, reason: "issuer mismatch" };
   }
-  const iss = unverifiedPayload.iss;
+  const iss = issRaw;
 
   const jwksUrl = deriveJwksUrl(iss);
   const fetchFn = jwksFetch ?? fetch;

--- a/packages/authhero/src/tenant-members/control-plane-roundtrip.test.ts
+++ b/packages/authhero/src/tenant-members/control-plane-roundtrip.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { createControlPlaneClient } from "../helpers/control-plane-client";
+import { createTenantMembersControlPlaneApp } from "../routes/proxy-control-plane/tenant-members";
+import { createControlPlaneTenantMembersAdapter } from "./remote-backend";
+import { createLocalTenantMembersBackend } from "./local-backend";
+import { CONTROL_PLANE_TENANT_MEMBERS_PATH } from "./wire";
+import type { AuthenticateControlPlane } from "../routes/proxy-control-plane/custom-domains";
+
+const CP = "control-plane";
+const ACME = "acme";
+const EVIL = "evil";
+
+// The service token stands in for a real JWT: its embedded tenant is the
+// `tenant_id` claim the control plane pins on. `tok::<tenant>`.
+type Fetchable = { fetch(req: Request): Response | Promise<Response> };
+
+const authenticate: AuthenticateControlPlane = async (c) => {
+  const header = c.req.raw.headers.get("authorization") ?? "";
+  const match = /^Bearer\s+tok::(.*)$/.exec(header);
+  if (!match) return { ok: false, reason: "bad token" };
+  const tenant = match[1] ?? "";
+  return { ok: true, tenantId: tenant || undefined };
+};
+
+/** Minimal control-plane adapters, seeded with acme's org + one user + role. */
+function makeControlPlaneData() {
+  const users = new Map<string, any>([
+    ["u1", { user_id: "u1", email: "a@acme.com", name: "Ann" }],
+  ]);
+  const roles = new Map<string, any>([
+    ["role_admin", { id: "role_admin", name: "Tenant Admin" }],
+  ]);
+  const organizations = new Map<string, any>([
+    ["org_acme", { id: "org_acme", name: ACME, display_name: "Acme" }],
+  ]);
+  const userOrgs: any[] = [];
+  const userRoles: any[] = [];
+  let seq = 0;
+
+  return {
+    organizations: {
+      async get(_t: string, id: string) {
+        return (
+          organizations.get(id) ??
+          [...organizations.values()].find((o) => o.name === id) ??
+          null
+        );
+      },
+    },
+    users: { async get(_t: string, id: string) { return users.get(id) ?? null; } },
+    roles: {
+      async get(_t: string, id: string) { return roles.get(id) ?? null; },
+      async list() {
+        return { roles: [...roles.values()], start: 0, limit: 100, length: roles.size };
+      },
+    },
+    userOrganizations: {
+      async list(_t: string, params: any) {
+        const q = params?.q ?? "";
+        let rows = userOrgs;
+        if (q.startsWith("organization_id:"))
+          rows = userOrgs.filter((r) => r.organization_id === q.slice(16));
+        else if (q.startsWith("user_id:"))
+          rows = userOrgs.filter((r) => r.user_id === q.slice(8));
+        return { userOrganizations: rows, start: 0, limit: 100, length: rows.length };
+      },
+      async create(_t: string, params: any) {
+        const row = { id: `uo_${++seq}`, ...params };
+        userOrgs.push(row);
+        return row;
+      },
+      async remove(_t: string, id: string) {
+        const i = userOrgs.findIndex((r) => r.id === id);
+        if (i >= 0) userOrgs.splice(i, 1);
+        return i >= 0;
+      },
+    },
+    userRoles: {
+      async list(_t: string, userId: string, _p: any, orgId?: string) {
+        return userRoles
+          .filter((r) => r.user_id === userId && r.organization_id === (orgId ?? ""))
+          .map((r) => roles.get(r.role_id))
+          .filter(Boolean);
+      },
+      async create(_t: string, u: string, r: string, o?: string) {
+        userRoles.push({ user_id: u, role_id: r, organization_id: o ?? "" });
+        return true;
+      },
+      async remove() { return true; },
+    },
+    invites: {
+      async list() { return { invites: [], start: 0, limit: 100, length: 0 }; },
+      async get() { return null; },
+      async create(_t: string, p: any) { return { ...p }; },
+      async remove() { return true; },
+    },
+  } as any;
+}
+
+/** Wire a remote adapter whose transport dispatches into the control-plane app. */
+function makeRemote(app: Fetchable) {
+  const client = createControlPlaneClient({
+    baseUrl: "https://cp.example.com",
+    getServiceToken: async (tenantId) => `tok::${tenantId}`,
+    fetchImpl: async (input, init) => {
+      // Rewrite onto the app; only the path matters to the Hono router.
+      const url = typeof input === "string" ? input : new Request(input).url;
+      const path = url.replace("https://cp.example.com", "");
+      return app.fetch(new Request(`http://cp${path}`, init ?? undefined));
+    },
+  });
+  return createControlPlaneTenantMembersAdapter({ client });
+}
+
+function makeApp(data = makeControlPlaneData()) {
+  const backend = createLocalTenantMembersBackend({
+    data,
+    controlPlaneTenantId: CP,
+    issuer: "https://cp.example.com/",
+    invitationClientId: "invite-client",
+  });
+  // Mount at the real base path so the remote adapter's paths line up.
+  const root = new Hono();
+  root.route(
+    CONTROL_PLANE_TENANT_MEMBERS_PATH,
+    createTenantMembersControlPlaneApp({ getBackend: () => backend, authenticate }),
+  );
+  return { app: root, data };
+}
+
+describe("tenant-members control-plane round trip", () => {
+  let app: Fetchable;
+  beforeEach(() => {
+    app = makeApp().app;
+  });
+
+  it("delegates a full add → list cycle, pinned to the token's tenant", async () => {
+    const remote = makeRemote(app);
+    await remote.addMembers(ACME, ["u1"]);
+    await remote.assignMemberRoles(ACME, "u1", ["role_admin"]);
+
+    const result = await remote.listMembers(ACME);
+    expect(result.members.map((m) => m.user_id)).toEqual(["u1"]);
+    expect(result.members[0]?.roles.map((r) => r.id)).toEqual(["role_admin"]);
+  });
+
+  it("rejects a body that names a tenant other than the token's (no cross-tenant writes)", async () => {
+    // Token is for acme, but the body claims evil. The control plane must 403,
+    // NOT act on acme silently and NOT act on evil.
+    const res = await app.fetch(
+      new Request(`http://cp${CONTROL_PLANE_TENANT_MEMBERS_PATH}/members`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer tok::${ACME}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ tenant_id: EVIL, user_ids: ["u1"] }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a mismatched tenant_id query on reads", async () => {
+    const res = await app.fetch(
+      new Request(
+        `http://cp${CONTROL_PLANE_TENANT_MEMBERS_PATH}/members?tenant_id=${EVIL}`,
+        { headers: { authorization: `Bearer tok::${ACME}` } },
+      ),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("fails closed for a token that carries no tenant binding", async () => {
+    const res = await app.fetch(
+      new Request(`http://cp${CONTROL_PLANE_TENANT_MEMBERS_PATH}/members`, {
+        headers: { authorization: "Bearer tok::" },
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects an unauthenticated request", async () => {
+    const res = await app.fetch(
+      new Request(`http://cp${CONTROL_PLANE_TENANT_MEMBERS_PATH}/members`),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("surfaces a missing organization as a not-found", async () => {
+    const remote = makeRemote(app);
+    // 'ghost' has no org; the token is minted for ghost, the control plane
+    // resolves no org and returns 404, which the adapter maps to the typed
+    // not-found error.
+    await expect(remote.listMembers("ghost")).rejects.toThrow(
+      /no organization/i,
+    );
+  });
+});

--- a/packages/authhero/src/tenant-members/local-backend.test.ts
+++ b/packages/authhero/src/tenant-members/local-backend.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createLocalTenantMembersBackend } from "./local-backend";
+import {
+  TenantInvitationNotFoundError,
+  TenantOrganizationNotFoundError,
+} from "./types";
+
+const CP = "control-plane"; // control-plane tenant id
+const TENANT = "acme"; // child tenant id == org name
+
+/**
+ * A tiny in-memory stand-in for the six control-plane adapters the backend
+ * touches. Only the methods the backend calls are implemented.
+ */
+function makeData() {
+  const organizations = new Map<string, any>();
+  const users = new Map<string, any>();
+  const roles = new Map<string, any>();
+  const userOrgs: any[] = [];
+  const userRoles: any[] = []; // { user_id, role_id, organization_id }
+  const invites = new Map<string, any>();
+  let seq = 0;
+
+  organizations.set("org_acme", {
+    id: "org_acme",
+    name: TENANT,
+    display_name: "Acme",
+  });
+
+  const data = {
+    organizations: {
+      async get(_t: string, id: string) {
+        // id-or-name resolution, matching the real adapter.
+        return (
+          organizations.get(id) ??
+          [...organizations.values()].find((o) => o.name === id) ??
+          null
+        );
+      },
+    },
+    users: {
+      async get(_t: string, id: string) {
+        return users.get(id) ?? null;
+      },
+    },
+    roles: {
+      async get(_t: string, id: string) {
+        return roles.get(id) ?? null;
+      },
+      async list() {
+        return {
+          roles: [...roles.values()],
+          start: 0,
+          limit: 100,
+          length: roles.size,
+        };
+      },
+    },
+    userOrganizations: {
+      async list(_t: string, params: any) {
+        const q = params?.q ?? "";
+        let rows = userOrgs;
+        if (q.startsWith("organization_id:")) {
+          const id = q.slice("organization_id:".length);
+          rows = userOrgs.filter((r) => r.organization_id === id);
+        } else if (q.startsWith("user_id:")) {
+          const id = q.slice("user_id:".length);
+          rows = userOrgs.filter((r) => r.user_id === id);
+        }
+        return {
+          userOrganizations: rows,
+          start: 0,
+          limit: params?.per_page ?? 25,
+          length: rows.length,
+        };
+      },
+      async create(_t: string, params: any) {
+        const row = { id: `uo_${++seq}`, ...params };
+        userOrgs.push(row);
+        return row;
+      },
+      async remove(_t: string, id: string) {
+        const i = userOrgs.findIndex((r) => r.id === id);
+        if (i === -1) return false;
+        userOrgs.splice(i, 1);
+        return true;
+      },
+    },
+    userRoles: {
+      async list(_t: string, userId: string, _p: any, orgId?: string) {
+        return userRoles
+          .filter(
+            (r) => r.user_id === userId && r.organization_id === (orgId ?? ""),
+          )
+          .map((r) => roles.get(r.role_id))
+          .filter(Boolean);
+      },
+      async create(
+        _t: string,
+        userId: string,
+        roleId: string,
+        orgId?: string,
+      ) {
+        userRoles.push({
+          user_id: userId,
+          role_id: roleId,
+          organization_id: orgId ?? "",
+        });
+        return true;
+      },
+      async remove(
+        _t: string,
+        userId: string,
+        roleId: string,
+        orgId?: string,
+      ) {
+        const i = userRoles.findIndex(
+          (r) =>
+            r.user_id === userId &&
+            r.role_id === roleId &&
+            r.organization_id === (orgId ?? ""),
+        );
+        if (i === -1) return false;
+        userRoles.splice(i, 1);
+        return true;
+      },
+    },
+    invites: {
+      async list() {
+        return {
+          invites: [...invites.values()],
+          start: 0,
+          limit: 100,
+          length: invites.size,
+        };
+      },
+      async get(_t: string, id: string) {
+        return invites.get(id) ?? null;
+      },
+      async create(_t: string, params: any) {
+        const row = {
+          created_at: "2026-01-01T00:00:00.000Z",
+          expires_at: "2026-01-08T00:00:00.000Z",
+          ...params,
+        };
+        invites.set(params.id, row);
+        return row;
+      },
+      async remove(_t: string, id: string) {
+        return invites.delete(id);
+      },
+    },
+  };
+
+  return {
+    data: data as any,
+    seed: {
+      addUser: (u: any) => users.set(u.user_id, u),
+      addRole: (r: any) => roles.set(r.id, r),
+      addOrg: (o: any) => organizations.set(o.id, o),
+    },
+    peek: { userOrgs, userRoles, invites },
+  };
+}
+
+function makeBackend(overrides: Record<string, unknown> = {}) {
+  const fx = makeData();
+  const backend = createLocalTenantMembersBackend({
+    data: fx.data,
+    controlPlaneTenantId: CP,
+    issuer: "https://cp.example.com/",
+    invitationClientId: "invite-client",
+    ...overrides,
+  });
+  return { backend, ...fx };
+}
+
+describe("local tenant-members backend", () => {
+  let fx: ReturnType<typeof makeBackend>;
+  beforeEach(() => {
+    fx = makeBackend();
+    fx.seed.addRole({ id: "role_admin", name: "Tenant Admin" });
+    fx.seed.addRole({ id: "role_view", name: "Viewer" });
+    fx.seed.addUser({ user_id: "u1", email: "a@acme.com", name: "Ann" });
+  });
+
+  it("throws not-found for a tenant with no organization", async () => {
+    await expect(fx.backend.listMembers("nope")).rejects.toBeInstanceOf(
+      TenantOrganizationNotFoundError,
+    );
+  });
+
+  it("lists members with their org-scoped roles", async () => {
+    await fx.backend.addMembers(TENANT, ["u1"]);
+    await fx.backend.assignMemberRoles(TENANT, "u1", ["role_admin"]);
+
+    const result = await fx.backend.listMembers(TENANT);
+    expect(result.members).toHaveLength(1);
+    expect(result.members[0]).toMatchObject({
+      user_id: "u1",
+      email: "a@acme.com",
+    });
+    expect(result.members[0]?.roles.map((r) => r.id)).toEqual(["role_admin"]);
+  });
+
+  it("does not add the same member twice, and skips unknown users", async () => {
+    await fx.backend.addMembers(TENANT, ["u1", "u1", "ghost"]);
+    expect(fx.peek.userOrgs).toHaveLength(1);
+    expect(fx.peek.userOrgs[0].user_id).toBe("u1");
+  });
+
+  it("assign roles is idempotent", async () => {
+    await fx.backend.addMembers(TENANT, ["u1"]);
+    await fx.backend.assignMemberRoles(TENANT, "u1", ["role_admin"]);
+    await fx.backend.assignMemberRoles(TENANT, "u1", ["role_admin", "role_view"]);
+    const roles = await fx.backend.listMemberRoles(TENANT, "u1");
+    expect(roles.map((r) => r.id).sort()).toEqual(["role_admin", "role_view"]);
+  });
+
+  it("removes a member", async () => {
+    await fx.backend.addMembers(TENANT, ["u1"]);
+    await fx.backend.removeMembers(TENANT, ["u1"]);
+    const result = await fx.backend.listMembers(TENANT);
+    expect(result.members).toHaveLength(0);
+  });
+
+  it("creates an invitation scoped to the tenant's org and lists only its own", async () => {
+    // An invitation on a different org must not leak into this tenant's list.
+    fx.seed.addOrg({ id: "org_other", name: "other" });
+    await fx.data.invites.create(CP, {
+      id: "inv_other",
+      organization_id: "org_other",
+      invitee: { email: "x@other.com" },
+    });
+
+    const invite = await fx.backend.createInvitation(TENANT, {
+      invitee: { email: "new@acme.com" },
+      inviter: { name: "Ann" },
+      send_invitation_email: false,
+    });
+    expect(invite.organization_id).toBe("org_acme");
+    expect(invite.invitation_url).toContain("organization=org_acme");
+
+    const list = await fx.backend.listInvitations(TENANT);
+    expect(list.map((i) => i.id)).toEqual([invite.id]);
+  });
+
+  it("refuses to create an invitation without a configured client id", async () => {
+    const { backend } = makeBackend({ invitationClientId: undefined });
+    await expect(
+      backend.createInvitation(TENANT, { invitee: { email: "x@acme.com" } }),
+    ).rejects.toThrow(/invitation client id/i);
+  });
+
+  it("revoking an invitation from another org is a not-found, not a delete", async () => {
+    fx.seed.addOrg({ id: "org_other", name: "other" });
+    await fx.data.invites.create(CP, {
+      id: "inv_other",
+      organization_id: "org_other",
+      invitee: { email: "x@other.com" },
+    });
+    await expect(
+      fx.backend.revokeInvitation(TENANT, "inv_other"),
+    ).rejects.toBeInstanceOf(TenantInvitationNotFoundError);
+    expect(fx.peek.invites.has("inv_other")).toBe(true);
+  });
+});

--- a/packages/authhero/src/tenant-members/local-backend.ts
+++ b/packages/authhero/src/tenant-members/local-backend.ts
@@ -1,0 +1,331 @@
+import {
+  DataAdapters,
+  Organization,
+} from "@authhero/adapter-interfaces";
+import { generateInviteId } from "../utils/entity-id";
+import { getDefaultUserPicture } from "../helpers/avatar";
+import {
+  TenantInvitation,
+  TenantInvitationInput,
+  TenantInvitationNotFoundError,
+  TenantMember,
+  TenantMembersBackend,
+  TenantMembersListResult,
+  TenantMembersPageParams,
+  TenantOrganizationNotFoundError,
+  TenantRole,
+} from "./types";
+
+/** The control-plane adapters the team lives in. */
+type TeamAdapters = Pick<
+  DataAdapters,
+  | "organizations"
+  | "userOrganizations"
+  | "userRoles"
+  | "users"
+  | "roles"
+  | "invites"
+>;
+
+export interface LocalTenantMembersBackendOptions {
+  /**
+   * Adapters bound to the CONTROL-PLANE database — the team lives there, not on
+   * the tenant shard. On the control-plane instance this is just `ctx.env.data`.
+   */
+  data: TeamAdapters;
+  /** Tenant id under which the org rows are stored (the control-plane tenant). */
+  controlPlaneTenantId: string;
+  /** Issuer used to build invitation acceptance links and default avatars. */
+  issuer: string;
+  /**
+   * Client id embedded in invitation links. Resolved server-side so the caller
+   * never supplies it (the admin-UI bug this fixes). Without it, invitations
+   * cannot be created and `createInvitation` throws.
+   */
+  invitationClientId?: string;
+  /**
+   * Best-effort invitation email delivery. Bound to a request context at the
+   * call site (it needs branding/email infra). Failures must not fail the
+   * create — Auth0 returns the invite even when delivery fails.
+   */
+  sendInvitationEmail?: (params: {
+    to: string;
+    invitationUrl: string;
+    inviterName?: string;
+    organizationName: string;
+    ttlSec: number;
+  }) => Promise<void>;
+}
+
+/**
+ * A `TenantMembersBackend` that resolves the tenant's control-plane
+ * organization and manages membership/roles/invitations directly against the
+ * control-plane adapters. Used where the code already runs with the
+ * control-plane database in reach: single-instance deployments (via the
+ * management route) and the control-plane proxy resource (which fronts remote
+ * shards).
+ */
+export function createLocalTenantMembersBackend(
+  options: LocalTenantMembersBackendOptions,
+): TenantMembersBackend {
+  const { data, controlPlaneTenantId, issuer } = options;
+
+  /**
+   * A tenant's org is the one whose `name` equals the tenant id. `get` resolves
+   * by id then falls back to name, so pass the tenant id; still verify `name`
+   * matches so an accidental id collision can't hand back the wrong team.
+   */
+  async function resolveOrg(tenantId: string): Promise<Organization> {
+    const org = await data.organizations.get(controlPlaneTenantId, tenantId);
+    if (!org || org.name !== tenantId) {
+      throw new TenantOrganizationNotFoundError(tenantId);
+    }
+    return org;
+  }
+
+  async function findMembership(
+    organizationId: string,
+    userId: string,
+  ): Promise<string | undefined> {
+    const userOrgs = await data.userOrganizations.list(controlPlaneTenantId, {
+      q: `user_id:${userId}`,
+      per_page: 100,
+    });
+    return userOrgs.userOrganizations.find(
+      (uo) => uo.organization_id === organizationId,
+    )?.id;
+  }
+
+  return {
+    async listMembers(
+      tenantId: string,
+      params: TenantMembersPageParams = {},
+    ): Promise<TenantMembersListResult> {
+      const org = await resolveOrg(tenantId);
+      const page = params.page ?? 0;
+      const per_page = params.per_page ?? 25;
+
+      const userOrgsResult = await data.userOrganizations.list(
+        controlPlaneTenantId,
+        {
+          page,
+          per_page,
+          include_totals: true,
+          q: `organization_id:${org.id}`,
+        },
+      );
+
+      const members = (
+        await Promise.all(
+          userOrgsResult.userOrganizations.map(async (userOrg) => {
+            const user = await data.users.get(
+              controlPlaneTenantId,
+              userOrg.user_id,
+            );
+            if (!user) return null;
+            const roles = await data.userRoles.list(
+              controlPlaneTenantId,
+              user.user_id,
+              undefined,
+              org.id,
+            );
+            const member: TenantMember = {
+              user_id: user.user_id,
+              email: user.email || undefined,
+              name: user.name || undefined,
+              picture: user.picture || getDefaultUserPicture(issuer, user),
+              roles,
+            };
+            return member;
+          }),
+        )
+      ).filter((m): m is TenantMember => m !== null);
+
+      return {
+        members,
+        start: userOrgsResult.start ?? page * per_page,
+        limit: userOrgsResult.limit ?? per_page,
+        total: userOrgsResult.length ?? members.length,
+      };
+    },
+
+    async addMembers(tenantId: string, userIds: string[]): Promise<void> {
+      const org = await resolveOrg(tenantId);
+      for (const userId of userIds) {
+        // Only add real control-plane users — an org membership pointing at a
+        // non-existent user would render as a blank row forever.
+        const user = await data.users.get(controlPlaneTenantId, userId);
+        if (!user) continue;
+        const existing = await findMembership(org.id, userId);
+        if (!existing) {
+          await data.userOrganizations.create(controlPlaneTenantId, {
+            user_id: userId,
+            organization_id: org.id,
+          });
+        }
+      }
+    },
+
+    async removeMembers(tenantId: string, userIds: string[]): Promise<void> {
+      const org = await resolveOrg(tenantId);
+      for (const userId of userIds) {
+        const membershipId = await findMembership(org.id, userId);
+        if (membershipId) {
+          await data.userOrganizations.remove(
+            controlPlaneTenantId,
+            membershipId,
+          );
+        }
+      }
+    },
+
+    async listMemberRoles(
+      tenantId: string,
+      userId: string,
+    ): Promise<TenantRole[]> {
+      const org = await resolveOrg(tenantId);
+      return data.userRoles.list(
+        controlPlaneTenantId,
+        userId,
+        undefined,
+        org.id,
+      );
+    },
+
+    async assignMemberRoles(
+      tenantId: string,
+      userId: string,
+      roleIds: string[],
+    ): Promise<void> {
+      const org = await resolveOrg(tenantId);
+      const existing = await data.userRoles.list(
+        controlPlaneTenantId,
+        userId,
+        undefined,
+        org.id,
+      );
+      const already = new Set(existing.map((r) => r.id));
+      for (const roleId of roleIds) {
+        if (already.has(roleId)) continue;
+        await data.userRoles.create(
+          controlPlaneTenantId,
+          userId,
+          roleId,
+          org.id,
+        );
+      }
+    },
+
+    async removeMemberRoles(
+      tenantId: string,
+      userId: string,
+      roleIds: string[],
+    ): Promise<void> {
+      const org = await resolveOrg(tenantId);
+      for (const roleId of roleIds) {
+        await data.userRoles.remove(
+          controlPlaneTenantId,
+          userId,
+          roleId,
+          org.id,
+        );
+      }
+    },
+
+    async listRoles(
+      tenantId: string,
+      params: TenantMembersPageParams = {},
+    ): Promise<TenantRole[]> {
+      // Assignable roles are the control-plane tenant's roles. Resolving the org
+      // first keeps the "unknown tenant → 404" contract uniform across methods.
+      await resolveOrg(tenantId);
+      const result = await data.roles.list(controlPlaneTenantId, {
+        page: params.page ?? 0,
+        per_page: params.per_page ?? 100,
+        q: params.q,
+      });
+      return result.roles;
+    },
+
+    async listInvitations(
+      tenantId: string,
+      params: TenantMembersPageParams = {},
+    ): Promise<TenantInvitation[]> {
+      const org = await resolveOrg(tenantId);
+      const result = await data.invites.list(controlPlaneTenantId, {
+        page: params.page ?? 0,
+        per_page: params.per_page ?? 100,
+      });
+      return result.invites.filter(
+        (invite) => invite.organization_id === org.id,
+      );
+    },
+
+    async createInvitation(
+      tenantId: string,
+      input: TenantInvitationInput,
+    ): Promise<TenantInvitation> {
+      const org = await resolveOrg(tenantId);
+      if (!options.invitationClientId) {
+        throw new Error(
+          "Cannot create invitation: no invitation client id is configured for tenant-members.",
+        );
+      }
+
+      const inviteId = generateInviteId();
+      const invitationUrlObj = new URL("u2/accept-invitation", issuer);
+      invitationUrlObj.searchParams.set("invitation", inviteId);
+      invitationUrlObj.searchParams.set("organization", org.id);
+      const invitationUrl = invitationUrlObj.toString();
+
+      const invite = await data.invites.create(controlPlaneTenantId, {
+        id: inviteId,
+        organization_id: org.id,
+        client_id: options.invitationClientId,
+        invitation_url: invitationUrl,
+        invitee: input.invitee,
+        inviter: input.inviter ?? {},
+        roles: input.roles,
+        send_invitation_email: input.send_invitation_email,
+        ttl_sec: input.ttl_sec,
+      });
+
+      if (
+        input.send_invitation_email !== false &&
+        input.invitee.email &&
+        options.sendInvitationEmail
+      ) {
+        try {
+          await options.sendInvitationEmail({
+            to: input.invitee.email,
+            invitationUrl,
+            inviterName: input.inviter?.name,
+            organizationName: org.display_name || org.name || org.id,
+            ttlSec: input.ttl_sec ?? 604800,
+          });
+        } catch (err) {
+          console.error(
+            `[tenant-members] failed to send invitation email for ${invite.id}:`,
+            err,
+          );
+        }
+      }
+
+      return invite;
+    },
+
+    async revokeInvitation(
+      tenantId: string,
+      invitationId: string,
+    ): Promise<void> {
+      const org = await resolveOrg(tenantId);
+      const invite = await data.invites.get(controlPlaneTenantId, invitationId);
+      if (!invite || invite.organization_id !== org.id) {
+        // Uniform "not found" — either the invite is gone or it belongs to a
+        // different org (which this tenant admin must not be able to probe).
+        throw new TenantInvitationNotFoundError(invitationId);
+      }
+      await data.invites.remove(controlPlaneTenantId, invitationId);
+    },
+  };
+}

--- a/packages/authhero/src/tenant-members/remote-backend.ts
+++ b/packages/authhero/src/tenant-members/remote-backend.ts
@@ -1,0 +1,286 @@
+import { HTTPException } from "hono/http-exception";
+import {
+  ControlPlaneClient,
+  ControlPlaneResponse,
+} from "../helpers/control-plane-client";
+import { CONTROL_PLANE_TENANT_MEMBERS_SCOPE } from "../routes/proxy-control-plane/scopes";
+import {
+  TenantInvitation,
+  TenantInvitationInput,
+  TenantMembersBackend,
+  TenantMembersListResult,
+  TenantMembersPageParams,
+  TenantOrganizationNotFoundError,
+  TenantRole,
+  tenantMembersListSchema,
+} from "./types";
+import { CONTROL_PLANE_TENANT_MEMBERS_PATH } from "./wire";
+
+export interface ControlPlaneTenantMembersOptions {
+  /** Authed transport to the control plane (shared with other adapters). */
+  client: ControlPlaneClient;
+  /** Override the control-plane resource path (tests, custom mounts). */
+  basePath?: string;
+}
+
+function errorMessage(data: unknown, fallback: string): string {
+  if (data !== null && typeof data === "object") {
+    const body = data as { message?: unknown; error?: unknown };
+    if (typeof body.message === "string") return body.message;
+    if (typeof body.error === "string") return body.error;
+  }
+  return fallback;
+}
+
+/**
+ * Map a non-2xx control-plane response onto an exception. A 4xx passes through
+ * with its status; anything else is a 502 — the shard is fine, its upstream is
+ * not. 404 is handled by callers (it means "no team / not found"), so it never
+ * reaches here.
+ */
+function toHttpException(
+  response: ControlPlaneResponse,
+  action: string,
+): HTTPException {
+  const message = errorMessage(
+    response.data,
+    `Control plane failed to ${action} (status ${response.status})`,
+  );
+  if (response.status >= 400 && response.status < 500) {
+    return new HTTPException(response.status as 400, { message });
+  }
+  return new HTTPException(502, { message });
+}
+
+function query(params: Record<string, string | number | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "") search.set(key, String(value));
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : "";
+}
+
+/**
+ * A `TenantMembersBackend` for a tenant shard whose own database does not hold
+ * the control-plane organization that models its team. Every call is delegated
+ * up to the authoritative `tenant-members` resource
+ * (`createTenantMembersControlPlaneApp`) over the shared control-plane client,
+ * which mints a service token bound to this tenant. The control plane pins the
+ * org from that token, so the shard never has to (and cannot) name it.
+ */
+export function createControlPlaneTenantMembersAdapter(
+  options: ControlPlaneTenantMembersOptions,
+): TenantMembersBackend {
+  const { client } = options;
+  const basePath = options.basePath ?? CONTROL_PLANE_TENANT_MEMBERS_PATH;
+  const scope = CONTROL_PLANE_TENANT_MEMBERS_SCOPE;
+
+  return {
+    async listMembers(
+      tenantId: string,
+      params: TenantMembersPageParams = {},
+    ): Promise<TenantMembersListResult> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "GET",
+        path: `${basePath}/members${query({
+          tenant_id: tenantId,
+          page: params.page,
+          per_page: params.per_page,
+          q: params.q,
+        })}`,
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 200) {
+        throw toHttpException(response, "list tenant members");
+      }
+      const parsed = tenantMembersListSchema.safeParse(response.data);
+      if (!parsed.success) {
+        throw new HTTPException(502, {
+          message: "Control plane returned an unparseable member list",
+        });
+      }
+      return parsed.data;
+    },
+
+    async addMembers(tenantId: string, userIds: string[]): Promise<void> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "POST",
+        path: `${basePath}/members`,
+        body: { tenant_id: tenantId, user_ids: userIds },
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 204 && response.status !== 200) {
+        throw toHttpException(response, "add tenant members");
+      }
+    },
+
+    async removeMembers(tenantId: string, userIds: string[]): Promise<void> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "DELETE",
+        path: `${basePath}/members`,
+        body: { tenant_id: tenantId, user_ids: userIds },
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 204 && response.status !== 200) {
+        throw toHttpException(response, "remove tenant members");
+      }
+    },
+
+    async listMemberRoles(
+      tenantId: string,
+      userId: string,
+    ): Promise<TenantRole[]> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "GET",
+        path: `${basePath}/members/${encodeURIComponent(userId)}/roles${query({ tenant_id: tenantId })}`,
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 200) {
+        throw toHttpException(response, "list member roles");
+      }
+      return (response.data as TenantRole[]) ?? [];
+    },
+
+    async assignMemberRoles(
+      tenantId: string,
+      userId: string,
+      roleIds: string[],
+    ): Promise<void> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "POST",
+        path: `${basePath}/members/${encodeURIComponent(userId)}/roles`,
+        body: { tenant_id: tenantId, roles: roleIds },
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 204 && response.status !== 200) {
+        throw toHttpException(response, "assign member roles");
+      }
+    },
+
+    async removeMemberRoles(
+      tenantId: string,
+      userId: string,
+      roleIds: string[],
+    ): Promise<void> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "DELETE",
+        path: `${basePath}/members/${encodeURIComponent(userId)}/roles`,
+        body: { tenant_id: tenantId, roles: roleIds },
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 204 && response.status !== 200) {
+        throw toHttpException(response, "remove member roles");
+      }
+    },
+
+    async listRoles(
+      tenantId: string,
+      params: TenantMembersPageParams = {},
+    ): Promise<TenantRole[]> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "GET",
+        path: `${basePath}/roles${query({
+          tenant_id: tenantId,
+          page: params.page,
+          per_page: params.per_page,
+          q: params.q,
+        })}`,
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 200) {
+        throw toHttpException(response, "list assignable roles");
+      }
+      return (response.data as TenantRole[]) ?? [];
+    },
+
+    async listInvitations(
+      tenantId: string,
+      params: TenantMembersPageParams = {},
+    ): Promise<TenantInvitation[]> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "GET",
+        path: `${basePath}/invitations${query({
+          tenant_id: tenantId,
+          page: params.page,
+          per_page: params.per_page,
+        })}`,
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 200) {
+        throw toHttpException(response, "list invitations");
+      }
+      return (response.data as TenantInvitation[]) ?? [];
+    },
+
+    async createInvitation(
+      tenantId: string,
+      input: TenantInvitationInput,
+    ): Promise<TenantInvitation> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "POST",
+        path: `${basePath}/invitations`,
+        body: { tenant_id: tenantId, ...input },
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 201 && response.status !== 200) {
+        throw toHttpException(response, "create invitation");
+      }
+      return response.data as TenantInvitation;
+    },
+
+    async revokeInvitation(
+      tenantId: string,
+      invitationId: string,
+    ): Promise<void> {
+      const response = await client.request({
+        tenantId,
+        scope,
+        method: "DELETE",
+        path: `${basePath}/invitations/${encodeURIComponent(invitationId)}${query({ tenant_id: tenantId })}`,
+      });
+      if (response.status === 404) {
+        throw new TenantOrganizationNotFoundError(tenantId);
+      }
+      if (response.status !== 204 && response.status !== 200) {
+        throw toHttpException(response, "revoke invitation");
+      }
+    },
+  };
+}

--- a/packages/authhero/src/tenant-members/types.ts
+++ b/packages/authhero/src/tenant-members/types.ts
@@ -1,0 +1,123 @@
+import { z } from "@hono/zod-openapi";
+import { inviteSchema, roleSchema } from "@authhero/adapter-interfaces";
+
+/**
+ * A tenant's "team" is not the tenant's own users. It is an organization on the
+ * control-plane tenant whose `name` equals the tenant id (see
+ * `@authhero/multi-tenancy` provisioning). Its members are control-plane users
+ * holding org-scoped roles, and the tenant shard cannot write those rows.
+ *
+ * `TenantMembersBackend` is the seam that hides "where the team actually lives":
+ *  - on a single-instance / control-plane deployment it resolves the org and
+ *    acts on the local control-plane adapters (`createLocalTenantMembersBackend`);
+ *  - on a Workers-for-Platforms shard it delegates every call up to the control
+ *    plane over the shared control-plane client
+ *    (`createControlPlaneTenantMembersAdapter`).
+ *
+ * Every method takes the CHILD `tenantId` (the tenant whose team is managed),
+ * never an organization id — the org is resolved from the tenant id internally.
+ * The management route that fronts this has already pinned `tenantId` to the
+ * caller's verified org claim, so the backend never has to re-authorize.
+ */
+
+export const tenantMemberSchema = z.object({
+  user_id: z.string(),
+  email: z.string().optional(),
+  name: z.string().optional(),
+  picture: z.string().optional(),
+  roles: z.array(roleSchema).default([]),
+});
+export type TenantMember = z.infer<typeof tenantMemberSchema>;
+
+export const tenantMembersListSchema = z.object({
+  members: z.array(tenantMemberSchema),
+  start: z.number(),
+  limit: z.number(),
+  total: z.number(),
+});
+export type TenantMembersListResult = z.infer<typeof tenantMembersListSchema>;
+
+/**
+ * The invitee-facing fields of an invitation create. `organization_id`,
+ * `invitation_url` and `id` are resolved server-side (the org from the tenant
+ * id, the URL from the control-plane issuer), never trusted from the caller —
+ * that is the fix for the admin UI's "invite silently disappears when the
+ * client id isn't in local storage" foot-gun.
+ */
+export const tenantInvitationInputSchema = z.object({
+  invitee: z.object({ email: z.string().email() }),
+  inviter: z.object({ name: z.string().optional() }).default({}),
+  roles: z.array(z.string()).default([]).optional(),
+  send_invitation_email: z.boolean().default(true).optional(),
+  ttl_sec: z.number().int().max(2592000).optional(),
+});
+// `z.input`, not `z.infer`: `inviter`/`send_invitation_email` carry defaults,
+// so callers may omit them (the schema fills them on parse).
+export type TenantInvitationInput = z.input<typeof tenantInvitationInputSchema>;
+
+export interface TenantMembersPageParams {
+  page?: number;
+  per_page?: number;
+  q?: string;
+}
+
+export type TenantInvitation = z.infer<typeof inviteSchema>;
+export type TenantRole = z.infer<typeof roleSchema>;
+
+export interface TenantMembersBackend {
+  listMembers(
+    tenantId: string,
+    params?: TenantMembersPageParams,
+  ): Promise<TenantMembersListResult>;
+  addMembers(tenantId: string, userIds: string[]): Promise<void>;
+  removeMembers(tenantId: string, userIds: string[]): Promise<void>;
+  listMemberRoles(tenantId: string, userId: string): Promise<TenantRole[]>;
+  assignMemberRoles(
+    tenantId: string,
+    userId: string,
+    roleIds: string[],
+  ): Promise<void>;
+  removeMemberRoles(
+    tenantId: string,
+    userId: string,
+    roleIds: string[],
+  ): Promise<void>;
+  /** Roles that can be granted to a member — the control-plane tenant's roles. */
+  listRoles(
+    tenantId: string,
+    params?: TenantMembersPageParams,
+  ): Promise<TenantRole[]>;
+  listInvitations(
+    tenantId: string,
+    params?: TenantMembersPageParams,
+  ): Promise<TenantInvitation[]>;
+  createInvitation(
+    tenantId: string,
+    input: TenantInvitationInput,
+  ): Promise<TenantInvitation>;
+  revokeInvitation(tenantId: string, invitationId: string): Promise<void>;
+}
+
+/**
+ * Base for the "asked for something that isn't there" cases a backend can hit.
+ * The management route maps any of these to a 404. It is a distinct type (not a
+ * bare HTTPException) so the local and remote backends can agree on the
+ * semantics without depending on hono.
+ */
+export class TenantMembersNotFoundError extends Error {}
+
+/** The tenant id names no control-plane organization — i.e. no team. */
+export class TenantOrganizationNotFoundError extends TenantMembersNotFoundError {
+  constructor(tenantId: string) {
+    super(`No organization found for tenant "${tenantId}"`);
+    this.name = "TenantOrganizationNotFoundError";
+  }
+}
+
+/** The invitation does not exist, or belongs to a different tenant's team. */
+export class TenantInvitationNotFoundError extends TenantMembersNotFoundError {
+  constructor(invitationId: string) {
+    super(`Invitation "${invitationId}" not found`);
+    this.name = "TenantInvitationNotFoundError";
+  }
+}

--- a/packages/authhero/src/tenant-members/wire.ts
+++ b/packages/authhero/src/tenant-members/wire.ts
@@ -1,0 +1,32 @@
+import { z } from "@hono/zod-openapi";
+import { tenantInvitationInputSchema } from "./types";
+
+/**
+ * The HTTP contract shared by the control-plane `tenant-members` resource
+ * (`createTenantMembersControlPlaneApp`) and the remote client that calls it
+ * (`createControlPlaneTenantMembersAdapter`). Keeping the paths and body shapes
+ * in one place is what keeps the two ends from drifting.
+ */
+export const CONTROL_PLANE_TENANT_MEMBERS_PATH =
+  "/api/v2/proxy/control-plane/tenant-members";
+
+/**
+ * `tenant_id` rides on every write body for wire readability, but the server
+ * NEVER acts on it: the tenant is taken from the verified token and a mismatch
+ * is refused (same rule as the custom-domains resource). A shard holding the
+ * scope must not touch another tenant's team by naming it.
+ */
+const tenantIdField = { tenant_id: z.string().optional() };
+
+export const membersMutationBodySchema = z.object({
+  ...tenantIdField,
+  user_ids: z.array(z.string()).min(1),
+});
+
+export const memberRolesBodySchema = z.object({
+  ...tenantIdField,
+  roles: z.array(z.string()).min(1),
+});
+
+export const createInvitationBodySchema =
+  tenantInvitationInputSchema.extend(tenantIdField);

--- a/packages/authhero/src/types/AuthHeroConfig.ts
+++ b/packages/authhero/src/types/AuthHeroConfig.ts
@@ -384,6 +384,32 @@ export interface AuthHeroConfig {
      * needs a view across every tenant that only exists here.
      */
     customDomains?: import("@authhero/adapter-interfaces").CustomDomainsAdapter;
+
+    /**
+     * The authoritative tenant-team resource. When set, mounts
+     * `/api/v2/proxy/control-plane/tenant-members` — the resource tenant shards
+     * call through `createControlPlaneTenantMembersAdapter` so their admins can
+     * manage who administers the tenant (control-plane organization membership
+     * + org-scoped roles + invitations). Wire the backend to the control-plane
+     * database via `createLocalTenantMembersBackend`.
+     */
+    tenantMembers?: import("../routes/proxy-control-plane/tenant-members").TenantMembersControlPlaneOptions;
+  };
+
+  /**
+   * Enables the tenant-scoped `/api/v2/tenant-members` management resource,
+   * which lets a tenant admin manage their own team from the per-tenant admin
+   * UI. Every request is pinned to the caller's `org_name` claim, then
+   * delegated to the backend this returns.
+   *
+   * Return `createLocalTenantMembersBackend(...)` on a single-instance /
+   * control-plane deployment (the team lives in the same database), or
+   * `createControlPlaneTenantMembersAdapter(...)` on a Workers-for-Platforms
+   * shard (the team lives on the control plane and is reached over the shared
+   * control-plane client). Leave unset to not mount the resource.
+   */
+  tenantMembers?: {
+    getBackend: import("../routes/management-api/tenant-members").GetTenantMembersBackend;
   };
 
   /**

--- a/packages/authhero/src/types/AuthHeroConfig.ts
+++ b/packages/authhero/src/types/AuthHeroConfig.ts
@@ -363,6 +363,14 @@ export interface AuthHeroConfig {
      */
     jwksFetch?: (url: string) => Promise<Response>;
     /**
+     * Optional predicate widening the accepted token issuers beyond
+     * `env.ISSUER` / the inbound host to a deployment's own WFP tenant
+     * subdomains, whose per-tenant control-plane credential `jwksFetch`
+     * resolves locally (see #1139). Consulted before any JWKS fetch; return
+     * `true` only for issuer hosts you serve.
+     */
+    isTrustedIssuer?: (iss: string) => boolean;
+    /**
      * Optional receiver for `POST /sync` events emitted by tenant shards via
      * the `ControlPlaneSyncDestination`. Mount on the control-plane authhero
      * instance only. Implementations MUST be idempotent — the outbox retries


### PR DESCRIPTION
Closes #1137. Aligns the shard→control-plane authentication with #1139.

## Problem

There was no way for a **tenant admin** to manage their tenant's team from the admin UI. A tenant's team is a control-plane organization whose `name` equals the tenant id; its members are control-plane users holding org-scoped roles — rows the tenant shard cannot write. Only a global/control-plane admin could add or remove a tenant's administrators.

## Approach

This is "Problem A from #1080 without Problem B" — an authoritative side effect the shard can't perform, but no local mirror/staleness handling. It reuses the #1080 shared control-plane client seam.

New `TenantMembersBackend` interface with two implementations:
- **local** (`createLocalTenantMembersBackend`) — resolves the org and mutates the control-plane DB directly; for single-instance / control-plane deployments.
- **remote** (`createControlPlaneTenantMembersAdapter`) — delegates over the shared `ControlPlaneClient`; for Workers-for-Platforms shards.

### Server
- `GET/POST/DELETE /api/v2/tenant-members` (+ `/{user_id}/roles`, `/roles`, `/invitations`) — the tenant-scoped management resource. Enable via top-level `tenantMembers.getBackend`.
- `/api/v2/proxy/control-plane/tenant-members` — the authoritative resource, gated by the new `controlplane:tenant_members` scope. Enable via `proxyControlPlane.tenantMembers`.

### Admin UI
- New per-tenant **Team** page: invite colleagues by email, remove admins, edit each admin's roles. The invitation client is resolved server-side, fixing the control-plane page's "invite UI silently disappears when the client id isn't in local storage" foot-gun.
- Members are control-plane users, so there is no "add existing user" search here (the shard can't enumerate control-plane users) — the entry path is an email invitation. The existing control-plane `/tenants/:id/members` page is untouched for global admins.

## Security — two independent org pins
1. The **management route** requires the token's `org_name` claim to equal the request `tenant_id` (server-side, not from the URL) — a tenant-A admin cannot manage tenant B by swapping the `tenant-id` header.
2. The **control-plane resource** independently re-pins the org from the verified service token's `tenant_id` claim.

A request-supplied `tenant_id` that mismatches → **403**, never a silent act-on-the-authed-tenant.

## #1139 alignment: `isTrustedIssuer` hook

Per #1139, a WFP shard signs its write-through token with **its own** key (`iss = https://{tenant}.{host}/`), which is neither `env.ISSUER` nor the inbound control-plane host — so the proxy-control-plane verifier rejected it. This adds the single authhero-core change #1139 calls for: an optional `proxyControlPlane.isTrustedIssuer(iss)` predicate, threaded into `verifyControlPlaneToken`, that widens the accepted issuers to a deployment's own tenant subdomains. It is consulted **before** any JWKS fetch (SSRF guard intact), the signature must still verify against the locally-resolved key, and `tenant_id` is still pinned — so trust is not broadened. Shared by every mounted resource (custom-domains, tenant-members, sync).

The rest of #1139 (per-tenant CP-comm keypair, control-plane public-key registry, provisioning, local `jwksFetch` resolution, `getServiceToken` signing) is host wiring in the deployment repo and tracked under #1139.

## Tests
23 new tests, all green; full authhero suite passes (1860+ passed):
- local backend: org resolution + 404, members-with-roles, add/assign idempotency, invitation org-scoping, cross-org revoke = not-found.
- control-plane round trip (remote adapter ↔ resource): happy path, spoofed body/query `tenant_id` → 403, no-tenant token → 403, unauthenticated → 401, missing org → not-found.
- management-route org pin: match (incl. case-insensitive) delegates; mismatch / missing `org_name` → 403 on reads and writes.
- verifier issuer allow-list: subdomain rejected without the hook (no fetch); accepted with it (fetches the subdomain JWKS); predicate short-circuited when `expectedIssuers` already matches; still rejects untrusted issuers.

Changeset: `authhero` minor, `@authhero/admin` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tenant **Team** page for inviting members, managing roles, removing admins, and revoking pending invitations.
  * Added tenant team management APIs for members, roles, and invitations.
  * Added support for trusted deployment-subdomain issuers in control-plane authentication.

* **Documentation**
  * Documented tenant team self-service setup, authorization, deployment options, and Workers for Platforms support.

* **Bug Fixes**
  * Invitation setup now resolves the invitation client server-side when local client information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->