### PR TITLE
fix(proxy-control-plane): bind isTrustedIssuer to the tenant_id claim (#1143)

### DIFF
--- a/.changeset/tricky-isTrustedIssuer-tenant-binding.md
+++ b/.changeset/tricky-isTrustedIssuer-tenant-binding.md
@@ -1,0 +1,22 @@
+---
+"authhero": patch
+---
+
+Security: bind the control-plane `isTrustedIssuer` predicate to the token's
+`tenant_id` claim.
+
+`verifyControlPlaneToken` accepted WFP tenant-subdomain issuers via
+`isTrustedIssuer` but never bound the tenant encoded in `iss` (the key owner)
+to the `tenant_id` claim it returned. With per-tenant signing keys, a caller
+holding tenant A's key could set `tenant_id: "B"` and act on tenant B — a
+cross-tenant escalation on the subdomain-issuer path (#1143).
+
+The predicate now receives the (unverified) `tenant_id` claim as a second
+argument — `isTrustedIssuer?: (iss, tenantId) => boolean` — so deployments can
+bind key-owner to claimed-tenant atomically, e.g.
+`(iss, tid) => !!tid && iss === \`https://${tid}.${issuerHost}/\``. The binding
+is confirmed by the signature check the verifier runs immediately afterwards.
+
+This is a signature change to the `isTrustedIssuer` hook shipped in 8.25.0.
+There are no consumers of the hook yet, so it lands without a deprecation
+window; this must be in place before any deployment enables subdomain issuers.

--- a/packages/authhero/src/routes/proxy-control-plane/index.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/index.ts
@@ -63,8 +63,14 @@ export interface ProxyControlPlaneOptions {
    * JWKS fetch, so it still constrains where keys are fetched from; return
    * `true` only for issuer hosts you serve. Applies to every mounted resource
    * (custom-domains, tenant-members, sync).
+   *
+   * The second argument is the token's (unverified) `tenant_id` claim. Bind it
+   * to `iss` so a caller holding one tenant's subdomain key cannot act on
+   * another by naming it in the claim (#1143), e.g.
+   * `(iss, tid) => !!tid && iss === \`https://${tid}.${issuerHost}/\``. The
+   * binding is confirmed by the signature check the verifier runs afterwards.
    */
-  isTrustedIssuer?: (iss: string) => boolean;
+  isTrustedIssuer?: (iss: string, tenantId: string | undefined) => boolean;
 
   /**
    * Optional handler for `POST /sync` — receives `controlplane.sync.*` events
@@ -217,9 +223,7 @@ export function createProxyControlPlaneApp(
       "/tenant-members",
       createTenantMembersControlPlaneApp({
         getBackend: options.tenantMembers.getBackend,
-        authenticate: authenticateWithScope(
-          CONTROL_PLANE_TENANT_MEMBERS_SCOPE,
-        ),
+        authenticate: authenticateWithScope(CONTROL_PLANE_TENANT_MEMBERS_SCOPE),
       }),
     );
   }

--- a/packages/authhero/src/routes/proxy-control-plane/verify.test.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/verify.test.ts
@@ -36,14 +36,13 @@ describe("verifyControlPlaneToken issuer allow-list", () => {
     // Return an empty key set so verification fails AFTER the issuer gate — we
     // only care that the gate let it through and the fetch targeted the
     // tenant-subdomain JWKS.
-    const jwksFetch = vi.fn(async () =>
-      new Response(JSON.stringify({ keys: [] }), {
-        headers: { "content-type": "application/json" },
-      }),
+    const jwksFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ keys: [] }), {
+          headers: { "content-type": "application/json" },
+        }),
     );
-    const isTrustedIssuer = vi.fn(
-      (iss: string) => iss === TENANT_ISSUER,
-    );
+    const isTrustedIssuer = vi.fn((iss: string) => iss === TENANT_ISSUER);
 
     const result = await verifyControlPlaneToken({
       token: makeToken(header, payload),
@@ -53,7 +52,9 @@ describe("verifyControlPlaneToken issuer allow-list", () => {
       isTrustedIssuer,
     });
 
-    expect(isTrustedIssuer).toHaveBeenCalledWith(TENANT_ISSUER);
+    // The predicate receives both the issuer AND the (unverified) tenant_id
+    // claim, so a deployment can bind the two (#1143).
+    expect(isTrustedIssuer).toHaveBeenCalledWith(TENANT_ISSUER, "acme");
     expect(jwksFetch).toHaveBeenCalledWith(
       "https://acme.cp.example.com/.well-known/jwks.json",
     );
@@ -62,10 +63,11 @@ describe("verifyControlPlaneToken issuer allow-list", () => {
   });
 
   it("does not consult isTrustedIssuer for an issuer already in expectedIssuers", async () => {
-    const jwksFetch = vi.fn(async () =>
-      new Response(JSON.stringify({ keys: [] }), {
-        headers: { "content-type": "application/json" },
-      }),
+    const jwksFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ keys: [] }), {
+          headers: { "content-type": "application/json" },
+        }),
     );
     const isTrustedIssuer = vi.fn(() => false);
     await verifyControlPlaneToken({
@@ -94,10 +96,62 @@ describe("verifyControlPlaneToken issuer allow-list", () => {
     expect(jwksFetch).not.toHaveBeenCalled();
   });
 
+  it("binds iss to the claimed tenant_id: rejects when a tenant's key names another tenant", async () => {
+    // Tenant A holds A's subdomain key (iss = A) but claims tenant_id: "B".
+    // A predicate that binds `iss` to the claimed tenant rejects this before
+    // any key fetch — the cross-tenant escalation of #1143.
+    const jwksFetch = vi.fn(async () => new Response("{}"));
+    const isTrustedIssuer = vi.fn(
+      (iss: string, tid: string | undefined) =>
+        !!tid && iss === `https://${tid}.cp.example.com/`,
+    );
+    const result = await verifyControlPlaneToken({
+      token: makeToken(header, {
+        ...payload,
+        iss: TENANT_ISSUER,
+        tenant_id: "b",
+      }),
+      jwksFetch,
+      expectedIssuers: [CP_ISSUER],
+      requiredScope: "controlplane:tenant_members",
+      isTrustedIssuer,
+    });
+    expect(isTrustedIssuer).toHaveBeenCalledWith(TENANT_ISSUER, "b");
+    expect(result).toEqual({ ok: false, reason: "issuer mismatch" });
+    expect(jwksFetch).not.toHaveBeenCalled();
+  });
+
+  it("binds iss to the claimed tenant_id: passes the gate when they agree", async () => {
+    const jwksFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ keys: [] }), {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const isTrustedIssuer = vi.fn(
+      (iss: string, tid: string | undefined) =>
+        !!tid && iss === `https://${tid}.cp.example.com/`,
+    );
+    const result = await verifyControlPlaneToken({
+      // iss = acme.cp.example.com AND tenant_id = "acme" — self-consistent.
+      token: makeToken(header, payload),
+      jwksFetch,
+      expectedIssuers: [CP_ISSUER],
+      requiredScope: "controlplane:tenant_members",
+      isTrustedIssuer,
+    });
+    expect(isTrustedIssuer).toHaveBeenCalledWith(TENANT_ISSUER, "acme");
+    // Gate passed; failure is now the empty key set, not the issuer/tenant.
+    expect(result).toEqual({ ok: false, reason: "unknown kid" });
+  });
+
   it("still rejects an untrusted issuer when the predicate returns false", async () => {
     const jwksFetch = vi.fn(async () => new Response("{}"));
     const result = await verifyControlPlaneToken({
-      token: makeToken(header, { ...payload, iss: "https://evil.example.com/" }),
+      token: makeToken(header, {
+        ...payload,
+        iss: "https://evil.example.com/",
+      }),
       jwksFetch,
       expectedIssuers: [CP_ISSUER],
       requiredScope: "controlplane:tenant_members",

--- a/packages/authhero/src/routes/proxy-control-plane/verify.ts
+++ b/packages/authhero/src/routes/proxy-control-plane/verify.ts
@@ -83,8 +83,20 @@ export interface VerifyControlPlaneTokenOptions {
    * hosts you actually serve. The signature must still verify against the
    * resolved key, so this does not broaden trust beyond "a caller holding that
    * tenant's registered private key."
+   *
+   * `tenantId` is the token's (as-yet UNVERIFIED) `tenant_id` claim. With
+   * per-tenant signing keys the key owner is encoded in `iss` while the
+   * `tenant_id` claim is set freely by the caller, so a predicate that only
+   * looks at `iss` cannot stop tenant A (holding A's key) from acting on
+   * tenant B by claiming `tenant_id: "B"`. Bind the two here — e.g.
+   * `(iss, tid) => !!tid && iss === \`https://${tid}.${host}/\``. This is
+   * sound despite `tenant_id` being unverified at predicate time: it is the
+   * SAME token whose signature is checked moments later, so verification
+   * confirms the exact `tenant_id` the predicate bound to `iss`. A forged
+   * `tenant_id` either fails the predicate (mismatch with `iss`) or fails
+   * signature verification (the caller lacks that subdomain's key).
    */
-  isTrustedIssuer?: (iss: string) => boolean;
+  isTrustedIssuer?: (iss: string, tenantId: string | undefined) => boolean;
 }
 
 function deriveJwksUrl(iss: string): string {
@@ -115,11 +127,14 @@ export async function verifyControlPlaneToken(
         : [options.requiredScope];
 
   let header: { alg?: unknown; kid?: unknown };
-  let unverifiedPayload: { iss?: unknown };
+  let unverifiedPayload: { iss?: unknown; tenant_id?: unknown };
   try {
     const decoded = decode(token);
     header = decoded.header as { alg?: unknown; kid?: unknown };
-    unverifiedPayload = decoded.payload as { iss?: unknown };
+    unverifiedPayload = decoded.payload as {
+      iss?: unknown;
+      tenant_id?: unknown;
+    };
   } catch {
     return { ok: false, reason: "malformed token" };
   }
@@ -135,12 +150,23 @@ export async function verifyControlPlaneToken(
   // The optional `isTrustedIssuer` predicate widens the allow-list to a
   // deployment's own WFP tenant subdomains, but is still consulted here — ahead
   // of the fetch — so the SSRF guarantee holds.
+  //
+  // The predicate also receives the (unverified) `tenant_id` claim so it can
+  // bind the key owner in `iss` to the tenant the caller claims to act on:
+  // without this, a caller holding tenant A's subdomain key could set
+  // `tenant_id: "B"` and act on B (cross-tenant escalation, #1143). Passing
+  // the unverified claim is safe — the signature check below confirms the
+  // exact `tenant_id` the predicate bound to `iss`.
   const issRaw = unverifiedPayload.iss;
+  const claimedTenantId =
+    typeof unverifiedPayload.tenant_id === "string"
+      ? unverifiedPayload.tenant_id
+      : undefined;
   if (
     typeof issRaw !== "string" ||
     !(
       expectedIssuers.some((expected) => isAllowedIssuer(issRaw, expected)) ||
-      options.isTrustedIssuer?.(issRaw) === true
+      options.isTrustedIssuer?.(issRaw, claimedTenantId) === true
     )
   ) {
     return { ok: false, reason: "issuer mismatch" };

--- a/packages/authhero/src/types/AuthHeroConfig.ts
+++ b/packages/authhero/src/types/AuthHeroConfig.ts
@@ -368,8 +368,13 @@ export interface AuthHeroConfig {
      * subdomains, whose per-tenant control-plane credential `jwksFetch`
      * resolves locally (see #1139). Consulted before any JWKS fetch; return
      * `true` only for issuer hosts you serve.
+     *
+     * The second argument is the token's (unverified) `tenant_id` claim. Bind
+     * it to `iss` so a caller holding one tenant's subdomain key cannot act on
+     * another by naming it in the claim (#1143), e.g.
+     * `(iss, tid) => !!tid && iss === \`https://${tid}.${issuerHost}/\``.
      */
-    isTrustedIssuer?: (iss: string) => boolean;
+    isTrustedIssuer?: (iss: string, tenantId: string | undefined) => boolean;
     /**
      * Optional receiver for `POST /sync` events emitted by tenant shards via
      * the `ControlPlaneSyncDestination`. Mount on the control-plane authhero


### PR DESCRIPTION
## Summary

Closes #1143 — a cross-tenant escalation on the subdomain-issuer path.

`verifyControlPlaneToken` accepts WFP tenant-subdomain issuers via `isTrustedIssuer` (shipped in 8.25.0, #1139), but the predicate is `(iss) => boolean` — it only gates *where keys are fetched from* and never binds the tenant encoded in `iss` (the key owner) to the `tenant_id` claim it returns. With per-tenant signing keys, a caller proving *"I hold tenant A's key"* could set `tenant_id: "B"` in the claim and act on **any** tenant it names.

Not exploitable today (no consumer enables `isTrustedIssuer`), so this is a **fix-before-enable** that must land before any deployment turns on subdomain issuers (#1139 custom domains, #1137/#1140 tenant-members — both share the verify path).

## Fix

Thread the (unverified) `tenant_id` claim into the predicate:

```ts
isTrustedIssuer?: (iss: string, tenantId: string | undefined) => boolean;
```

Consumers then bind key-owner to claimed-tenant atomically:

```ts
isTrustedIssuer: (iss, tid) => !!tid && iss === `https://${tid}.${issuerHost}/`,
```

Sound despite `tenant_id` being unverified at predicate time: it's the **same token** whose signature is verified moments later, so the signature check confirms the exact `tenant_id` the predicate bound to `iss`. A forged `tenant_id` either fails the predicate (mismatch with `iss`) or fails signature verification (caller lacks that subdomain's key).

## Changes

- `verify.ts` — extract `tenant_id` from the decoded payload; pass it as the predicate's second arg at the pre-fetch gate; type + docs updated.
- `index.ts` / `AuthHeroConfig.ts` — propagate the two-arg signature (public config type). `authenticate` already forwards `options.isTrustedIssuer`, no threading change needed.
- Tests — updated the existing two-arg call assertion; added cases where a tenant's key naming another tenant is rejected before any JWKS fetch, and a self-consistent `iss`/`tenant_id` passes the gate.
- Changeset — `authhero` patch. No `isTrustedIssuer` consumers exist yet, so the signature change lands without a deprecation window.

## Verification

- `vitest run src/routes/proxy-control-plane/` — 33 passed
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened control-plane token verification by binding the token issuer to its claimed tenant.
  * Helps prevent cross-tenant escalation using a valid signing key with a different tenant claim.

* **Breaking Changes**
  * Custom trusted-issuer checks now receive both the issuer and the token’s claimed tenant ID.

* **Tests**
  * Added coverage for matching and mismatched issuer–tenant combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->