### PR TITLE
feat(kysely): add control_plane_comm_keys migration (#1149)

### DIFF
--- a/.changeset/control-plane-comm-keys-migration.md
+++ b/.changeset/control-plane-comm-keys-migration.md
@@ -1,0 +1,5 @@
+---
+"@authhero/kysely-adapter": patch
+---
+
+Add the `control_plane_comm_keys` migration: the registry of per-tenant control-plane-communication public keys, so a WFP shard's write-through calls can be verified locally by the control plane (#1139).

--- a/packages/kysely/migrate/migrations/2026-07-16T10:00:00_control_plane_comm_keys.ts
+++ b/packages/kysely/migrate/migrations/2026-07-16T10:00:00_control_plane_comm_keys.ts
@@ -1,0 +1,49 @@
+import { Kysely } from "kysely";
+
+/**
+ * Registry of per-tenant control-plane-communication PUBLIC keys (issue #1139).
+ *
+ * Each WFP tenant shard is provisioned a dedicated keypair: the private half
+ * becomes the shard's `CONTROL_PLANE_COMM_KEY` secret and signs only its
+ * write-through calls (custom domains, tenant members) — never the tenant's
+ * user tokens. The public half lives here so the control plane's verifier
+ * resolves it locally, with no reach back to the shard.
+ *
+ * A table rather than KV: the control plane must verify a shard's token
+ * immediately after provisioning, and an eventually-consistent store yields
+ * transient `unknown kid` failures inside the propagation window.
+ *
+ * `kid` is the primary key — verification resolves a key by `kid` and rotation
+ * mints a new one, so several live rows per tenant are expected (a token signed
+ * with the prior key must still verify during a swap).
+ *
+ * No FK to `tenants`, for the same reason as `tenant_operations`: cleanup is a
+ * deprovision concern, and an orphaned public key is inert — it can only verify
+ * a token whose private half nothing holds.
+ *
+ * `public_jwk` holds the full JWK JSON including `kid` + `alg`
+ * (`crypto.subtle.exportKey("jwk")` omits both, so the producer must stamp
+ * them; the verifier matches on `kid` and rejects on `alg` mismatch).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("control_plane_comm_keys")
+    .ifNotExists()
+    .addColumn("kid", "varchar(255)", (col) => col.notNull().primaryKey())
+    .addColumn("tenant_id", "varchar(255)", (col) => col.notNull())
+    .addColumn("public_jwk", "text", (col) => col.notNull())
+    .addColumn("created_at", "varchar(35)", (col) => col.notNull())
+    .addColumn("revoked_at", "varchar(35)")
+    .execute();
+
+  // The verify path selects a tenant's non-revoked keys, newest first.
+  await db.schema
+    .createIndex("control_plane_comm_keys_tenant_id_created_at_idx")
+    .on("control_plane_comm_keys")
+    .columns(["tenant_id", "created_at"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("control_plane_comm_keys").ifExists().execute();
+}

--- a/packages/kysely/migrate/migrations/index.ts
+++ b/packages/kysely/migrate/migrations/index.ts
@@ -177,6 +177,7 @@ import * as o078_tenant_database_version from "./2026-06-27T12:00:00_tenant_data
 import * as o079_user_activity_and_user_column_cleanup from "./2026-06-30T12:00:00_user_activity_and_user_column_cleanup";
 import * as o080_drop_user_activity_columns_from_users from "./2026-07-02T12:00:00_drop_user_activity_columns_from_users";
 import * as o081_tenant_operations from "./2026-07-04T12:00:00_tenant_operations";
+import * as o082_control_plane_comm_keys from "./2026-07-16T10:00:00_control_plane_comm_keys";
 
 // These need to be in alphabetic order
 export default {
@@ -359,4 +360,5 @@ export default {
   o079_user_activity_and_user_column_cleanup,
   o080_drop_user_activity_columns_from_users,
   o081_tenant_operations,
+  o082_control_plane_comm_keys,
 };


### PR DESCRIPTION
Adds the `control_plane_comm_keys` migration to `packages/kysely/migrate/migrations` — the registry of per-tenant control-plane-communication **public** keys introduced by #1139.

It lands upstream because `packages/kysely/migrate/migrations` is the canonical migration set that downstream deployments copy from; a consumer-local migration would silently drift and get clobbered on the next copy. Note authhero itself never reads this table — `jwksFetch` is a deployment-supplied hook, so the storage sits behind a seam the consumer controls. Only the **schema** needs to be canonical here.

## Design notes (carried into the migration's docblock)

- **`kid` is the PK** — verification resolves a key by `kid` and rotation mints a new one, so several live rows per tenant are expected: a token signed with the prior key must still verify during a swap.
- **No FK to `tenants`** — same reasoning as `tenant_operations`. Cleanup is a deprovision concern, and an orphaned public key is inert: it can only verify a token whose private half nothing holds.
- **`public_jwk` is the full JWK JSON**, including `kid` + `alg` (`crypto.subtle.exportKey("jwk")` omits both, so the producer must stamp them; the verifier matches on `kid` and rejects on `alg` mismatch).
- **A table, not KV** — the control plane must verify a shard's token immediately after provisioning, and an eventually-consistent store yields transient `unknown kid` failures inside the propagation window. The verify path is cold (write-through only fires on custom-domain / tenant-member CRUD), so a DB read costs nothing.

## Deviations from the issue

- Uses `Kysely<unknown>` rather than the `Kysely<Database>` in the issue sketch, matching the convention of the surrounding migrations (`tenant_operations` and friends).
- `migrate/migrations/index.d.ts` is left untouched: it's stale checked-in build output that stops at `o071` and never picked up `tenant_operations`, so extending it here would be out of step with the last ten migrations.

## Verification

Beyond the suite, I drove the migration against an in-memory SQLite to confirm behavior rather than just that it doesn't throw:

- `up` creates the table and the `(tenant_id, created_at)` index with the intended DDL;
- two live keys per tenant coexist and select newest-first (the rotation case);
- a duplicate `kid` is rejected by the PK;
- `down` drops the table cleanly.

`pnpm --filter @authhero/kysely-adapter test` passes (46 files, 281 tests), as does the full pre-commit build/test hook across the monorepo.

Closes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database support for storing per-tenant control-plane communication verification keys.
  * Added key lifecycle tracking, including creation and optional revocation timestamps.
  * Added indexing to support efficient verification-key lookups.

* **Chores**
  * Registered the new database migration and scheduled a patch release for the database adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->