### PR TITLE
fix(cloudflare): serve /u/widget/* from control plane in wfp-forward (#1179)

### DIFF
--- a/.changeset/wfp-widget-carveout.md
+++ b/.changeset/wfp-widget-carveout.md
@@ -1,0 +1,14 @@
+---
+"@authhero/cloudflare-adapter": patch
+---
+
+Serve `/u/widget/*` from the control plane in `createWfpForwardMiddleware`
+instead of dispatching it to the tenant worker. The u2 universal-login pages
+load the widget bundle as an ES module to hydrate the form, but a per-tenant
+WFP dispatch worker has no static-assets binding and no `widgetHandler`, so the
+request 404'd and the u2 Continue / social buttons rendered inert on every WFP
+tenant pinned to u2.
+
+The middleware now carves out a configurable list of shared static-asset path
+prefixes (`localPaths`, default `["/u/widget/"]`) that fall through to the
+local control-plane app. Pass `localPaths: []` to opt out.

--- a/apps/docs/customization/multi-tenancy/control-plane-defaults.md
+++ b/apps/docs/customization/multi-tenancy/control-plane-defaults.md
@@ -599,11 +599,16 @@ is on the main entry; the sync helpers are on the `@authhero/cloudflare-adapter/
 subpath, whose `authhero` + `@authhero/multi-tenancy` peers are **optional** —
 install them only if you import `/wfp`.
 
-- **`createWfpForwardMiddleware({ tenants, controlPlaneTenantId, dispatcherBinding?, scriptNameTemplate?, resolveTenantId? })`**
+- **`createWfpForwardMiddleware({ tenants, controlPlaneTenantId, dispatcherBinding?, scriptNameTemplate?, resolveTenantId?, localPaths? })`**
   → Hono `MiddlewareHandler` — forwards a resolved tenant's request to its WFP
   worker over the dispatch namespace. Control-plane / shared / unknown tenants,
   and `wfp` tenants not yet `provisioning_state === "ready"`, fall through to the
-  local app. Pass it as `init`'s `tenantDispatch` config so it is mounted inside
+  local app. Requests matching `localPaths` (default `["/u/widget/"]`) are never
+  dispatched either — they are shared static assets (the universal-login widget
+  bundle) that only the control plane can serve, so a per-tenant dispatch worker
+  would 404 them; they fall through so the control-plane app serves them. Pass
+  `localPaths: []` to disable the carve-out. Pass it as `init`'s `tenantDispatch`
+  config so it is mounted inside
   authhero's management API **after** the CORS middleware — then the central CORS
   middleware applies the `Access-Control-Allow-*` headers to the dispatched
   response and no manual CORS handling is needed in the host app. (Mounting it

--- a/packages/cloudflare/src/wfp-provisioner/wfp-forward.ts
+++ b/packages/cloudflare/src/wfp-provisioner/wfp-forward.ts
@@ -5,6 +5,20 @@ import type { DispatchNamespace } from "../code-executor";
 const DEFAULT_DISPATCHER_BINDING = "DISPATCHER";
 const DEFAULT_SCRIPT_NAME_TEMPLATE = "tenant-{tenant_id}-auth";
 
+/**
+ * Path prefixes served from the control plane rather than dispatched to a
+ * tenant worker. These are shared static assets that are byte-identical across
+ * tenants and only exist on the control plane's deployment.
+ *
+ * `/u/widget/` is the universal-login (u2) widget bundle. It's a multi-file
+ * Stencil bundle the SSR'd pages load as an ES module to hydrate the form. A
+ * per-tenant dispatch worker has no static-assets binding and no configured
+ * `widgetHandler`, so forwarding these requests 404s and the u2 buttons render
+ * inert. Serving them from the control plane — where the assets live — keeps
+ * zero per-tenant weight.
+ */
+const DEFAULT_LOCAL_PATHS = ["/u/widget/"];
+
 export interface WfpForwardOptions {
   /** Tenants adapter, used to look up the resolved tenant's `deployment_type`. */
   tenants: TenantsDataAdapter;
@@ -29,6 +43,18 @@ export interface WfpForwardOptions {
   resolveTenantId?: (
     c: Context,
   ) => string | undefined | Promise<string | undefined>;
+  /**
+   * Request path prefixes that are **never** dispatched to a tenant worker,
+   * even for a fully-provisioned `wfp` tenant. Matching requests fall through
+   * to the local (control-plane) app so it serves them from its own assets /
+   * handlers.
+   *
+   * Use this for shared static assets that only the control plane can serve —
+   * a per-tenant dispatch worker has no static-assets binding. Defaults to
+   * `["/u/widget/"]` (the universal-login widget bundle); pass `[]` to disable
+   * the carve-out entirely, or extend the list for other shared assets.
+   */
+  localPaths?: string[];
 }
 
 function isDispatchNamespace(value: unknown): value is DispatchNamespace {
@@ -57,6 +83,10 @@ function fillTemplate(template: string, tenantId: string): string {
  * dispatching to a not-yet-deployed worker would only hard-fail the request.
  * The tenant worker receives the original request verbatim and owns the full
  * response.
+ *
+ * Requests whose path matches `localPaths` (default `["/u/widget/"]`) are also
+ * never dispatched — they are shared static assets that only the control plane
+ * can serve, so a per-tenant worker would 404 them. See `DEFAULT_LOCAL_PATHS`.
  */
 export function createWfpForwardMiddleware(
   options: WfpForwardOptions,
@@ -67,9 +97,21 @@ export function createWfpForwardMiddleware(
     dispatcherBinding = DEFAULT_DISPATCHER_BINDING,
     scriptNameTemplate = DEFAULT_SCRIPT_NAME_TEMPLATE,
     resolveTenantId = (c) => c.req.header("tenant-id"),
+    localPaths = DEFAULT_LOCAL_PATHS,
   } = options;
 
   return async (c, next) => {
+    // Shared static assets (byte-identical across tenants, served only by the
+    // control plane) must not be forwarded to a tenant worker that can't serve
+    // them. Check the path before resolving the tenant so it short-circuits
+    // regardless of which tenant the request would otherwise route to.
+    if (localPaths.length > 0) {
+      const path = c.req.path;
+      if (localPaths.some((prefix) => path.startsWith(prefix))) {
+        return next();
+      }
+    }
+
     const tenantId = await resolveTenantId(c);
     if (!tenantId || tenantId === controlPlaneTenantId) {
       return next();

--- a/packages/cloudflare/test/wfp-forward.spec.ts
+++ b/packages/cloudflare/test/wfp-forward.spec.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import type { Tenant, TenantsDataAdapter } from "@authhero/adapter-interfaces";
+import { createWfpForwardMiddleware } from "../src";
+
+const CONTROL_PLANE = "main";
+
+function tenant(overrides: Partial<Tenant> = {}): Tenant {
+  return {
+    id: "acme",
+    name: "Acme",
+    deployment_type: "wfp",
+    provisioning_state: "ready",
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  } as Tenant;
+}
+
+/** Minimal tenants adapter exposing just the `get` the middleware calls. */
+function tenantsAdapter(
+  get: (id: string) => Promise<Tenant | null>,
+): TenantsDataAdapter {
+  return { get } as unknown as TenantsDataAdapter;
+}
+
+/**
+ * Build a dispatch namespace whose worker responds with a marker so a test can
+ * assert whether the request was dispatched to the tenant worker or served
+ * locally. Records every dispatched script name / path.
+ */
+function dispatcher() {
+  const dispatched: { script: string; path: string }[] = [];
+  const namespace = {
+    get(script: string) {
+      return {
+        async fetch(req: Request) {
+          dispatched.push({ script, path: new URL(req.url).pathname });
+          return new Response("from-tenant-worker", { status: 200 });
+        },
+      };
+    },
+  };
+  return { namespace, dispatched };
+}
+
+/** App that dispatches, then serves a local marker for anything not forwarded. */
+function buildApp(
+  middleware: ReturnType<typeof createWfpForwardMiddleware>,
+  env: Record<string, unknown>,
+) {
+  const app = new Hono();
+  app.use(middleware);
+  app.all("*", (c) => c.text("from-control-plane", 200));
+  return {
+    request: (path: string, headers: Record<string, string> = {}) =>
+      app.request(path, { headers }, env),
+  };
+}
+
+describe("createWfpForwardMiddleware localPaths carve-out", () => {
+  it("serves /u/widget/* from the control plane instead of dispatching (default)", async () => {
+    const { namespace, dispatched } = dispatcher();
+    const get = vi.fn(async () => tenant());
+    const app = buildApp(
+      createWfpForwardMiddleware({
+        tenants: tenantsAdapter(get),
+        controlPlaneTenantId: CONTROL_PLANE,
+      }),
+      { DISPATCHER: namespace },
+    );
+
+    const res = await app.request("/u/widget/authhero-widget.esm.js?v=abc", {
+      "tenant-id": "acme",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("from-control-plane");
+    expect(dispatched).toHaveLength(0);
+    // The carve-out short-circuits before the tenant lookup.
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("still dispatches non-carved-out paths for a ready wfp tenant", async () => {
+    const { namespace, dispatched } = dispatcher();
+    const app = buildApp(
+      createWfpForwardMiddleware({
+        tenants: tenantsAdapter(async () => tenant()),
+        controlPlaneTenantId: CONTROL_PLANE,
+      }),
+      { DISPATCHER: namespace },
+    );
+
+    const res = await app.request("/u2/login?state=xyz", {
+      "tenant-id": "acme",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("from-tenant-worker");
+    expect(dispatched).toEqual([
+      { script: "tenant-acme-auth", path: "/u2/login" },
+    ]);
+  });
+
+  it("honours a custom localPaths list", async () => {
+    const { namespace, dispatched } = dispatcher();
+    const app = buildApp(
+      createWfpForwardMiddleware({
+        tenants: tenantsAdapter(async () => tenant()),
+        controlPlaneTenantId: CONTROL_PLANE,
+        localPaths: ["/u/widget/", "/shared-assets/"],
+      }),
+      { DISPATCHER: namespace },
+    );
+
+    const widget = await app.request("/u/widget/foo.js", {
+      "tenant-id": "acme",
+    });
+    const shared = await app.request("/shared-assets/logo.png", {
+      "tenant-id": "acme",
+    });
+
+    expect(await widget.text()).toBe("from-control-plane");
+    expect(await shared.text()).toBe("from-control-plane");
+    expect(dispatched).toHaveLength(0);
+  });
+
+  it("dispatches /u/widget/* when the carve-out is disabled with []", async () => {
+    const { namespace, dispatched } = dispatcher();
+    const app = buildApp(
+      createWfpForwardMiddleware({
+        tenants: tenantsAdapter(async () => tenant()),
+        controlPlaneTenantId: CONTROL_PLANE,
+        localPaths: [],
+      }),
+      { DISPATCHER: namespace },
+    );
+
+    const res = await app.request("/u/widget/authhero-widget.esm.js", {
+      "tenant-id": "acme",
+    });
+
+    expect(await res.text()).toBe("from-tenant-worker");
+    expect(dispatched).toHaveLength(1);
+  });
+
+  it("does not carve out /u/widget/* for the control-plane tenant either (served locally regardless)", async () => {
+    const { namespace, dispatched } = dispatcher();
+    const app = buildApp(
+      createWfpForwardMiddleware({
+        tenants: tenantsAdapter(async () => tenant()),
+        controlPlaneTenantId: CONTROL_PLANE,
+      }),
+      { DISPATCHER: namespace },
+    );
+
+    const res = await app.request("/u/widget/authhero-widget.esm.js", {
+      "tenant-id": CONTROL_PLANE,
+    });
+
+    expect(await res.text()).toBe("from-control-plane");
+    expect(dispatched).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1179 — on a Workers-for-Platforms tenant pinned to **u2**, the universal-login page renders but its buttons are inert: the SSR'd page loads the widget bundle from `/u/widget/authhero-widget.esm.js` to hydrate the form, but `createWfpForwardMiddleware` dispatches that request verbatim to the per-tenant dispatch worker, which has **no static-assets binding and no `widgetHandler`** — so it 404s and no click handlers ever bind.

The widget bundle is a multi-file Stencil bundle (uses `import.meta.url` + relative chunk imports and lazy-loads several `p-*.js` chunks), so it can't just be inlined as a single string — it has to be served from a real path. And it's byte-identical across tenants, so it shouldn't live in each tenant worker at all. This implements the issue's preferred **option 1**: a control-plane carve-out in the forward middleware.

## Change

`createWfpForwardMiddleware` gains a `localPaths` option (default `["/u/widget/"]`). Requests matching one of those prefixes fall through to the local (control-plane) app instead of being dispatched to the tenant worker:

- The check short-circuits **before** the tenant lookup, so it's cheap and host-agnostic.
- It calls `next()` — the widget is served **in-process on the control-plane worker**, the same way the CP already serves it for its own host. No extra network hop; it actually *skips* the dispatch fetch.
- Default includes `/u/widget/`, so this fixes every WFP-u2 tenant with **zero consumer config changes**. Pass `localPaths: []` to opt out, or extend the list for other shared assets.

## Note for deployers

This routes the request correctly but doesn't itself produce the bytes — the control plane still needs to serve `/u/widget/*` locally (via its `widgetHandler` or static assets, as it already does at 200 today).

Longer term, if the shared-static-asset surface grows beyond this one prefix, the cleaner direction is to give the widget an absolute/configurable asset base URL (shared assets origin / CDN) so SSR pages reference it directly and no per-request routing carve-out is needed on any host.

## Testing

- New `packages/cloudflare/test/wfp-forward.spec.ts` — 5 cases: default carve-out (and that it short-circuits before the tenant lookup), non-carved paths still dispatch, custom `localPaths`, disabled with `[]`, and control-plane tenant.
- Full wfp suite green (60/60); `@authhero/cloudflare-adapter` builds clean.
- Changeset added (`@authhero/cloudflare-adapter` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)