### PR TITLE
feat(admin): add Organizations tab to client edit screen (#1146)

### DIFF
--- a/.changeset/client-organizations-tab.md
+++ b/.changeset/client-organizations-tab.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": minor
+---
+
+Add an Organizations tab to the client (application) edit screen exposing `organization_usage` (Deny/Allow/Require) and `organization_require_behavior` (No prompt/Pre-login/Post-login). These were previously only editable via raw JSON, but are required to enable org-scoped token exchange (a `Deny` client is rejected with `unauthorized_client`).

--- a/apps/admin/src/resources/clients/edit.tsx
+++ b/apps/admin/src/resources/clients/edit.tsx
@@ -5,6 +5,7 @@ import { DetailsTab } from "./tabs/details-tab";
 import { SsoTab } from "./tabs/sso-tab";
 import { ClientGrantsTab } from "./tabs/client-grants-tab";
 import { ConnectionsTab } from "./tabs/connections-tab";
+import { OrganizationsTab } from "./tabs/organizations-tab";
 import { AdvancedTab } from "./tabs/advanced-tab";
 import { RefreshTokensTab } from "./tabs/refresh-tokens-tab";
 import { RawJsonTab } from "./tabs/raw-json-tab";
@@ -52,6 +53,7 @@ export function ClientEdit() {
             <TabsTrigger value="sso">SSO</TabsTrigger>
             <TabsTrigger value="grants">Client Grants</TabsTrigger>
             <TabsTrigger value="connections">Connections</TabsTrigger>
+            <TabsTrigger value="organizations">Organizations</TabsTrigger>
             <TabsTrigger value="advanced">Advanced</TabsTrigger>
             <TabsTrigger value="refresh">Refresh Tokens</TabsTrigger>
             <TabsTrigger value="raw">Raw JSON</TabsTrigger>
@@ -67,6 +69,9 @@ export function ClientEdit() {
           </TabsContent>
           <TabsContent value="connections" className="mt-4">
             <ConnectionsTab />
+          </TabsContent>
+          <TabsContent value="organizations" className="mt-4">
+            <OrganizationsTab />
           </TabsContent>
           <TabsContent value="advanced" className="mt-4">
             <AdvancedTab />

--- a/apps/admin/src/resources/clients/tabs/organizations-tab.tsx
+++ b/apps/admin/src/resources/clients/tabs/organizations-tab.tsx
@@ -1,0 +1,39 @@
+import { SelectInput } from "@/components/admin";
+
+const ORGANIZATION_USAGE_CHOICES = [
+  { id: "deny", name: "Deny (default) — no organization context" },
+  { id: "allow", name: "Allow — organization context is optional" },
+  { id: "require", name: "Require — organization context is mandatory" },
+];
+
+const ORGANIZATION_REQUIRE_BEHAVIOR_CHOICES = [
+  { id: "no_prompt", name: "No prompt" },
+  { id: "pre_login_prompt", name: "Pre-login prompt" },
+  { id: "post_login_prompt", name: "Post-login prompt (requires OIDC Conformant)" },
+];
+
+export function OrganizationsTab() {
+  return (
+    <>
+      <p className="text-sm text-muted-foreground mb-2">
+        Control whether this application authenticates users in the context of
+        an organization. <code>Allow</code> or <code>Require</code> is needed
+        for org-scoped token exchanges — a client left at <code>Deny</code> is
+        rejected with <code>unauthorized_client</code> when requesting
+        organization context.
+      </p>
+      <SelectInput
+        source="organization_usage"
+        label="Type of Users"
+        choices={ORGANIZATION_USAGE_CHOICES}
+        helperText="Defines how to proceed during an authentication transaction with regards to an organization."
+      />
+      <SelectInput
+        source="organization_require_behavior"
+        label="Login Flow"
+        choices={ORGANIZATION_REQUIRE_BEHAVIOR_CHOICES}
+        helperText="Only applies when Type of Users is 'Require'. Determines how the user is prompted for an organization. 'Post-login prompt' requires OIDC Conformant to be enabled on the Advanced tab."
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Closes #1146

## Summary

Adds an **Organizations** tab to the client (application) edit screen, mirroring Auth0's Application → Organizations tab. `organization_usage` and `organization_require_behavior` were previously only editable via the raw-JSON tab, even though they are enforced at the token endpoint — a client left at `deny` is rejected with `unauthorized_client` when requesting org context (e.g. RFC 8693 token exchange).

## Changes

- **New** `apps/admin/src/resources/clients/tabs/organizations-tab.tsx` — two `SelectInput`s:
  - `organization_usage` → Deny / Allow / Require
  - `organization_require_behavior` → No prompt / Pre-login prompt / Post-login prompt (post-login noted as requiring OIDC Conformant)
  - Inline help text explaining that `allow`/`require` is required for org-scoped token exchange.
- `apps/admin/src/resources/clients/edit.tsx` — imported the tab, added the trigger between Connections and Advanced, wired the `TabsContent`.
- Changeset (`@authhero/admin` minor).

Both fields already round-trip through `PATCH /api/v2/clients/{id}` and match the Client Zod schema enums, so no transform or API change was needed.

## Acceptance criteria

- [x] `organization_usage` and `organization_require_behavior` are viewable/editable without touching raw JSON.
- [x] Values persist via the management API and reflect on reload (existing update form + PATCH round-trip).
- [x] Inline help text explains that `allow`/`require` is required for org-context token exchanges.

## Notes

- Existing clients created before the `deny` default may have `organization_usage` unset, so the select renders empty (placeholder) rather than "Deny" until saved — consistent with the other optional selects on the Advanced tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)