### PR TITLE
fix(authhero): return 400 for bodyless POST /api/v2/users

### DIFF
--- a/.changeset/users-post-empty-body-400.md
+++ b/.changeset/users-post-empty-body-400.md
@@ -1,0 +1,7 @@
+---
+"authhero": patch
+---
+
+Return 400 instead of 500 for `POST /api/v2/users` requests sent without a body
+
+The route declared its request body without `required: true`, so `@hono/zod-openapi` installed its optional-body middleware, which only runs the zod validator when a `Content-Type` header is present. A request with no body and no `Content-Type` therefore skipped validation entirely and reached the handler with `{}`, failing later at the database layer with a NOT NULL constraint violation and surfacing as a generic 500. Marking the body as required makes the validator run unconditionally and reject such requests with a 400.

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -351,6 +351,7 @@ const postRoot = defineRoute({
         "tenant-id": z.string().optional(),
       }),
       body: {
+        required: true,
         content: {
           "application/json": {
             schema: userInsertSchema.extend({

--- a/packages/authhero/test/management-api/users.test.ts
+++ b/packages/authhero/test/management-api/users.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { getAdminToken } from "../helpers/token";
+import { getTestServer } from "../helpers/test-server";
+
+describe("POST /api/v2/users", () => {
+  it("returns 400 rather than 500 when the request has no body or content-type", async () => {
+    const { managementApp, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    // A bodyless POST used to bypass the zod validator entirely (the body was
+    // not marked `required`), so the handler ran with `{}` and only failed at
+    // the database layer, surfacing as a generic 500.
+    const response = await managementApp.request(
+      "/users",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+        },
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when a required field is missing from the body", async () => {
+    const { managementApp, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    const response = await managementApp.request(
+      "/users",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+        // `connection` is required by userInsertSchema.
+        body: JSON.stringify({ email: "no-connection@example.com" }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("still creates a user when given a valid body", async () => {
+    const { managementApp, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    const response = await managementApp.request(
+      "/users",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "valid-body@example.com",
+          connection: "Username-Password-Authentication",
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body).toMatchObject({ email: "valid-body@example.com" });
+  });
+});


### PR DESCRIPTION
## Problem

`POST /api/v2/users` with no request body and no `Content-Type` header returns a **500** instead of a 400:

```bash
curl --location --request POST 'https://<tenant>.token.sesamy.com/api/v2/users' \
  --header 'Authorization: Bearer <management-token>'
# => 500 {"message":"Internal Server Error"}
```

## Cause

The route declared its request body without `required: true`. In `@hono/zod-openapi`, an optional body installs a middleware that only runs the zod validator when a `Content-Type` header is present — otherwise it injects `{}` as the validated data and calls `next()`:

```js
if (route.request?.body?.required) validators.push(validator);
else {
  const mw = async (c, next) => {
    if (c.req.header("content-type")) { ... return await validator(c, next); }
    c.req.addValidatedData("json", {});   // validation bypassed
    await next();
  };
}
```

So the handler ran with `connection === undefined` and only failed at the database layer with `SQLITE_CONSTRAINT_NOTNULL: users.provider`. That throw is not an `HTTPException`, so the root `onError` reported it as a generic 500.

## Fix

Mark the body `required: true` so the validator always runs and rejects the request with a 400.

## Tests

Adds `packages/authhero/test/management-api/users.test.ts` covering:
- bodyless POST → 400 (fails on `main` with the exact production `NOT NULL constraint failed: users.provider` error)
- body missing the required `connection` → 400
- valid body → 201 (happy path unaffected)

Full `authhero` suite passes (1880 tests).

## Note: this is systemic

No route in the repo sets `body.required: true` — there are ~113 `body: {` blocks, 30 in the management API. Every write route has the same hole. This PR fixes only `POST /users`; a follow-up sweep is worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Requests to create a user without a request body now return a clear `400 Bad Request` response instead of a server error.
  - Invalid user creation requests missing required fields are consistently rejected with `400 Bad Request`.
  - Valid user creation requests continue to succeed with a `201 Created` response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->