### PR TITLE
fix: recover CIMD tenant on social-login callback and resume

### DIFF
--- a/.changeset/cimd-social-login-tenant.md
+++ b/.changeset/cimd-social-login-tenant.md
@@ -1,0 +1,12 @@
+---
+"authhero": patch
+---
+
+Fix CIMD (MCP client) login failing after a social/redirect connection. The
+social-login `/callback` and `/authorize/resume` routes resolve their tenant
+from the login-session state rather than the host, so they called
+`getEnrichedClient` without a tenant. For CIMD clients this threw
+`tenant_id is required to resolve a CIMD client`, dead-ending the flow at
+`/u/login/identifier?error=access_denied` (e.g. after logging in with Google),
+while email/OTP kept working. `getEnrichedClient` now recovers the tenant from
+the CIMD stub row upserted on the first `/authorize`.

--- a/packages/authhero/src/authentication-flows/resume.ts
+++ b/packages/authhero/src/authentication-flows/resume.ts
@@ -103,8 +103,8 @@ export async function resumeLoginSession(
   // BEFORE fetching the enriched client: the client-bundle wrapper routes
   // reads by ctx.var, so without this every resume pays per-entity
   // round-trips for tenant/connections/clientConnections instead of one
-  // bundle cache hit. CIMD client_ids (https URLs) have no clients row to
-  // resolve a tenant from, so they keep the host-derived path.
+  // bundle cache hit. CIMD client_ids (https URLs) aren't looked up here;
+  // getEnrichedClient recovers their tenant from the CIMD stub row instead.
   const sessionClientId = loginSession.authParams.client_id;
   let resolvedTenantId: string | undefined;
   if (!isCimdClientId(sessionClientId)) {

--- a/packages/authhero/src/helpers/client.ts
+++ b/packages/authhero/src/helpers/client.ts
@@ -138,12 +138,23 @@ export async function getEnrichedClient(
   // `login_sessions` (see migration 2025-09-16T12:30:00); runtime values still
   // come from the freshly-fetched document, not the stub.
   if (isCimdClientId(clientId)) {
-    if (!tenantId) {
+    // The tenant is normally passed in, resolved from the request host/domain.
+    // State-keyed routes (the social-login /callback and /authorize/resume)
+    // carry no host-derived tenant, so fall back to the CIMD stub row that was
+    // upserted under the tenant on the first /authorize (ensureCimdStubClient).
+    // Without this, social login and resume throw for CIMD clients even though
+    // the tenant is unambiguously fixed by the login session in flight.
+    let cimdTenantId = tenantId;
+    if (!cimdTenantId) {
+      const stub = await env.data.clients.getByClientId(clientId);
+      cimdTenantId = stub?.tenant_id;
+    }
+    if (!cimdTenantId) {
       throw new JSONHTTPException(400, {
         message: "tenant_id is required to resolve a CIMD client",
       });
     }
-    const tenant = await env.data.tenants.get(tenantId);
+    const tenant = await env.data.tenants.get(cimdTenantId);
     if (!tenant) {
       throw new JSONHTTPException(404, { message: "Tenant not found" });
     }
@@ -151,8 +162,8 @@ export async function getEnrichedClient(
       throw new JSONHTTPException(403, { message: "Client not found" });
     }
     const synthesized = await resolveCimdClient(clientId, fetchOpts);
-    const allConnections = await env.data.connections.list(tenantId);
-    await ensureCimdStubClient(env, tenantId, synthesized);
+    const allConnections = await env.data.connections.list(cimdTenantId);
+    await ensureCimdStubClient(env, cimdTenantId, synthesized);
     return enrichClient(env, synthesized, tenant, allConnections.connections);
   }
 

--- a/packages/authhero/test/routes/auth-api/cimd.spec.ts
+++ b/packages/authhero/test/routes/auth-api/cimd.spec.ts
@@ -7,6 +7,7 @@ import {
   resolveCimdClient,
   cimdDocumentSchema,
 } from "../../../src/helpers/cimd";
+import { getEnrichedClient } from "../../../src/helpers/client";
 import { SsrfFetchOptions } from "../../../src/utils/ssrf-fetch";
 
 const CIMD_URL = "https://rp.example.com/cimd.json";
@@ -316,5 +317,57 @@ describe("/authorize with a CIMD client_id", () => {
     expect(stub).not.toBeNull();
     expect(stub?.name).toBe("Example MCP Client");
     expect(stub?.client_metadata?.cimd).toBe("true");
+  });
+});
+
+describe("getEnrichedClient recovers the CIMD tenant on state-keyed routes", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  // Regression: after a social login (e.g. Google), the browser returns to the
+  // /callback (and then /authorize/resume) route. Those routes resolve their
+  // tenant from the login-session state, not the host, so ctx.var.tenant_id is
+  // empty and connectionCallback/resumeLoginSession call getEnrichedClient with
+  // no tenant argument. For a CIMD client this used to throw
+  // "tenant_id is required to resolve a CIMD client", dead-ending the login at
+  // /u/login/identifier?error=access_denied. It must instead recover the tenant
+  // from the stub row upserted on the first /authorize.
+  it("resolves a CIMD client without a tenant hint once the stub exists", async () => {
+    const { oauthApp, env } = await getTestServer();
+    await enableCimd(env);
+    env.ALLOW_PRIVATE_OUTBOUND_FETCH = true;
+    mockFetchJson(validDocument());
+
+    // First /authorize upserts the stub row under the tenant, exactly as the
+    // real flow does before the browser is redirected out to the IdP.
+    const oauthClient = testClient(oauthApp, env);
+    await oauthClient.authorize.$get({
+      query: {
+        client_id: CIMD_URL,
+        redirect_uri: "https://rp.example.com/callback",
+        response_type: "code",
+        scope: "openid",
+        code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+        code_challenge_method: "S256",
+        state: "xyz",
+      },
+    });
+
+    // Mirror connectionCallback/resumeLoginSession: no tenant, no fetch opts.
+    const client = await getEnrichedClient(env, CIMD_URL);
+
+    expect(client.client_id).toBe(CIMD_URL);
+    expect(client.tenant.id).toBe("tenantId");
+    expect(client.name).toBe("Example MCP Client");
+  });
+
+  it("still throws when no stub exists and no tenant is supplied", async () => {
+    const { env } = await getTestServer();
+    await enableCimd(env);
+    env.ALLOW_PRIVATE_OUTBOUND_FETCH = true;
+    mockFetchJson(validDocument());
+
+    await expect(getEnrichedClient(env, CIMD_URL)).rejects.toThrow(
+      /tenant_id is required/,
+    );
   });
 });


### PR DESCRIPTION
Fixes #1167.

## Problem

After logging in with a social connection (e.g. Google), a CIMD/MCP client dead-ends back at the login screen:

```
/u/login/identifier?state=...&error=access_denied&error_description=tenant_id+is+required+to+resolve+a+CIMD+client
```

Email + OTP works; social login fails.

## Root cause

`getEnrichedClient` requires a `tenantId` for CIMD clients (the `client_id` is an https URL with no `clients` row to derive the tenant from). The social-login callback (`connectionCallback`) calls it with **no tenant argument**, and `/callback` + `/authorize/resume` are `STATE_KEYED_PATHS` where the host-based single-tenant auto-detect is skipped — so `ctx.var.tenant_id` is empty and nothing supplies the tenant. The passwordless path passes `ctx.var.tenant_id` through, which is why email/OTP kept working. `resumeLoginSession` had the same latent gap (passes `undefined` for CIMD).

## Fix

`getEnrichedClient` now recovers the CIMD tenant from the stub `clients` row — upserted under the tenant on the first `/authorize` via `ensureCimdStubClient` — when no tenant is passed in. This mirrors the existing non-CIMD `getByClientId` fallback and repairs both the social callback and resume paths centrally. The stub always exists by the time either route runs (created on the first `/authorize`, before the redirect out to the IdP).

Also corrected the now-inaccurate comment in `resume.ts`.

## Tests

New regression block in `cimd.spec.ts`:
- Drives `/authorize` to create the stub, then calls `getEnrichedClient(env, CIMD_URL)` with no tenant/fetch-opts (exactly as `connectionCallback` does) and asserts it resolves to the tenant. Fails without the fix.
- Asserts the genuine "no stub, no tenant" case still throws, locking in that contract.

All 22 CIMD tests pass. Changeset included (`authhero` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CIMD client login failures after social or redirect-based authentication.
  * Login flows now correctly retain tenant context through callbacks and authorization resume steps.
  * Prevented valid login attempts from ending unexpectedly with an access-denied error.
  * Improved recovery when tenant information is not available in the initial request.

* **Tests**
  * Added regression coverage for CIMD authorization and tenant recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->