### PR TITLE
feat(create-authhero): scaffold retention sweep into Cloudflare templates (#1172)

### DIFF
--- a/.changeset/retention-cron-templates.md
+++ b/.changeset/retention-cron-templates.md
@@ -1,0 +1,15 @@
+---
+"create-authhero": patch
+---
+
+Scaffold a working retention sweep into the Cloudflare templates so fresh
+projects don't accumulate rows forever. The `cloudflare` and
+`cloudflare-control-plane` templates now export a `scheduled` handler that calls
+`runRetention` and declare a daily `[triggers] crons` block in `wrangler.toml`,
+pruning expired `codes`, processed `outbox_events` and expired sessions without
+the operator having to discover the data-retention guide first.
+
+`cloudflare-wfp-tenant` deliberately gets no cron — dispatch-namespace Workers
+never receive `scheduled` events — and instead documents that tenant shards are
+swept centrally from the control plane. `aws-sst` records that DynamoDB's native
+TTL already expires these rows, so it needs no sweep.

--- a/apps/docs/deployment/data-retention.md
+++ b/apps/docs/deployment/data-retention.md
@@ -24,6 +24,14 @@ export default {
 
 Daily is a reasonable cadence.
 
+### Scaffolded projects already have this
+
+If you started from a `create-authhero` template you do not need to add this by hand — it is wired at scaffold time:
+
+- **`cloudflare`** and **`cloudflare-control-plane`** ship a `scheduled` handler that calls `runRetention`, plus a `[triggers] crons = ["0 3 * * *"]` block in `wrangler.toml`. Adjust the schedule to taste.
+- **`cloudflare-wfp-tenant`** has **no** cron on purpose. Workers uploaded to a Workers-for-Platforms dispatch namespace never receive `scheduled` events, so a cron there would silently never fire. Each tenant Worker reads only its own D1, so those shards must be swept **centrally**: iterate tenants from the control plane and call `runRetention({ dataAdapter, tenantId })` against each tenant's database. (The control-plane template sweeps its own D1 only; the cross-tenant driver is left for you to wire.)
+- **`aws-sst`** needs no sweep at all. DynamoDB's native TTL expires codes, sessions and refresh tokens by `expiresAt` on its own, and the AWS adapter exposes no `outbox` or `sessionCleanup`. See [Adapter behaviour](#adapter-behaviour).
+
 `runRetention` sweeps every prunable table, using the default window for each:
 
 | Table(s) | Default window | Notes |

--- a/packages/create-authhero/templates/aws-sst/sst.config.ts
+++ b/packages/create-authhero/templates/aws-sst/sst.config.ts
@@ -27,6 +27,12 @@ export default $config({
         gsi1: { hashKey: "gsi1pk", rangeKey: "gsi1sk" },
         gsi2: { hashKey: "gsi2pk", rangeKey: "gsi2sk" },
       },
+      // Data retention: no scheduled `runRetention` sweep is needed on AWS.
+      // DynamoDB's native TTL (below) expires codes, sessions and refresh
+      // tokens by `expiresAt` on its own, the AWS adapter exposes no `outbox`
+      // or `sessionCleanup`, and its `codes.cleanup()` is a no-op returning 0.
+      // The Cloudflare templates schedule a sweep because SQLite/D1 has no
+      // equivalent. See https://authhero.net/deployment/data-retention.
       ttl: "expiresAt",
     });
 

--- a/packages/create-authhero/templates/cloudflare-control-plane/src/index.ts
+++ b/packages/create-authhero/templates/cloudflare-control-plane/src/index.ts
@@ -22,17 +22,8 @@ export default {
     const issuer = `${url.protocol}//${url.host}/`;
     const origin = request.headers.get("Origin") || "";
 
-    const db = drizzle(env.AUTH_DB, { schema });
-    let dataAdapter: DataAdapters = createAdapters(db, {
-      useTransactions: false,
-    });
-
-    if (env.ENCRYPTION_KEY) {
-      dataAdapter = createEncryptedDataAdapter(
-        dataAdapter,
-        await loadEncryptionKey(env.ENCRYPTION_KEY),
-      );
-    }
+    const { db, dataAdapter: baseAdapter } = await buildDataAdapter(env);
+    let dataAdapter = baseAdapter;
 
     // Rollout source: project the control plane's inheritable defaults into a
     // WFP tenant's own database. Runs inline here; swap for a Cloudflare
@@ -98,20 +89,32 @@ export default {
   // `buildTenantAdapters(env, tenantId)` below. That cross-tenant driver is not
   // wired here yet; see https://authhero.net/deployment/data-retention.
   async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
-    const db = drizzle(env.AUTH_DB, { schema });
-    let dataAdapter: DataAdapters = createAdapters(db, {
-      useTransactions: false,
-    });
-    if (env.ENCRYPTION_KEY) {
-      dataAdapter = createEncryptedDataAdapter(
-        dataAdapter,
-        await loadEncryptionKey(env.ENCRYPTION_KEY),
-      );
-    }
+    const { dataAdapter } = await buildDataAdapter(env);
     const { sweeps } = await runRetention({ dataAdapter });
     console.log("retention sweep", sweeps);
   },
 };
+
+/**
+ * Build the base DataAdapters over the control plane's own D1 (AUTH_DB),
+ * wrapped with encryption when ENCRYPTION_KEY is set. Shared by the request
+ * path and the retention cron so both see the same schema, transaction and
+ * encryption configuration. The fetch handler decorates the returned adapter
+ * with custom-domains support after this base is built.
+ */
+async function buildDataAdapter(env: Env) {
+  const db = drizzle(env.AUTH_DB, { schema });
+  let dataAdapter: DataAdapters = createAdapters(db, {
+    useTransactions: false,
+  });
+  if (env.ENCRYPTION_KEY) {
+    dataAdapter = createEncryptedDataAdapter(
+      dataAdapter,
+      await loadEncryptionKey(env.ENCRYPTION_KEY),
+    );
+  }
+  return { db, dataAdapter };
+}
 
 /**
  * Return the DataAdapters over the given tenant's OWN D1, wrapped with the same

--- a/packages/create-authhero/templates/cloudflare-control-plane/src/index.ts
+++ b/packages/create-authhero/templates/cloudflare-control-plane/src/index.ts
@@ -8,6 +8,7 @@ import {
   DataAdapters,
   createEncryptedDataAdapter,
   loadEncryptionKey,
+  runRetention,
 } from "authhero";
 import { createDirectRolloutAdapter } from "@authhero/multi-tenancy";
 import createApp from "./app";
@@ -81,6 +82,34 @@ export default {
     const app = createApp(config, rollout);
 
     return app.fetch(request, { ...env, ISSUER: issuer });
+  },
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Retention sweep (this Worker's own D1)
+  // ────────────────────────────────────────────────────────────────────────
+  // Prunes expired `codes`, processed `outbox_events` and expired sessions in
+  // the control plane's own database, which otherwise grows without bound.
+  // Runs on the cron in wrangler.toml.
+  //
+  // NOTE: this sweeps only AUTH_DB (the control_plane tenant). Each WFP tenant
+  // has its OWN D1 and its tenant Worker cannot carry a cron (dispatch-namespace
+  // Workers don't receive scheduled events), so tenant shards must be swept
+  // centrally — call `runRetention({ dataAdapter, tenantId })` per tenant using
+  // `buildTenantAdapters(env, tenantId)` below. That cross-tenant driver is not
+  // wired here yet; see https://authhero.net/deployment/data-retention.
+  async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
+    const db = drizzle(env.AUTH_DB, { schema });
+    let dataAdapter: DataAdapters = createAdapters(db, {
+      useTransactions: false,
+    });
+    if (env.ENCRYPTION_KEY) {
+      dataAdapter = createEncryptedDataAdapter(
+        dataAdapter,
+        await loadEncryptionKey(env.ENCRYPTION_KEY),
+      );
+    }
+    const { sweeps } = await runRetention({ dataAdapter });
+    console.log("retention sweep", sweeps);
   },
 };
 

--- a/packages/create-authhero/templates/cloudflare-control-plane/wrangler.toml
+++ b/packages/create-authhero/templates/cloudflare-control-plane/wrangler.toml
@@ -18,6 +18,16 @@ main = "src/index.ts"
 compatibility_date = "2026-05-01"
 compatibility_flags = ["nodejs_compat"]
 
+# ════════════════════════════════════════════════════════════════════════════
+# Scheduled retention sweep (this Worker's own D1)
+# ════════════════════════════════════════════════════════════════════════════
+# Runs the `scheduled` handler in src/index.ts, pruning expired `codes`,
+# processed `outbox_events` and expired sessions in the control-plane database.
+# WFP tenant shards have their own D1 and are swept centrally — see the note in
+# src/index.ts and https://authhero.net/deployment/data-retention.
+[triggers]
+crons = ["0 3 * * *"]
+
 [assets]
 directory = "./dist/assets"
 

--- a/packages/create-authhero/templates/cloudflare-wfp-tenant/src/index.ts
+++ b/packages/create-authhero/templates/cloudflare-wfp-tenant/src/index.ts
@@ -23,6 +23,18 @@ import { Env } from "./types";
 // Must match the control plane Worker's CONTROL_PLANE_TENANT_ID.
 const CONTROL_PLANE_TENANT_ID = "control_plane";
 
+// ──────────────────────────────────────────────────────────────────────────────
+// Data retention: no cron here — this is deliberate.
+//
+// This Worker is uploaded to a Workers-for-Platforms dispatch namespace and is
+// only ever invoked via `env.DISPATCHER.get(name).fetch()`. Dispatch-namespace
+// Workers do NOT receive `scheduled` events, so a `[triggers] crons` block here
+// would never fire. Its D1 (codes, outbox_events, expired sessions) must instead
+// be swept centrally: iterate tenants from the control plane and call
+// `runRetention({ dataAdapter, tenantId })` against each tenant's own database.
+// See https://authhero.net/deployment/data-retention.
+// ──────────────────────────────────────────────────────────────────────────────
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);

--- a/packages/create-authhero/templates/cloudflare-wfp-tenant/wrangler.toml
+++ b/packages/create-authhero/templates/cloudflare-wfp-tenant/wrangler.toml
@@ -17,6 +17,10 @@ main = "src/index.ts"
 compatibility_date = "2026-05-01"
 compatibility_flags = ["nodejs_compat"]
 
+# No [triggers] crons here: dispatch-namespace Workers never receive scheduled
+# events, so a cron would never fire. This tenant's D1 is swept centrally from
+# the control plane — see the retention note in src/index.ts.
+
 [assets]
 directory = "./dist/assets"
 

--- a/packages/create-authhero/templates/cloudflare/src/index.ts
+++ b/packages/create-authhero/templates/cloudflare/src/index.ts
@@ -5,14 +5,35 @@ import createApp from "./app";
 import { Env } from "./types";
 import {
   AuthHeroConfig,
+  DataAdapters,
   createEncryptedDataAdapter,
   loadEncryptionKey,
+  runRetention,
 } from "authhero";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // OPTIONAL: Uncomment to enable Cloudflare adapters (Analytics Engine, etc.)
 // ──────────────────────────────────────────────────────────────────────────────
 // import createCloudflareAdapters from "@authhero/cloudflare-adapter";
+
+/**
+ * Build the data adapter. Shared by `fetch` and the `scheduled` handler so both
+ * request traffic and the retention sweep talk to the database the same way.
+ */
+async function buildDataAdapter(env: Env): Promise<DataAdapters> {
+  const db = drizzle(env.AUTH_DB, { schema });
+  let dataAdapter = createAdapters(db, { useTransactions: false });
+
+  // Encrypt sensitive credential fields at rest when ENCRYPTION_KEY is set.
+  // In local dev it comes from .dev.vars; in production set it with
+  // `wrangler secret put ENCRYPTION_KEY`. Without it, behavior is unchanged.
+  if (env.ENCRYPTION_KEY) {
+    const encryptionKey = await loadEncryptionKey(env.ENCRYPTION_KEY);
+    dataAdapter = createEncryptedDataAdapter(dataAdapter, encryptionKey);
+  }
+
+  return dataAdapter;
+}
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -22,16 +43,7 @@ export default {
     // Get the origin from the request for dynamic CORS
     const origin = request.headers.get("Origin") || "";
 
-    const db = drizzle(env.AUTH_DB, { schema });
-    let dataAdapter = createAdapters(db, { useTransactions: false });
-
-    // Encrypt sensitive credential fields at rest when ENCRYPTION_KEY is set.
-    // In local dev it comes from .dev.vars; in production set it with
-    // `wrangler secret put ENCRYPTION_KEY`. Without it, behavior is unchanged.
-    if (env.ENCRYPTION_KEY) {
-      const encryptionKey = await loadEncryptionKey(env.ENCRYPTION_KEY);
-      dataAdapter = createEncryptedDataAdapter(dataAdapter, encryptionKey);
-    }
+    const dataAdapter = await buildDataAdapter(env);
 
     // ────────────────────────────────────────────────────────────────────────
     // OPTIONAL: Cloudflare Analytics Engine for centralized logging
@@ -93,5 +105,20 @@ export default {
     };
 
     return app.fetch(request, envWithIssuer);
+  },
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Retention sweep
+  // ────────────────────────────────────────────────────────────────────────
+  // Runs on the cron in wrangler.toml ([triggers] crons). Several AuthHero
+  // tables (codes, outbox_events, expired sessions) accumulate rows that normal
+  // traffic never deletes, so without this a deployment grows without bound.
+  // `runRetention` sweeps every prunable table in one call and picks up tables
+  // added in future AuthHero versions with no change here.
+  // See https://authhero.net/deployment/data-retention for details and tuning.
+  async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
+    const dataAdapter = await buildDataAdapter(env);
+    const { sweeps } = await runRetention({ dataAdapter });
+    console.log("retention sweep", sweeps);
   },
 };

--- a/packages/create-authhero/templates/cloudflare/wrangler.toml
+++ b/packages/create-authhero/templates/cloudflare/wrangler.toml
@@ -17,6 +17,17 @@ compatibility_date = "2026-05-01"
 compatibility_flags = ["nodejs_compat"]
 
 # ════════════════════════════════════════════════════════════════════════════
+# Scheduled retention sweep
+# ════════════════════════════════════════════════════════════════════════════
+# Runs the `scheduled` handler in src/index.ts, which calls `runRetention` to
+# prune expired `codes`, processed `outbox_events` and expired sessions. Without
+# this cron those tables grow without bound. Daily at 03:00 UTC is a sensible
+# default; adjust the schedule to taste.
+# https://authhero.net/deployment/data-retention
+[triggers]
+crons = ["0 3 * * *"]
+
+# ════════════════════════════════════════════════════════════════════════════
 # Static Assets (CSS, JS, Widget)
 # ════════════════════════════════════════════════════════════════════════════
 # Serve static assets from the authhero package.


### PR DESCRIPTION
Closes #1172.

## Problem

`create-authhero` templates exported only `fetch` with no `[triggers]`/`crons` block, so a scaffold → deploy → run-traffic project accumulated `codes`, `outbox_events` and expired sessions **forever** — the exact shape of #1155. #1159 collapsed retention into one `runRetention({ dataAdapter })` call, but that only helps operators who already know to read the [Data Retention guide](apps/docs/deployment/data-retention.md). This wires it at scaffold time so new projects need to discover nothing.

## Changes

- **`cloudflare`** — extract a shared `buildDataAdapter(env)` helper (used by both `fetch` and the new handler) and add a `scheduled()` handler calling `runRetention`; daily `[triggers] crons = ["0 3 * * *"]` in `wrangler.toml`.
- **`cloudflare-control-plane`** — `scheduled()` sweeping its own D1 + cron.
- **`cloudflare-wfp-tenant`** — **no cron, by design.** Dispatch-namespace Workers never receive `scheduled` events, so a cron there would silently never fire. Documents that tenant shards are swept **centrally** from the control plane (`runRetention({ dataAdapter, tenantId })` per tenant).
- **`aws-sst`** — decision recorded: DynamoDB's native `ttl: "expiresAt"` already expires codes/sessions/refresh-tokens, and the AWS adapter exposes no `outbox`/`sessionCleanup`, so no sweep is needed.
- **`proxy` / `cloudflare-wfp-dispatcher`** — untouched (hold no AuthHero data).
- **Docs** — new "Scaffolded projects already have this" section in the Data Retention guide.

## Acceptance (from #1172)

- [x] Cloudflare templates scaffold with a working scheduled handler calling `runRetention` + a cron trigger.
- [x] WFP tenant sweep strategy decided (centrally driven) and documented.
- [x] Decision recorded for `aws-sst`.
- [x] Data Retention guide notes scaffolded projects already have this wired.

## Follow-up (not in this PR)

The cross-tenant WFP sweep **driver** (control plane iterating every tenant's D1) depends on `buildTenantAdapters`, which is still a `501` stub in the control-plane template. This PR documents the strategy and flags it in-code; the driver itself is left for a separate issue.

## Notes

- Template-only change. These templates reference the published `authhero`/`@authhero/drizzle` packages and aren't part of the workspace typecheck (`create-authhero` compiles `src` only; templates ship as `publicDir`), so they can't be run in-repo. Handler code mirrors the existing `fetch` adapter-build path and the documented `runRetention` example.
- Changeset: patch to `create-authhero`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloudflare templates now perform automated daily retention sweeps to prune expired codes, outbox events, and sessions (03:00 UTC).
  * Control-plane deployments centrally handle retention for tenant data; WFP tenant workers don’t run scheduled jobs.
  * Credential data remains encrypted at rest when encryption is configured.

* **Documentation**
  * Updated retention docs with a “Scaffolded projects already have this” section, explaining template-specific behavior for Cloudflare vs AWS and why tenant Workers lack cron.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->