### PR TITLE
fix: filter role and user permissions tabs by search query

### DIFF
--- a/.changeset/fix-role-user-permissions-search.md
+++ b/.changeset/fix-role-user-permissions-search.md
@@ -1,0 +1,5 @@
+---
+"@authhero/admin": patch
+---
+
+Fix permissions search on the role and user permissions tabs. The `q` search query was written to the URL but ignored by the data provider, so typing in the search box never filtered the list. The role- and user-permissions branches now route through the shared client-side list handler, filtering on permission name, description, and resource server, and gain client-side sorting.

--- a/apps/admin/src/auth0DataProvider.ts
+++ b/apps/admin/src/auth0DataProvider.ts
@@ -1502,38 +1502,58 @@ export default (
       if (resource === "permissions" && params.target === "user_id") {
         const result = await managementClient.users.permissions.list(
           params.id as string,
-          buildPaginationParams(),
+          { page: 0, per_page: 100 },
         );
         const permissions = (result as any).response || result;
         const permissionsArray = Array.isArray(permissions)
           ? permissions
           : permissions.permissions || [];
-        return {
+        return clientSideListHandler({
           data: permissionsArray.map((item: any) => ({
             id: `${item.resource_server_identifier}:${item.permission_name}`,
             ...item,
           })),
-          total: permissionsArray.length || 0,
-        };
+          page,
+          perPage: perPage || 25,
+          sortField: field,
+          sortOrder: order,
+          searchQuery: params.filter?.q,
+          searchFields: [
+            "permission_name",
+            "description",
+            "resource_server_identifier",
+            "resource_server_name",
+          ],
+        });
       }
 
       // Permissions nested under roles
       if (resource === "permissions" && params.target === "role_id") {
         const result = await managementClient.roles.permissions.list(
           params.id as string,
-          buildPaginationParams(),
+          { page: 0, per_page: 100 },
         );
         const permissions = (result as any).response || result;
         const permissionsArray = Array.isArray(permissions)
           ? permissions
           : permissions.permissions || [];
-        return {
+        return clientSideListHandler({
           data: permissionsArray.map((item: any) => ({
             id: `${item.resource_server_identifier}:${item.permission_name}`,
             ...item,
           })),
-          total: permissionsArray.length || 0,
-        };
+          page,
+          perPage: perPage || 25,
+          sortField: field,
+          sortOrder: order,
+          searchQuery: params.filter?.q,
+          searchFields: [
+            "permission_name",
+            "description",
+            "resource_server_identifier",
+            "resource_server_name",
+          ],
+        });
       }
 
       // Roles nested under users


### PR DESCRIPTION
## Problem

On the role permissions tab (e.g. `/…/roles/:id?q=users:read&tab=permissions`), typing in the search box did nothing. The `q` value was written to the URL and the list filter, but the admin data provider ignored it.

In `auth0DataProvider.ts`, the `getManyReference` branches for permissions nested under **roles** (`target === "role_id"`) and under **users** (`target === "user_id"`) passed only pagination to the management API and returned the results unfiltered — no server-side `q` forwarded, no client-side filtering. This was inconsistent with the sibling scope handler, which already routes through the shared `clientSideListHandler` with `searchQuery: params.filter?.q`.

## Fix

Route both permissions branches through `clientSideListHandler`, matching the scope handler:

- Fetch the full permission set (`per_page: 100`) in one call instead of server-paginating — necessary because `clientSideListHandler` does search/sort/paging locally and search must see the whole set, not just the current page.
- Filter on `permission_name`, `description`, `resource_server_identifier`, and `resource_server_name`.
- Also gains working client-side sorting for free.

## Notes / limitation

The single fetch is capped at 100 permissions per role/user. That covers typical cases, but a role/user with more than 100 permissions would not have entries beyond the first 100 included in search — the same single-page limitation the scope handler avoids only because `resourceServers.get` returns all scopes at once. A paginated fetch-all loop can remove the cap if needed.

## Testing

- `tsc --noEmit` passes for `apps/admin`.
- No dedicated data-provider test suite exists in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)