### PR TITLE
fix: scope the PATCH phone uniqueness check to sms users

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,9 @@
+---
+"authhero": patch
+---
+
+Scope the management API PATCH phone-number uniqueness check to `sms` users, matching the create path and Auth0.
+
+The PATCH handler rejected a phone update if *any* user in the tenant held that number, regardless of provider — the same over-broad rule PR #1165 removed from the database, still live at the app layer. Non-sms users legitimately share phone numbers (placeholder and api-created values are common), so this produced spurious 409s on valid updates.
+
+A phone number only identifies a user on the passwordless `sms` connection, so the check now applies only when the target user is an sms user, and only collides against other sms users. The lookup also moved to the provider-scoped `getUserByProvider` helper, which removes an unscoped `per_page: 10` query that silently missed matches past the tenth.

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -680,19 +680,24 @@ const patchByUser_id = defineRoute({
       }
     }
 
-    // Check if the phone_number is being changed to an existing phone_number of another user
+    // A phone number only *identifies* a user on the passwordless `sms`
+    // connection, so uniqueness is enforced only for sms users — mirroring the
+    // create path above and Auth0. For every other provider the phone is
+    // ordinary profile data that people legitimately share (see #1162), and an
+    // unscoped check 409s on the placeholder numbers non-sms users carry.
     if (
+      targetUser.provider === "sms" &&
       userFields.phone_number &&
       userFields.phone_number !== targetUser.phone_number
     ) {
-      const { users: existingUsers } = await data.users.list(tenantId, {
-        page: 0,
-        per_page: 10,
-        include_totals: false,
-        q: `phone_number:${userFields.phone_number}`,
+      const existingSmsUser = await getUserByProvider({
+        userAdapter: data.users,
+        tenant_id: tenantId,
+        username: userFields.phone_number,
+        provider: "sms",
       });
 
-      if (existingUsers.some((u) => u.user_id !== targetUserId)) {
+      if (existingSmsUser && existingSmsUser.user_id !== targetUserId) {
         throw new HTTPException(409, {
           message: "Another user with the same phone number already exists.",
         });

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -443,8 +443,14 @@ const postRoot = defineRoute({
     // connection, so uniqueness is enforced here (Auth0-style, at lookup)
     // rather than by a database constraint spanning every provider — for
     // non-sms providers the phone is ordinary profile data that people
-    // legitimately share (see #1162). Mirrors the resolve-to-existing check
-    // the login flow does in getOrCreateUserByProvider.
+    // legitimately share (see #1162).
+    //
+    // This uses the same lookup as the login flow's getOrCreateUserByProvider
+    // but *deliberately* differs in outcome: login resolves to the existing
+    // user, management create 409s. Creating a user here is an explicit
+    // administrative act, often scripted in bulk, so silently returning a
+    // user_id the caller did not create would hide a merge. The split is
+    // intentional, not an oversight — see #1166.
     if (provider === "sms" && phone_number) {
       const existingSmsUser = await getUserByProvider({
         userAdapter: ctx.env.data.users,

--- a/packages/authhero/test/management-api/users.test.ts
+++ b/packages/authhero/test/management-api/users.test.ts
@@ -72,6 +72,77 @@ describe("POST /api/v2/users", () => {
     const body = await response.json();
     expect(body).toMatchObject({ email: "valid-body@example.com" });
   });
+
+  // Management create deliberately 409s where the login flow resolves to the
+  // existing user: creating a user here is an explicit administrative act,
+  // often scripted in bulk, so silently returning a user_id the caller did not
+  // create would hide a merge. Decision recorded in #1166.
+  it("rejects creating a second sms user with an existing sms phone number", async () => {
+    const { managementApp, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    await env.data.users.create("tenantId", {
+      user_id: "sms|existing",
+      phone_number: "+46700000010",
+      email_verified: false,
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+    });
+
+    const response = await managementApp.request(
+      "/users",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          phone_number: "+46700000010",
+          connection: "sms",
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  it("allows creating a non-sms user carrying a phone number an sms user holds", async () => {
+    const { managementApp, env } = await getTestServer();
+    const token = await getAdminToken();
+
+    await env.data.users.create("tenantId", {
+      user_id: "sms|holder",
+      phone_number: "+46700000011",
+      email_verified: false,
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+    });
+
+    const response = await managementApp.request(
+      "/users",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "carries-phone@example.com",
+          phone_number: "+46700000011",
+          connection: "Username-Password-Authentication",
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(201);
+  });
 });
 
 describe("PATCH /api/v2/users/:user_id phone_number uniqueness", () => {

--- a/packages/authhero/test/management-api/users.test.ts
+++ b/packages/authhero/test/management-api/users.test.ts
@@ -73,3 +73,147 @@ describe("POST /api/v2/users", () => {
     expect(body).toMatchObject({ email: "valid-body@example.com" });
   });
 });
+
+describe("PATCH /api/v2/users/:user_id phone_number uniqueness", () => {
+  const PHONE = "+46700000001";
+
+  async function patchPhone(
+    managementApp: Awaited<ReturnType<typeof getTestServer>>["managementApp"],
+    env: Awaited<ReturnType<typeof getTestServer>>["env"],
+    userId: string,
+    phone_number: string,
+  ) {
+    const token = await getAdminToken();
+    return managementApp.request(
+      `/users/${encodeURIComponent(userId)}`,
+      {
+        method: "PATCH",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ phone_number }),
+      },
+      env,
+    );
+  }
+
+  it("allows a non-sms user to take a phone number another non-sms user already has", async () => {
+    const { managementApp, env } = await getTestServer();
+
+    // Placeholder/dummy numbers on email-provider users are ordinary profile
+    // data, not identities — production carries thousands of them (#1166).
+    // The old unscoped check 409'd on these, blocking legitimate updates.
+    await env.data.users.create("tenantId", {
+      user_id: "auth2|other-email-user",
+      email: "other@example.com",
+      email_verified: true,
+      phone_number: PHONE,
+      provider: "auth2",
+      connection: "Username-Password-Authentication",
+      is_social: false,
+    });
+    await env.data.users.create("tenantId", {
+      user_id: "auth2|target-email-user",
+      email: "target@example.com",
+      email_verified: true,
+      provider: "auth2",
+      connection: "Username-Password-Authentication",
+      is_social: false,
+    });
+
+    const response = await patchPhone(
+      managementApp,
+      env,
+      "auth2|target-email-user",
+      PHONE,
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("allows a non-sms user to take a phone number an sms user identifies by", async () => {
+    const { managementApp, env } = await getTestServer();
+
+    await env.data.users.create("tenantId", {
+      user_id: "sms|sms-user",
+      phone_number: PHONE,
+      email_verified: false,
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+    });
+    await env.data.users.create("tenantId", {
+      user_id: "auth2|profile-user",
+      email: "profile@example.com",
+      email_verified: true,
+      provider: "auth2",
+      connection: "Username-Password-Authentication",
+      is_social: false,
+    });
+
+    // The sms user's phone is their identity, but that does not stop an
+    // unrelated user recording the same number as profile data.
+    const response = await patchPhone(
+      managementApp,
+      env,
+      "auth2|profile-user",
+      PHONE,
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("still rejects an sms user taking a phone number another sms user identifies by", async () => {
+    const { managementApp, env } = await getTestServer();
+
+    await env.data.users.create("tenantId", {
+      user_id: "sms|incumbent",
+      phone_number: PHONE,
+      email_verified: false,
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+    });
+    await env.data.users.create("tenantId", {
+      user_id: "sms|challenger",
+      phone_number: "+46700000002",
+      email_verified: false,
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+    });
+
+    const response = await patchPhone(
+      managementApp,
+      env,
+      "sms|challenger",
+      PHONE,
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  it("lets an sms user keep a phone number that only they hold", async () => {
+    const { managementApp, env } = await getTestServer();
+
+    await env.data.users.create("tenantId", {
+      user_id: "sms|sole-holder",
+      phone_number: "+46700000003",
+      email_verified: false,
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+    });
+
+    const response = await patchPhone(
+      managementApp,
+      env,
+      "sms|sole-holder",
+      PHONE,
+    );
+
+    expect(response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Addresses items 1 and 2 of #1166. Does **not** close it — items 3 and 4 need decisions and production data, see below.

## Item 1 — the bug

The management API PATCH handler rejected a phone update if *any* user in the tenant held that number, regardless of provider:

```ts
q: `phone_number:${userFields.phone_number}`   // every provider
```

That is the same over-broad rule PR #1165 removed from the database, still live at the app layer — while the create path directly above it correctly gated on `provider === "sms"`. The two paths disagreed.

This is not theoretical. A phone number only *identifies* a user on the passwordless `sms` connection; for every other provider it is ordinary profile data. #1166 counts ~2,177 non-`sms` rows in production carrying email-provider placeholder and api-created dummy numbers, and every one of them was a spurious 409 on a legitimate update.

The check now runs only when the **target** user is an sms user, and collides only against **other sms** users, via the same provider-scoped `getUserByProvider` helper the create path uses. That also retires an unscoped `per_page: 10` lookup which silently missed matches past the tenth.

## Item 2 — create vs. login, decided

#1166 asked whether management create should keep its 409 or adopt Auth0's resolve-to-existing. **Decision: keep the 409.**

Creating a user through the management API is an explicit administrative act, frequently scripted in bulk. Silently returning a `user_id` the caller did not ask to create would hide a merge from the one caller least equipped to notice it. Auth0's resolve-to-existing belongs to the SMS *login* connection, which AuthHero already implements separately in `getOrCreateUserByProvider`.

No behaviour change — but the create-path comment claimed it "mirrors" that login check, which read as an accident awaiting reconciliation. The two share a lookup and deliberately differ in outcome, and now say so.

## Tests

Neither path had any coverage for the phone 409, which is how this shipped. Six cases added:

| Case | Before | After |
| --- | --- | --- |
| non-sms user takes a phone another non-sms user has | 409 ❌ | 200 ✅ |
| non-sms user takes a phone an sms user identifies by | 409 ❌ | 200 ✅ |
| sms user takes a phone another sms user identifies by | 409 | 409 ✅ |
| sms user keeps a phone only they hold | 200 | 200 ✅ |
| create second sms user on an existing sms phone | 409 | 409 ✅ |
| create non-sms user carrying an sms user's phone | 201 | 201 ✅ |

The two regression cases were verified to fail against the previous handler, and the four guard cases pass under both — so they lock behaviour rather than merely restating the new code.

Typecheck clean, full `management-api` suite 36/36.

## Still open on #1166

- **Item 3** — `unique_email_provider` review. Needs quantifying against production; not something I can do from here.
- **Item 4** — the ~461 genuine sms collision groups (families vs. memberships). Explicitly a human product answer, and it decides whether any merge happens at all.

I have left #1166 open for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)