### PR TITLE
feat: token-exchange grant in the picker, honest issuer mismatch errors (#1150, #1151)

### DIFF
--- a/.changeset/client-token-exchange-grant-type.md
+++ b/.changeset/client-token-exchange-grant-type.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": minor
+---
+
+Add the RFC 8693 token-exchange grant (`urn:ietf:params:oauth:grant-type:token-exchange`) to the client Grant Types picker. The token endpoint enforces the client's `grant_types` allowlist, so an org-scoped token exchange was rejected with `unauthorized_client` unless the grant was added via `PATCH /api/v2/clients/{id}` by hand. Clients that already carry the grant now show it as enabled instead of silently omitting it. Companion to the Organizations tab — enabling org-scoped token exchange is now fully reachable from the dashboard.

--- a/.changeset/token-exchange-issuer-mismatch-diagnostics.md
+++ b/.changeset/token-exchange-issuer-mismatch-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"authhero": patch
+---
+
+Report both issuers on a token-exchange `Subject token issuer mismatch`, and name the unresolved host when the expected issuer fell back to `env.ISSUER`. When a request's host resolves no tenant, `custom_domain` is never set and the expected issuer silently becomes the bare `ISSUER` host, so a token minted by a subdomain-addressed tenant could never match — and the error blamed the token, which was the one thing that was correct. The comparison itself is unchanged and stays byte-exact (Auth0 behaves the same); only the diagnostics improve. The issuer values are public discovery data, not secrets.

--- a/apps/admin/src/resources/clients/tabs/details-tab.tsx
+++ b/apps/admin/src/resources/clients/tabs/details-tab.tsx
@@ -23,6 +23,10 @@ const GRANT_TYPE_CHOICES = [
   { id: "password", name: "Password" },
   { id: "mfa", name: "MFA" },
   { id: "passwordless_otp", name: "Passwordless OTP" },
+  {
+    id: "urn:ietf:params:oauth:grant-type:token-exchange",
+    name: "Token Exchange",
+  },
 ];
 
 const EMAIL_VALIDATION_CHOICES = [

--- a/packages/authhero/src/authentication-flows/token-exchange.ts
+++ b/packages/authhero/src/authentication-flows/token-exchange.ts
@@ -122,12 +122,22 @@ export async function tokenExchangeGrant(
     throw error;
   }
 
+  // The comparison is byte-exact and stays that way (Auth0 behaves the same).
+  // The values are public discovery data, so report both rather than only the
+  // verdict. When no tenant domain resolved from the request host, `getIssuer`
+  // silently falls back to env.ISSUER — a token minted by a subdomain-addressed
+  // tenant can then never match, and a bare "mismatch" blames the token for
+  // what is really a host that resolved no tenant. Say which one happened.
   const expectedIssuer = getIssuer(ctx.env, ctx.var.custom_domain);
   if (subjectPayload.iss !== expectedIssuer) {
-    failLog("Subject token was not issued by this server");
+    const fallbackNote = ctx.var.custom_domain
+      ? ""
+      : ` — request host '${ctx.var.host ?? "unknown"}' did not resolve to a tenant domain, so the expected issuer fell back to the configured ISSUER`;
+    const detail = `(token iss=${subjectPayload.iss ?? "none"}, expected=${expectedIssuer}${fallbackNote})`;
+    failLog(`Subject token was not issued by this server ${detail}`);
     throw new JSONHTTPException(invalidGrantStatus, {
       error: "invalid_grant",
-      error_description: "Subject token issuer mismatch",
+      error_description: `Subject token issuer mismatch ${detail}`,
     });
   }
 

--- a/packages/authhero/test/authentication-flows/token-exchange.spec.ts
+++ b/packages/authhero/test/authentication-flows/token-exchange.spec.ts
@@ -201,6 +201,103 @@ describe("token-exchange grant (RFC 8693)", () => {
     expect(response.status).toBe(403);
     const body = (await response.json()) as ErrorResponse;
     expect(body.error).toBe("invalid_grant");
+    // Both issuers are named so the mismatch is diagnosable from the response
+    // alone — they're public discovery values, not secrets.
+    expect(body.error_description).toContain(
+      "token iss=https://other-issuer.example.com/",
+    );
+    expect(body.error_description).toContain(`expected=${ISSUER}`);
+  });
+
+  it("names the unresolved host when the expected issuer fell back to ISSUER", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await seedExchangeClient(env);
+    const org = await seedOrg(env);
+    await env.data.userOrganizations.create(TENANT_ID, {
+      user_id: USER_ID,
+      organization_id: org.id,
+    });
+
+    // The scenario from the field: a subdomain-addressed tenant minted the
+    // token, but the request's host resolves no tenant, so the comparison runs
+    // against the bare-host fallback and can never match.
+    const subjectToken = await mintSubjectToken({
+      iss: "https://tenant.localhost:3000/",
+    });
+
+    const oauthClient = testClient(oauthApp, env);
+    const response = await oauthClient.oauth.token.$post(
+      // @ts-expect-error - testClient type requires both form and json
+      {
+        form: {
+          grant_type: TOKEN_EXCHANGE_GRANT,
+          subject_token: subjectToken,
+          subject_token_type: ACCESS_TOKEN_TYPE,
+          client_id: EXCHANGE_CLIENT_ID,
+          client_secret: EXCHANGE_CLIENT_SECRET,
+          organization: org.id,
+        },
+      },
+      {
+        headers: {
+          "tenant-id": TENANT_ID,
+          "x-forwarded-host": "internal.svc.example.com",
+        },
+      },
+    );
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as ErrorResponse;
+    expect(body.error).toBe("invalid_grant");
+    expect(body.error_description).toContain(
+      "request host 'internal.svc.example.com' did not resolve to a tenant domain",
+    );
+    expect(body.error_description).toContain("fell back to the configured");
+  });
+
+  it("omits the ISSUER-fallback note when the host resolved a tenant domain", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await seedExchangeClient(env);
+    const org = await seedOrg(env);
+    await env.data.userOrganizations.create(TENANT_ID, {
+      user_id: USER_ID,
+      organization_id: org.id,
+    });
+    await env.data.customDomains.create(TENANT_ID, {
+      domain: "login.example.com",
+      custom_domain_id: "custom-domain-id",
+      type: "auth0_managed_certs",
+    });
+
+    // Host resolves to a real custom domain, so the expected issuer is that
+    // domain — a mismatch here really is the token's fault.
+    const subjectToken = await mintSubjectToken({
+      iss: "https://other-issuer.example.com/",
+    });
+
+    const oauthClient = testClient(oauthApp, env);
+    const response = await oauthClient.oauth.token.$post(
+      // @ts-expect-error - testClient type requires both form and json
+      {
+        form: {
+          grant_type: TOKEN_EXCHANGE_GRANT,
+          subject_token: subjectToken,
+          subject_token_type: ACCESS_TOKEN_TYPE,
+          client_id: EXCHANGE_CLIENT_ID,
+          client_secret: EXCHANGE_CLIENT_SECRET,
+          organization: org.id,
+        },
+      },
+      { headers: { host: "login.example.com" } },
+    );
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as ErrorResponse;
+    expect(body.error).toBe("invalid_grant");
+    expect(body.error_description).toContain(
+      "expected=https://login.example.com/",
+    );
+    expect(body.error_description).not.toContain("fell back");
   });
 
   it("rejects subject tokens that already carry an act claim (no chained exchange)", async () => {


### PR DESCRIPTION
Closes #1150. Closes #1151.

Two token-exchange fixes: one makes the feature configurable from the dashboard, the other makes its most confusing failure diagnosable.

## #1150 — Grant Types picker omits the token-exchange grant

The token endpoint enforces the client's `grant_types` allowlist *after* the grant handler runs, so a client could be fully configured for org-scoped token exchange — correct `organization_usage`, valid subject token, verified org membership — and still be rejected with `unauthorized_client` purely because the grant wasn't in `grant_types`. The only way to add it was `PATCH /api/v2/clients/{id}` by hand.

Adding the grant to `GRANT_TYPE_CHOICES` is the whole fix: `GrantTypesInput` already seeds `selected` from the real field value and its toggles only add/remove their own id, so a URN grant set via the API already survived edits — it just couldn't be seen or added.

With this and the Organizations tab (#1146), enabling org-scoped token exchange is fully reachable from the dashboard.

## #1151 — "Subject token issuer mismatch" blamed the token

When a request's host resolves no tenant, `custom_domain` is never set and `getIssuer` silently falls back to `env.ISSUER`. A token minted by a subdomain-addressed tenant then can never match, and the error names the one thing that was correct. This cost most of a day in the field.

The comparison itself is unchanged and stays byte-exact (Auth0 behaves the same) — only the diagnostics change. The error now names both issuers, plus the real cause when the expected issuer came from the fallback:

> `Subject token issuer mismatch (token iss=https://tenant.token.example.com/, expected=https://token.example.com/ — request host 'internal.svc' did not resolve to a tenant domain, so the expected issuer fell back to the configured ISSUER)`

The same detail goes into the `FAILED_EXCHANGE_SUBJECT_TOKEN_FOR_ACCESS_TOKEN` audit log, so it's diagnosable from logs too. Both issuer values are public discovery data, not secrets.

### Deviation from the issue's suggested fix — worth a look

The issue suggested failing with `invalid_request` / "could not resolve tenant from host" *before* comparing issuers. **`custom_domain` being unset does not imply no tenant resolved:** it's also unset on the `tenant-id` header path, single-tenant auto-detect, and plain apex-host deployments, where `env.ISSUER` genuinely is the right issuer. The existing happy-path test is exactly that shape — tenant from the header, no `custom_domain`, comparison against `env.ISSUER` succeeding. Failing there would reject requests that work today.

Deciding it from the host alone has the mirror problem: it would relabel a genuinely foreign-issuer token as a tenant-resolution failure, trading one misleading error for another.

Annotating the mismatch states only verifiable facts, never misclassifies, and changes no currently-passing request — while still naming the real cause inline.

## Tests

- Fallback note appears when the host resolves no tenant (the field scenario).
- Fallback note absent when a real custom domain resolves — a mismatch there really is the token's fault.
- The pre-existing foreign-issuer test now asserts both issuers are named.

Full `authhero` suite (1880) and `@authhero/admin` (30) pass; admin typechecks.

## Note for a separate cleanup

`pnpm format` reformats ~180 files repo-wide that are unrelated to this work — checked-in code has drifted from what prettier now produces, including four hunks in `token-exchange.ts` present at HEAD. I reverted all of it to keep this diff clean; the code here is prettier-clean on its own. The drift is worth its own commit, and likely means formatting isn't enforced in CI.

Changesets: `@authhero/admin` minor, `authhero` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Token Exchange to the dashboard’s client grant type options.
  * Existing clients with Token Exchange enabled now display it correctly.

* **Bug Fixes**
  * Improved token-exchange issuer mismatch errors with clearer details, including actual and expected issuers.
  * Added context when custom-domain resolution falls back to the default issuer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->