### PR TITLE
fix: don't log fapi for benign GET 404 read misses in management API

### DIFF
--- a/.changeset/fapi-skip-benign-read-miss.md
+++ b/.changeset/fapi-skip-benign-read-miss.md
@@ -1,0 +1,9 @@
+---
+"authhero": patch
+---
+
+Don't log a `fapi` (Failed API Operation) event when a management-API `GET`
+returns 404. A read miss — e.g. a client probing `GET /api/v2/users/{id}` for a
+user that doesn't exist — is an expected outcome that real Auth0 doesn't surface
+as an error-class log event; it just returns the 404. Non-GET 404s (and other
+4xx/5xx responses) are still logged as before.

--- a/packages/authhero/src/routes/management-api/index.ts
+++ b/packages/authhero/src/routes/management-api/index.ts
@@ -491,7 +491,13 @@ export default function create(config: AuthHeroConfig) {
       }
     }
 
-    if (status >= 400 && status < 600) {
+    // A `GET` that 404s is a benign read miss — a caller probing whether a
+    // resource (e.g. a user) exists. Real Auth0 doesn't surface that as a
+    // failed-API-operation log; it just returns the 404. Skip it here so these
+    // expected "not found" reads don't show up as error-class events.
+    const isBenignReadMiss = status === 404 && ctx.req.method === "GET";
+
+    if (status >= 400 && status < 600 && !isBenignReadMiss) {
       const tenantId = ctx.var.tenant_id || ctx.req.header("tenant-id");
       if (tenantId && ctx.env.data?.logs) {
         try {

--- a/packages/authhero/test/management-api/fapi-logging.test.ts
+++ b/packages/authhero/test/management-api/fapi-logging.test.ts
@@ -57,6 +57,63 @@ describe("management-api fapi logging", () => {
     });
   });
 
+  it("does not write a FAILED_API_OPERATION log for a benign read miss (GET user 404)", async () => {
+    const { managementApp, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    const res = await managementApp.request(
+      "/users/auth2|doesnotexist",
+      {
+        method: "GET",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(404);
+
+    const { logs } = await env.data.logs.list("tenantId", {
+      page: 0,
+      per_page: 50,
+      include_totals: true,
+    });
+    const fapi = logs.find((l) => l.type === LogTypes.FAILED_API_OPERATION);
+    expect(fapi).toBeUndefined();
+  });
+
+  it("still writes a FAILED_API_OPERATION log for a non-GET 404 (DELETE user)", async () => {
+    const { managementApp, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    const res = await managementApp.request(
+      "/users/auth2|doesnotexist",
+      {
+        method: "DELETE",
+        headers: {
+          "tenant-id": "tenantId",
+          authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(404);
+
+    const { logs } = await env.data.logs.list("tenantId", {
+      page: 0,
+      per_page: 50,
+      include_totals: true,
+    });
+    const fapi = logs.find((l) => l.type === LogTypes.FAILED_API_OPERATION);
+    expect(fapi).toBeDefined();
+    expect(fapi?.details).toMatchObject({
+      response: { statusCode: 404 },
+    });
+  });
+
   it("does not write a FAILED_API_OPERATION log for successful requests", async () => {
     const { managementApp, env } = await getTestServer();
     const token = await getAdminToken();


### PR DESCRIPTION
## Problem

A management-API `GET` that returns 404 — a client probing whether a resource exists, e.g. `GET /api/v2/users/{id}` for a user that doesn't exist — was being written to the tenant log stream as a `fapi` (Failed API Operation) event. Log consumers then flag `fapi` as an error, so these expected read misses showed up as noise/errors.

This came up from a real production log on `auth2.sesamy.com`:

```
GET /api/v2/users/smy|… (aud: default)  →  404 Not Found   type: fapi
```

Real Auth0 doesn't surface a routine read miss as a tenant log event — it just returns the 404 to the caller. Auth0's `sapi`/`fapi` API-operation events are effectively reserved for state-changing operations and auth-level failures, not benign reads.

## Change

In the management-API middleware (`packages/authhero/src/routes/management-api/index.ts`), skip the `fapi` log when the response is a `GET` returning `404`. Everything else — non-GET 404s (e.g. `DELETE` of an unknown user), 401/403 auth failures, other 4xx/5xx — is still logged exactly as before.

## Tests

Added to `test/management-api/fapi-logging.test.ts`:
- `GET` user 404 → **no** `fapi` log
- `DELETE` user 404 → **still writes** a `fapi` log

All 5 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)