### PR TITLE
feat: add runRetention() so retention is structural, not per-table opt-in

### DIFF
--- a/.changeset/tall-pans-shave.md
+++ b/.changeset/tall-pans-shave.md
@@ -1,0 +1,11 @@
+---
+"authhero": minor
+---
+
+Add `runRetention()` — a single entry point that sweeps every prunable table (`codes`, `outbox_events`, and sessions/refresh_tokens/login_sessions where the adapter supports it).
+
+Retention was previously per-table opt-in: each prunable table needed its own call that operators had to discover and remember, which is how `codes` grew unbounded in the first place. Scheduling `runRetention` now covers future prunable tables without any change to your handler.
+
+Every sweep runs even if an earlier one throws, so one broken adapter method cannot stop the rest being pruned; failures surface as a `RetentionSweepError` carrying the partial result. The per-table helpers (`cleanupCodes`, `cleanupOutbox`) remain exported as escape hatches.
+
+`runOutboxRelay` is unchanged — it still cleans up `outbox_events` after draining, and running both is safe.

--- a/apps/docs/deployment/data-retention.md
+++ b/apps/docs/deployment/data-retention.md
@@ -7,45 +7,68 @@ description: Which AuthHero tables grow without bound, and the scheduled sweeps 
 
 Several AuthHero tables hold rows that are only useful for a short window — a code that expires in minutes, a session that expires in weeks, an outbox event that has already been delivered. Nothing deletes these rows as a side effect of normal traffic, so **a deployment without a scheduled sweep accumulates them forever**.
 
-This is easy to miss because retention responsibility differs per table. This page is the full list.
+Retention is **one scheduled call**: `runRetention`. Schedule it and you are done — including for prunable tables added in future AuthHero versions, which it picks up without any change to your handler.
 
-## What you must schedule
-
-| Table(s) | Swept by | Default window | Notes |
-| --- | --- | --- | --- |
-| `codes` | `cleanupCodes(data.codes, { retentionDays })` | 1 day past expiry | Authorization codes, OTPs, OAuth2 state, email-verification and password-reset codes. Highest-churn table in the system. |
-| `outbox_events` | `cleanupOutbox(data.outbox, { retentionDays })` — or `runOutboxRelay`, which calls it for you | 7 days after processing | Only processed and dead-lettered events are removed. See [Outbox Relay (Cron)](./outbox-cron). |
-| `sessions`, `refresh_tokens`, `login_sessions` | `data.sessionCleanup?.({ tenant_id? })` | 1 week past expiry (fixed grace period) | Optional adapter method. Can be scoped to a single tenant. |
-| `logs` | Not swept by AuthHero | — | Prune on `date` yourself, on whatever window your audit obligations require. |
-
-Codes and outbox events are swept globally; they are not tenant-scoped, because an expired row is dead regardless of who owns it.
-
-## A complete scheduled handler
+## Schedule this
 
 ```ts
-import { cleanupCodes, runOutboxRelay } from "authhero";
+import { runRetention } from "authhero";
 
 export default {
   async scheduled(_event: ScheduledEvent, env: Env) {
-    // Outbox: drains pending events, then cleans up processed ones.
-    await runOutboxRelay({
-      dataAdapter,
-      issuer: env.ISSUER,
-      webhookInvoker,
-      codeExecutor,
-      retentionDays: 7,
-    });
-
-    // Codes: nothing else prunes these.
-    await cleanupCodes(dataAdapter.codes, { retentionDays: 1 });
-
-    // Sessions, refresh tokens and login sessions.
-    await dataAdapter.sessionCleanup?.();
+    const { sweeps } = await runRetention({ dataAdapter });
+    console.log(sweeps);
   },
 };
 ```
 
-Daily is a reasonable cadence for all three.
+Daily is a reasonable cadence.
+
+`runRetention` sweeps every prunable table, using the default window for each:
+
+| Table(s) | Default window | Notes |
+| --- | --- | --- |
+| `codes` | 1 day past expiry | Authorization codes, OTPs, OAuth2 state, email-verification and password-reset codes. Highest-churn table in the system. |
+| `outbox_events` | 7 days after processing | Only processed and dead-lettered events are removed. Skipped when the adapter has no `outbox`. |
+| `sessions`, `refresh_tokens`, `login_sessions` | 1 week past expiry (fixed grace period) | Skipped when the adapter does not implement `sessionCleanup`. |
+
+Codes and outbox events are swept globally; they are not tenant-scoped, because an expired row is dead regardless of who owns it. Pass `tenantId` to scope the session sweep to one tenant.
+
+Override the windows per table when you need to:
+
+```ts
+await runRetention({
+  dataAdapter,
+  codesRetentionDays: 1,
+  outboxRetentionDays: 30,
+});
+```
+
+### What it returns, and what it throws
+
+`runRetention` resolves to `{ sweeps }` — one entry per table with a `swept` / `skipped` / `failed` status and, where the adapter reports one, a `deleted` count. Logging it gives you a retention record per run.
+
+Every sweep runs even if an earlier one throws, so a single broken adapter method cannot stop the other tables being pruned. If any sweep failed, a `RetentionSweepError` is thrown once at the end, carrying `.result` (the partial sweep list) and `.errors`.
+
+## What it does not cover
+
+**Outbox delivery.** `runRetention` cleans up `outbox_events` but does not *drain* them. Delivery is [`runOutboxRelay`](./outbox-cron)'s job and is scheduled separately. Running both is safe — the relay's own cleanup pass and this one are idempotent.
+
+**`logs`.** Audit-retention obligations differ per deployment, so AuthHero will not silently delete audit rows on your behalf. Prune `logs` on `date` yourself, on whatever window your obligations require.
+
+## Per-table escape hatches
+
+The individual helpers remain exported for consumers who want to sweep a single table, or run tables on different schedules:
+
+```ts
+import { cleanupCodes, cleanupOutbox } from "authhero";
+
+await cleanupCodes(dataAdapter.codes, { retentionDays: 1 });
+await cleanupOutbox(dataAdapter.outbox, { retentionDays: 7 });
+await dataAdapter.sessionCleanup?.();
+```
+
+`runRetention` is the recommended default; reach for these only when you have a reason.
 
 ## Why `codes` has a grace period
 
@@ -59,4 +82,4 @@ Daily is a reasonable cadence for all three.
 
 ## If you are upgrading an existing deployment
 
-The kysely migration prunes expired codes before it adds the index, so it stays cheap even on a table that has grown to millions of rows. It logs what it removed. Once it has run, the scheduled `cleanupCodes` call is what stops the table growing again — the migration is a one-time catch-up, not a substitute for the cron.
+The kysely migration prunes expired codes before it adds the index, so it stays cheap even on a table that has grown to millions of rows. It logs what it removed. Once it has run, the scheduled `runRetention` call is what stops the table growing again — the migration is a one-time catch-up, not a substitute for the cron. A deployment that runs the migration but never schedules the sweep will regrow the table, with the one-time prune masking it for weeks.

--- a/apps/docs/deployment/outbox-cron.md
+++ b/apps/docs/deployment/outbox-cron.md
@@ -17,6 +17,10 @@ You need a scheduled handler if **any** of the following is true:
 
 If outbox is disabled, webhook delivery is fire-and-forget per request with no retry — no cron is possible or needed.
 
+::: tip This cron is about delivery, not retention
+`runOutboxRelay` cleans up `outbox_events` as a convenience, but it is not your retention story — it sweeps no other table, and it returns early when outbox is disabled. Schedule [`runRetention`](./data-retention) as well; it covers `codes`, sessions and outbox events in one call. Running both is safe.
+:::
+
 ## One-call handler: `runOutboxRelay`
 
 `runOutboxRelay` is the entire body of a scheduled handler. It builds the same destinations the inline dispatcher uses, mints per-tenant `auth-service` tokens via the same in-process path, drains the outbox, and cleans up processed events past the retention window.

--- a/packages/authhero/src/helpers/codes-cleanup.ts
+++ b/packages/authhero/src/helpers/codes-cleanup.ts
@@ -13,11 +13,11 @@ export interface CodesCleanupParams {
 
 /**
  * Delete codes that expired more than the retention window ago.
- * Intended for use in a scheduled handler / cron job.
  *
- * Codes are short-lived by design but nothing else prunes them, so without a
- * scheduled call to this the table grows without bound. See the Data Retention
- * deployment guide for the full set of tables that need sweeping.
+ * Prefer `runRetention`, which calls this along with every other prunable
+ * table — scheduling one call means a future prunable table is covered without
+ * editing your handler. Use this directly only when you want to sweep `codes`
+ * on its own schedule.
  *
  * @example
  * ```ts

--- a/packages/authhero/src/helpers/run-retention.ts
+++ b/packages/authhero/src/helpers/run-retention.ts
@@ -21,17 +21,39 @@ export interface RunRetentionConfig {
 
 export type RetentionSweepStatus = "swept" | "skipped" | "failed";
 
-export interface RetentionSweep {
+interface RetentionSweepBase {
   /** Table(s) this sweep covers, for logging. */
   table: string;
-  status: RetentionSweepStatus;
-  /** Rows deleted, when the underlying adapter reports a count. */
-  deleted?: number;
-  /** Why the sweep was skipped — an adapter that does not support it. */
-  reason?: string;
-  /** The failure, when `status` is `"failed"`. */
-  error?: unknown;
 }
+
+export interface RetentionSweepSwept extends RetentionSweepBase {
+  status: "swept";
+  /**
+   * Rows deleted. Absent when the underlying adapter reports no count —
+   * `sessionCleanup` returns void, so a session sweep succeeds without one.
+   */
+  deleted?: number;
+}
+
+export interface RetentionSweepSkipped extends RetentionSweepBase {
+  status: "skipped";
+  /** Why the sweep was skipped — an adapter that does not support it. */
+  reason: string;
+}
+
+export interface RetentionSweepFailed extends RetentionSweepBase {
+  status: "failed";
+  error: unknown;
+}
+
+/**
+ * Discriminated on `status`, so a sweep cannot carry fields that contradict
+ * it — no `error` on a successful sweep, no `deleted` on a failed one.
+ */
+export type RetentionSweep =
+  | RetentionSweepSwept
+  | RetentionSweepSkipped
+  | RetentionSweepFailed;
 
 export interface RunRetentionResult {
   sweeps: RetentionSweep[];

--- a/packages/authhero/src/helpers/run-retention.ts
+++ b/packages/authhero/src/helpers/run-retention.ts
@@ -1,0 +1,163 @@
+import { DataAdapters } from "@authhero/adapter-interfaces";
+import { cleanupCodes } from "./codes-cleanup";
+import { cleanupOutbox } from "./outbox-cleanup";
+
+export interface RunRetentionConfig {
+  /** Same `DataAdapters` passed to `init()`. */
+  dataAdapter: DataAdapters;
+
+  /** Grace period past expiry for `codes`. Default 1. */
+  codesRetentionDays?: number;
+
+  /** Days to keep processed/dead-lettered outbox events. Default 7. */
+  outboxRetentionDays?: number;
+
+  /**
+   * Scope the session sweep to a single tenant. Codes and outbox events are
+   * always swept globally — an expired row is dead regardless of who owns it.
+   */
+  tenantId?: string;
+}
+
+export type RetentionSweepStatus = "swept" | "skipped" | "failed";
+
+export interface RetentionSweep {
+  /** Table(s) this sweep covers, for logging. */
+  table: string;
+  status: RetentionSweepStatus;
+  /** Rows deleted, when the underlying adapter reports a count. */
+  deleted?: number;
+  /** Why the sweep was skipped — an adapter that does not support it. */
+  reason?: string;
+  /** The failure, when `status` is `"failed"`. */
+  error?: unknown;
+}
+
+export interface RunRetentionResult {
+  sweeps: RetentionSweep[];
+}
+
+/**
+ * Thrown when one or more sweeps failed. The other sweeps still ran — check
+ * `result` for what succeeded.
+ */
+export class RetentionSweepError extends Error {
+  readonly result: RunRetentionResult;
+  readonly errors: unknown[];
+
+  constructor(result: RunRetentionResult, errors: unknown[]) {
+    const failed = result.sweeps
+      .filter((sweep) => sweep.status === "failed")
+      .map((sweep) => sweep.table)
+      .join(", ");
+    super(`Retention sweep failed for: ${failed}`);
+    this.name = "RetentionSweepError";
+    this.result = result;
+    this.errors = errors;
+  }
+}
+
+/**
+ * Sweep every prunable AuthHero table in one call.
+ *
+ * This is the entry point for retention — a deployment that schedules this
+ * daily needs nothing else, and gains coverage of future prunable tables
+ * without editing its handler.
+ *
+ * Covers `codes`, `outbox_events`, and (where the adapter supports it)
+ * `sessions` / `refresh_tokens` / `login_sessions`. It does **not** drain the
+ * outbox: delivery is `runOutboxRelay`'s job, and the two are scheduled
+ * independently. Running both is safe — the relay's own cleanup pass and this
+ * one are idempotent.
+ *
+ * `logs` is deliberately excluded. Audit-retention obligations differ per
+ * deployment, so AuthHero will not silently delete audit rows on your behalf;
+ * prune `logs` on `date` yourself.
+ *
+ * Every sweep runs even if an earlier one throws, so one broken adapter method
+ * cannot stop the rest of the tables being pruned. If any sweep failed, a
+ * `RetentionSweepError` carrying the partial result is thrown once at the end.
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   async scheduled(_event, env) {
+ *     const { sweeps } = await runRetention({ dataAdapter });
+ *     console.log(sweeps);
+ *   },
+ * };
+ * ```
+ */
+export async function runRetention(
+  config: RunRetentionConfig,
+): Promise<RunRetentionResult> {
+  const { dataAdapter, codesRetentionDays, outboxRetentionDays, tenantId } =
+    config;
+
+  const sweeps: RetentionSweep[] = [];
+  const errors: unknown[] = [];
+
+  // Each entry returns a deleted count, or undefined when the adapter does not
+  // report one. Returning `null` marks the sweep unsupported by this adapter.
+  // Adding a prunable table means adding an entry here — not editing every
+  // consumer's scheduled handler.
+  const tasks: {
+    table: string;
+    run: () => Promise<number | undefined | null>;
+  }[] = [
+    {
+      table: "codes",
+      run: () =>
+        cleanupCodes(dataAdapter.codes, { retentionDays: codesRetentionDays }),
+    },
+    {
+      table: "outbox_events",
+      run: async () => {
+        if (!dataAdapter.outbox) {
+          return null;
+        }
+        return cleanupOutbox(dataAdapter.outbox, {
+          retentionDays: outboxRetentionDays,
+        });
+      },
+    },
+    {
+      table: "sessions, refresh_tokens, login_sessions",
+      run: async () => {
+        if (!dataAdapter.sessionCleanup) {
+          return null;
+        }
+        await dataAdapter.sessionCleanup(
+          tenantId ? { tenant_id: tenantId } : undefined,
+        );
+        return undefined;
+      },
+    },
+  ];
+
+  for (const task of tasks) {
+    try {
+      const deleted = await task.run();
+      if (deleted === null) {
+        sweeps.push({
+          table: task.table,
+          status: "skipped",
+          reason: "not supported by this adapter",
+        });
+      } else {
+        sweeps.push({ table: task.table, status: "swept", deleted });
+      }
+    } catch (error) {
+      errors.push(error);
+      sweeps.push({ table: task.table, status: "failed", error });
+    }
+  }
+
+  const result: RunRetentionResult = { sweeps };
+
+  if (errors.length > 0) {
+    throw new RetentionSweepError(result, errors);
+  }
+
+  return result;
+}

--- a/packages/authhero/src/index.ts
+++ b/packages/authhero/src/index.ts
@@ -56,6 +56,9 @@ export type {
   RunRetentionResult,
   RetentionSweep,
   RetentionSweepStatus,
+  RetentionSweepSwept,
+  RetentionSweepSkipped,
+  RetentionSweepFailed,
 } from "./helpers/run-retention";
 export { LogsDestination } from "./helpers/outbox-destinations/logs";
 export {

--- a/packages/authhero/src/index.ts
+++ b/packages/authhero/src/index.ts
@@ -50,6 +50,13 @@ export type {
 } from "./helpers/provision-tenant-clients";
 export { runOutboxRelay } from "./helpers/run-outbox-relay";
 export type { RunOutboxRelayConfig } from "./helpers/run-outbox-relay";
+export { runRetention, RetentionSweepError } from "./helpers/run-retention";
+export type {
+  RunRetentionConfig,
+  RunRetentionResult,
+  RetentionSweep,
+  RetentionSweepStatus,
+} from "./helpers/run-retention";
 export { LogsDestination } from "./helpers/outbox-destinations/logs";
 export {
   WebhookDestination,

--- a/packages/authhero/test/helpers/run-retention.spec.ts
+++ b/packages/authhero/test/helpers/run-retention.spec.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from "vitest";
+import type { DataAdapters } from "@authhero/adapter-interfaces";
+import {
+  runRetention,
+  RetentionSweepError,
+} from "../../src/helpers/run-retention";
+
+function makeDataAdapter(
+  overrides: {
+    codesCleanup?: ReturnType<typeof vi.fn>;
+    outboxCleanup?: ReturnType<typeof vi.fn> | null;
+    sessionCleanup?: ReturnType<typeof vi.fn> | null;
+  } = {},
+): DataAdapters {
+  const {
+    codesCleanup = vi.fn().mockResolvedValue(5),
+    outboxCleanup = vi.fn().mockResolvedValue(3),
+    sessionCleanup = vi.fn().mockResolvedValue(undefined),
+  } = overrides;
+
+  return {
+    codes: { cleanup: codesCleanup },
+    outbox: outboxCleanup ? { cleanup: outboxCleanup } : undefined,
+    sessionCleanup: sessionCleanup ?? undefined,
+  } as unknown as DataAdapters;
+}
+
+/** Days between `now` and an ISO cutoff string, rounded to the nearest day. */
+function daysAgo(cutoff: string): number {
+  return Math.round((Date.now() - new Date(cutoff).getTime()) / 86_400_000);
+}
+
+describe("runRetention", () => {
+  it("sweeps codes, outbox and sessions in one call", async () => {
+    const codesCleanup = vi.fn().mockResolvedValue(5);
+    const outboxCleanup = vi.fn().mockResolvedValue(3);
+    const sessionCleanup = vi.fn().mockResolvedValue(undefined);
+    const dataAdapter = makeDataAdapter({
+      codesCleanup,
+      outboxCleanup,
+      sessionCleanup,
+    });
+
+    const { sweeps } = await runRetention({ dataAdapter });
+
+    expect(codesCleanup).toHaveBeenCalledTimes(1);
+    expect(outboxCleanup).toHaveBeenCalledTimes(1);
+    expect(sessionCleanup).toHaveBeenCalledTimes(1);
+
+    expect(sweeps).toEqual([
+      { table: "codes", status: "swept", deleted: 5 },
+      { table: "outbox_events", status: "swept", deleted: 3 },
+      {
+        table: "sessions, refresh_tokens, login_sessions",
+        status: "swept",
+        deleted: undefined,
+      },
+    ]);
+  });
+
+  it("applies the documented default windows", async () => {
+    const codesCleanup = vi.fn().mockResolvedValue(0);
+    const outboxCleanup = vi.fn().mockResolvedValue(0);
+    await runRetention({
+      dataAdapter: makeDataAdapter({ codesCleanup, outboxCleanup }),
+    });
+
+    expect(daysAgo(codesCleanup.mock.calls[0][0])).toBe(1);
+    expect(daysAgo(outboxCleanup.mock.calls[0][0])).toBe(7);
+  });
+
+  it("honours per-table retention overrides", async () => {
+    const codesCleanup = vi.fn().mockResolvedValue(0);
+    const outboxCleanup = vi.fn().mockResolvedValue(0);
+    await runRetention({
+      dataAdapter: makeDataAdapter({ codesCleanup, outboxCleanup }),
+      codesRetentionDays: 0,
+      outboxRetentionDays: 30,
+    });
+
+    expect(daysAgo(codesCleanup.mock.calls[0][0])).toBe(0);
+    expect(daysAgo(outboxCleanup.mock.calls[0][0])).toBe(30);
+  });
+
+  it("still sweeps codes and sessions when the outbox is disabled", async () => {
+    const codesCleanup = vi.fn().mockResolvedValue(2);
+    const sessionCleanup = vi.fn().mockResolvedValue(undefined);
+    const { sweeps } = await runRetention({
+      dataAdapter: makeDataAdapter({
+        codesCleanup,
+        outboxCleanup: null,
+        sessionCleanup,
+      }),
+    });
+
+    expect(codesCleanup).toHaveBeenCalledTimes(1);
+    expect(sessionCleanup).toHaveBeenCalledTimes(1);
+    expect(sweeps[1]).toEqual({
+      table: "outbox_events",
+      status: "skipped",
+      reason: "not supported by this adapter",
+    });
+  });
+
+  it("skips sessions when the adapter does not implement sessionCleanup", async () => {
+    const { sweeps } = await runRetention({
+      dataAdapter: makeDataAdapter({ sessionCleanup: null }),
+    });
+
+    expect(sweeps[2]).toEqual({
+      table: "sessions, refresh_tokens, login_sessions",
+      status: "skipped",
+      reason: "not supported by this adapter",
+    });
+  });
+
+  it("scopes the session sweep to a tenant when asked", async () => {
+    const sessionCleanup = vi.fn().mockResolvedValue(undefined);
+    await runRetention({
+      dataAdapter: makeDataAdapter({ sessionCleanup }),
+      tenantId: "tenant-1",
+    });
+
+    expect(sessionCleanup).toHaveBeenCalledWith({ tenant_id: "tenant-1" });
+  });
+
+  it("sweeps sessions globally when no tenant is given", async () => {
+    const sessionCleanup = vi.fn().mockResolvedValue(undefined);
+    await runRetention({ dataAdapter: makeDataAdapter({ sessionCleanup }) });
+
+    expect(sessionCleanup).toHaveBeenCalledWith(undefined);
+  });
+
+  it("runs every remaining sweep when one throws, then reports the failure", async () => {
+    const boom = new Error("codes adapter is broken");
+    const codesCleanup = vi.fn().mockRejectedValue(boom);
+    const outboxCleanup = vi.fn().mockResolvedValue(3);
+    const sessionCleanup = vi.fn().mockResolvedValue(undefined);
+    const dataAdapter = makeDataAdapter({
+      codesCleanup,
+      outboxCleanup,
+      sessionCleanup,
+    });
+
+    // The whole point of the structural sweep: a broken adapter method must
+    // not stop the other tables being pruned.
+    await expect(runRetention({ dataAdapter })).rejects.toThrow(
+      RetentionSweepError,
+    );
+    expect(outboxCleanup).toHaveBeenCalledTimes(1);
+    expect(sessionCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries the partial result and the underlying errors on the thrown error", async () => {
+    const boom = new Error("outbox adapter is broken");
+    const dataAdapter = makeDataAdapter({
+      codesCleanup: vi.fn().mockResolvedValue(5),
+      outboxCleanup: vi.fn().mockRejectedValue(boom),
+    });
+
+    const error = await runRetention({ dataAdapter }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(RetentionSweepError);
+    if (!(error instanceof RetentionSweepError)) {
+      throw new Error("expected a RetentionSweepError");
+    }
+    expect(error.errors).toEqual([boom]);
+    expect(error.message).toContain("outbox_events");
+    expect(error.result.sweeps[0]).toEqual({
+      table: "codes",
+      status: "swept",
+      deleted: 5,
+    });
+    expect(error.result.sweeps[1]).toMatchObject({
+      table: "outbox_events",
+      status: "failed",
+      error: boom,
+    });
+  });
+});


### PR DESCRIPTION
Closes #1159.

## Problem

Retention was per-table guesswork. Each prunable table needed its own call that an operator had to discover and remember — which is how `codes` grew to ~2.5M rows (#1155). #1158 fixed the immediate bug but reproduced the shape, adding one more export to find:

```ts
await runOutboxRelay({ ... });        // drains + cleans outbox
await cleanupCodes(data.codes, {});   // new in #1158 — easy to miss
await data.sessionCleanup?.();        // optional adapter method
```

A deployment that upgrades, runs the backlog-clearing migration, and never finds `cleanupCodes` regrows the table — masked for weeks by the one-time prune.

## Change

`runRetention({ dataAdapter })` sweeps every prunable table in one call: `codes`, `outbox_events`, and sessions/refresh_tokens/login_sessions where the adapter supports it.

```ts
export default {
  async scheduled(_event: ScheduledEvent, env: Env) {
    const { sweeps } = await runRetention({ dataAdapter });
    console.log(sweeps);
  },
};
```

Adding a future prunable table means adding an entry to the internal task list — not editing every consumer's scheduled handler.

## Decisions worth reviewing

**Retention is not delivery.** `runRetention` cleans up `outbox_events` but does *not* drain them; that stays `runOutboxRelay`'s job, scheduled separately. Both passes are idempotent, so running both is safe. This is the issue's option 1, and it avoids option 2's failure mode — folding retention into `runOutboxRelay` would leave `codes` unswept exactly where outbox is disabled, since the relay returns early without an `outbox` adapter.

**Sweeps are independent.** Each runs even if an earlier one throws, then a `RetentionSweepError` carrying `.result` (the partial sweep list) and `.errors` is thrown once at the end. One broken adapter method cannot stop the other tables being pruned — that is the point of making this structural rather than a convenience wrapper.

**Unsupported sweeps report `skipped`, not failure**, so an adapter without `outbox` or without `sessionCleanup` works unchanged.

**`logs` is deliberately excluded, and now says so.** The issue asked for a decision. Audit-retention obligations differ per deployment, so AuthHero should not silently delete audit rows on the operator's behalf. Previously implied; now stated in both the helper docstring and the guide.

**Observability.** Returning a per-table `{ status, deleted }` list rather than `void` means a scheduled handler can log a retention record per run — cheap, and useful the next time someone asks whether a table is actually being swept.

## Docs

- [Data Retention](apps/docs/deployment/data-retention.md) now leads with `runRetention` and demotes the per-table helpers to an "escape hatches" section.
- [Outbox Relay (Cron)](apps/docs/deployment/outbox-cron.md) gains a callout so someone landing there learns the relay is not their retention story.
- `cleanupCodes`' docstring points at `runRetention` first.

## Tests

9 cases in `test/helpers/run-retention.spec.ts`: default windows, per-table overrides, tenant-scoped vs. global session sweep, both skip paths (no outbox / no `sessionCleanup`), and that a mid-sweep failure still runs the remaining tables and reports the partial result.

Full `test/helpers/` suite passes (293 tests), typecheck clean.

## Acceptance criteria

- [x] A single documented entry point sweeps every prunable table
- [x] Adding a new prunable table doesn't require consumers to edit their scheduled handler
- [x] Works when outbox is disabled
- [x] Data Retention guide leads with it; per-table helpers documented as the escape hatch
- [x] `logs` decision made and recorded (left to the operator, with the reasoning)

## Follow-up

#1172 — the `create-authhero` templates ship no scheduled handler at all, so a freshly scaffolded project still sweeps nothing until the operator wires up a cron. Note the WFP tenant case there may be a design question rather than a template edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `runRetention` to sweep eligible data—including codes, outbox events, and supported sessions—in one scheduled operation.
  * Added configurable retention periods and optional tenant-scoped cleanup.
  * Retention sweeps continue across all areas even when one fails, with detailed results and error reporting.

* **Documentation**
  * Updated scheduling guidance to recommend `runRetention`.
  * Clarified that outbox delivery remains separate from retention cleanup.
  * Documented default retention periods, upgrade considerations, and individual cleanup alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->