### PR TITLE
feat(hooks): allow account linking from a post-user-login code hook

### DIFF
--- a/.changeset/account-linking-identifier-invariants.md
+++ b/.changeset/account-linking-identifier-invariants.md
@@ -1,0 +1,9 @@
+---
+"authhero": minor
+---
+
+Harden account-linking identifier semantics for merged users.
+
+- **Email cascade (fixes the "changed my email, can't log in with my password" bug).** When the email of one email-identified identity in a linked cluster changes via the management API, the new address now propagates to the cluster's other email-identified identities (username-password / passwordless-email) so a linked password account isn't left logging in with the old address. sms (`phone_number`) and social (provider sub) identifiers are never rewritten. `email_verified` moves in lock-step so the cluster shares one verification state. New exported helpers `cascadeEmailToLinkedIdentities` and `isEmailIdentifiedUser`.
+- **PATCH is now pass-through.** The user PATCH body schema stopped letting `userInsertSchema`'s create-time defaults leak through `.partial()`: omitting `email_verified` no longer silently flips it to `false` (which locked out `email_validation: "enforced"` clients after any edit), and omitting `app_metadata` / `user_metadata` no longer wipes them.
+- **Opt-in profile promotion.** New `copyProfileFields` option on the `account-linking` template fills *absent* root profile fields on the primary from the secondary (e.g. a `birthdate` or phone the primary lacks) — fill-if-absent, never overwrite, and never an identifier or verification field. Off by default, matching Auth0 (a linked identity's own attributes otherwise stay under `identities[].profileData`).

--- a/.changeset/programmable-account-linking.md
+++ b/.changeset/programmable-account-linking.md
@@ -1,0 +1,36 @@
+---
+"@authhero/adapter-interfaces": minor
+"authhero": minor
+"@authhero/cloudflare-adapter": patch
+---
+
+Allow account linking from a `post-user-login` code hook (action).
+
+Tenants that need custom linking policy (link only within a domain, only for
+certain connections, only when an `app_metadata` flag is set, …) can now
+implement it as a user-authored action, alongside the existing built-in
+`account-linking` template hook. Fixes #1184.
+
+- **Opt-in.** Set `metadata.resolve_link_candidates: true` on a `post-user-login`
+  code hook. Only then does AuthHero run the extra same-email lookup and expose
+  `event.link_candidates` — an array of the primary accounts the built-in policy
+  would consider (oldest flagged `is_oldest`). Existing code hooks see no
+  behaviour or latency change and pay no extra query.
+- **New verb.** `api.user.setLinkedTo(primaryUserId)` is now available at
+  `post-user-login`. The action reads `event.link_candidates` and links to one
+  of them.
+- **Guarded host-side.** The write rejects any `primaryUserId` not present in
+  `event.link_candidates` (logging `FAILED_HOOK`) so an action can't be turned
+  into an account-takeover primitive; it enforces the verified-email gate
+  server-side regardless of what the action asserts; it uses "older account
+  wins" direction via `repointPrimary` (no 2-hop chains); and it is idempotent.
+  After linking, the resulting primary is re-fetched so downstream token
+  building sees it.
+- `userLinkingMode: "off"` still only suppresses the built-in email→primary
+  lookup — explicit action/template linking remains available.
+
+Internals: the per-trigger code-hook API allowlist, previously duplicated across
+both executors, is now a single `TRIGGER_API_SHAPES` source of truth in
+`@authhero/adapter-interfaces` (with a `LinkCandidate` type), and code-hook API
+replay now awaits each call so `setLinkedTo`'s writes complete before the login
+response is built.

--- a/docs/design/billing-and-console-on-substrat.md
+++ b/docs/design/billing-and-console-on-substrat.md
@@ -1,0 +1,370 @@
+# Design: AuthHero Control Plane & Billing on Substrat
+
+- **Status:** Draft / for discussion
+- **Author:** Markus Ahlstrand
+- **Created:** 2026-07-23 · **Revised:** 2026-07-28 (verified against Substrat repo at `/Users/markus/Projects/private/substrat`)
+- **Related:** AuthHero #1026 (tenant operations), #1057 (transactional outbox), #1080 (control-plane authority / delegating adapters), #1137 (tenant self-manage members), #1181 (cp signing keys); Substrat `@substrat-run/cli`, `control-plane-api` (`wfp.ts`), `@substrat-run/vertical-auth`, `substrat hostnames`
+
+---
+
+## 1. Summary
+
+The spine of this design is a **kernel-backed control plane**: the operational plane that
+provisions and manages AuthHero tenants and everything around them — **provisioning, tenant
+members/invites, custom domains, proxy routes, plans & billing**. Today that job is done by a
+*magic tenant inside AuthHero* (`tenantId = "control_plane"`) with cross-tenant concerns bolted
+on as special routes. This proposes replacing that with a purpose-built **Substrat kernel
+vertical** — which is the same thing we've been calling "the console."
+
+The line that makes it tractable:
+
+> **The AuthHero auth core stays on WFP with one D1 per tenant — no kernel rewrite.** It keeps
+> its own tenancy, migrations, and auth logic. Only the **control plane** becomes kernel-backed.
+> The auth core gains exactly **one** additive touch-point: an `entitlements` read-port it
+> consults where a plan limit bites. It never learns what Stripe or the kernel are.
+
+So the split is:
+
+- **Auth core** → hosted on Substrat's WFP platform, per-tenant D1, unchanged runtime.
+- **Control plane (= console)** → a kernel vertical: real tenancy, permissions with proof
+  paths, kernel-stamped audit, first-class provisioning. It *provisions and deploys* the auth
+  core and owns billing, members, and custom domains.
+
+This puts the SaaS-operations job where its invariants belong, and dissolves the current
+conflation of "the platform" with "a tenant of the platform."
+
+---
+
+## 2. The problem today: the control plane is a reused auth-tenant
+
+The control plane is currently `tenantId = "control_plane"` — a **tenant inside AuthHero itself**
+([`seed.ts:666`](../../packages/authhero/src/seed.ts#L666), `isControlPlane`; admins log in with
+`organization: "control_plane"`). The platform's management layer is modelled as one of the
+customer tenants, reusing auth-tenant machinery (users, orgs, members, cp-scoped signing keys
+from #1181) to represent "who runs the platform."
+
+Genuinely cross-tenant concerns — host→tenant resolution, custom-domains sync, proxy-route sync,
+tenant-members — are then **bolted on** as `proxy-control-plane` routes with their own token/
+scope verification (the `CONTROL_PLANE_*_SCOPE` constants in
+[`routes/proxy-control-plane/`](../../packages/authhero/src/routes/proxy-control-plane/index.ts)),
+*because the per-tenant model cannot express "operate across all tenants."*
+
+The costs of that shape:
+
+- **Conflation.** A control plane that is simultaneously a tenant of the system it controls.
+- **Bolt-on cross-tenant surface.** Every platform-wide operation is a special route with
+  bespoke auth, outside the normal model.
+- **Soft bootstrap knot.** The platform's own admins are users in a tenant of the very AuthHero
+  they administer.
+
+---
+
+## 3. The target: a kernel-backed control plane
+
+Substrat's kernel is not only scopes — it has an **audited control-plane layer above them**
+(`host.admin`, `control-plane-do`, `control-plane-api`): *"the control plane comes first and is
+audited."* That layer is the **sanctioned cross-tenant authority**, so a control plane is not a
+violation of the kernel's "no cross-tenant API" rule — it's the one place that rule is designed
+not to apply. The mapping is almost 1:1:
+
+| Today (messy) | Kernel-backed |
+|---|---|
+| `control_plane` magic tenant | the kernel **control plane** (`host.admin`) — not a tenant at all |
+| each AuthHero tenant | a kernel **tenant + provisioned scope** the CP addresses |
+| platform admins = users *in* AuthHero | control-plane **principals** (staff roster), logging in *via* AuthHero OIDC as an RP — not a tenant inside it |
+| bolt-on `CONTROL_PLANE_*_SCOPE` routes | first-class control-plane **operations**, audited, with proof paths |
+| cp signing keys, provisioning races (#1026), members (#1137) | kernel provisioning + atomic audit + roles/grants |
+
+The conflation dissolves: admins authenticate *through* AuthHero but live in the control plane,
+and the auth core is a runtime the control plane provisions and deploys — not where platform
+identity lives.
+
+### Two separate control planes, one-way dependency
+
+There are **two** control planes at **two layers**, and they must not merge:
+
+- **Substrat's platform control plane** (`control-plane-api` / `apps/control-plane`) — generic
+  infrastructure that provisions tenants/scopes, grants/reads entitlements, and deploys verticals
+  for *any* vertical. It **takes no dependency on AuthHero** and never will.
+- **AuthHero's control plane** — a product management layer (auth config, members, custom domains,
+  billing). It runs **as a vertical hosted on the platform** and *consumes* the platform CP via
+  the sanctioned client (`control-plane-api/client.ts`: `createTenant`, `provisionScope`,
+  `grantEntitlement`, `listEntitlements`, over an injectable service-binding fetch).
+
+The dependency is strictly **one-way: AuthHero → Substrat.** The sandbox contract enforces the
+separation — a hosted vertical gets *its own `ScopeDO` only*, **no `CONTROL_PLANE` binding**, and
+provisioning is **pull** (K-31: the platform calls the vertical to provision; the vertical can't
+create tenants/entitlements itself). So "kernel-backed" here means AuthHero's CP is a vertical
+*on* the kernel/platform, consuming the generic CP API — **not** a fork of, or merge into,
+Substrat's own control plane.
+
+---
+
+## 4. Architecture
+
+```mermaid
+flowchart TB
+  Admin["Platform / tenant admins"]
+  subgraph CP["Kernel-backed Control Plane (Substrat vertical) — replaces the control_plane magic tenant"]
+    Reg["tenant registry + provisioning<br/>(kernel control-plane layer)"]
+    Ops["members & invites (#1137)<br/>custom domains (#1080) · proxy routes · tenant-ops (#1026)"]
+    Billing["billing module<br/>subscription state + plan→entitlement"]
+    Conn["Stripe connector<br/>(webhooks + reconciliation alarm)"]
+  end
+  subgraph Auth["AuthHero auth core — WFP, one D1 per tenant (unchanged, no rewrite)"]
+    OAuth["OAuth/OIDC + Management API"]
+    Ent["entitlements read-port (NEW, additive)"]
+    D1[("per-tenant D1")]
+  end
+  Stripe(("Stripe"))
+
+  Admin -->|"login via AuthHero OIDC<br/>(@substrat-run/vertical-auth)"| CP
+  CP -->|"provision + deploy (wfp.ts)"| Auth
+  CP -->|"bind custom hostnames<br/>(substrat hostnames)"| Auth
+  Ent -->|"reads capability set per tenant"| CP
+  Billing --> Conn
+  Conn <-->|"customers · subscriptions · webhooks"| Stripe
+```
+
+Two databases per tenant, never one:
+
+- **Auth core:** per-tenant **D1**, schema owned by AuthHero's drizzle adapter (users, clients,
+  connections, its own migration journal). One DB per tenant via **WFP** — the isolation you
+  wanted, with no rewrite.
+- **Control plane:** kernel **scopes (DO/SQLite)** — `_substrat_*` audit spine, per-module
+  journaled migrations, kernel-stamped events, permissions with proof paths.
+
+They **cannot** share one physical DB (kernel rule 4 + AuthHero's adapter contract each own
+their schema/migrations; different storage products). **The join key is the tenant id** — the
+control plane's tenant id *is* the AuthHero (WFP) tenant id.
+
+---
+
+## 5. Components
+
+### 5.1 The control-plane vertical (Substrat, new/converged)
+
+The spine. Owns, as first-class audited operations:
+
+- **Tenant provisioning & lifecycle** (folds in #1026) — provision a tenant → bring up its
+  auth-core D1 (delegated to WFP) and its control-plane scope on one lifecycle event; lazy,
+  self-healing migrations replace the best-effort `afterCreate` seeding.
+- **Members & invites** (folds in #1137) — the people who administer a *tenant/account*, as
+  kernel roles/grants. (Distinct from Auth0 org invitations — see §7.)
+- **Custom domains & proxy routes** (folds in #1080) — the control plane is the authority; the
+  runtime is a delegating consumer. Now backed by `substrat hostnames` (§8).
+- **Plans & billing** (5.2–5.3).
+
+### 5.2 Billing module (Substrat, new, shared — in-scope, no network)
+
+> **Vocabulary note:** the current Substrat has no `engine-*` packages — the reuse unit is a
+> **vertical / shared package** plus a **marketplace**. What earlier drafts called
+> `engine-billing`/`engine-invoicing` should be read as a shared billing *module/package*. The
+> design (state machine vs connector split) is unchanged; only the packaging term is.
+
+Owns the **subscription state machine** and the **plan→entitlement effect**. Generic across every
+SaaS on the platform, so it's a shared module, not console-private code.
+
+- States `trialing → active → past_due → canceled` (mirrors Stripe), no illegal jumps.
+- **A plan change grants/revokes kernel entitlements** (the kernel's entitlement/grant
+  primitive — verify current API name). Unentitled features don't resolve — better than a flag.
+- Emits fat events (`billing.plan-changed`, …). **No `fetch`** (rule 2) — never talks to Stripe.
+- Money as minor-unit **strings** via `@substrat-run/contracts` helpers (rule 8), never floats.
+
+### 5.3 Stripe connector (Substrat, new, shared — network + webhooks + reconciliation)
+
+The **executor**, following the existing **Scrive connector** pattern (external API + webhook +
+cron/alarm reconciliation). Lives *outside* module code — Stripe calls must never run inside a
+scope transaction (rule 2).
+
+- **Outbound:** consumes billing events → creates/updates Stripe customers & subscriptions, with
+  idempotency keys.
+- **Inbound webhooks:** verify `Stripe-Signature` with **Web Crypto** (`crypto.subtle`), *not*
+  stripe-node's Node-crypto `constructEvent` (rule 9 + web-crypto-only).
+- **Reconciliation alarm (mandatory).** Webhooks are at-least-once, out-of-order, droppable —
+  the Scrive connector's last blocker before publish was exactly this sweep. A periodic alarm
+  reconciles scope state against Stripe as the backstop.
+- **Webhook routing is control-plane, not scoped.** A webhook arrives with a customer/subscription
+  id and *no tenant* — keep a `tenant ↔ stripe_customer` map at the control plane; the single
+  ingress fans out to the right scope.
+
+### 5.4 `entitlements` read-port (AuthHero — the *one* auth-core change)
+
+A plan isn't real unless something enforces it, and enforcement lives where the limited resource
+is created — **inside the auth core** (Nth active user, MFA-as-paid-feature, custom-domain
+gating, connection count, …). So AuthHero gains a **read-only** capability:
+
+```
+entitlements.get(tenantId) -> Set<capability>   // "what is this tenant entitled to?"
+```
+
+- Modelled as an **adapter port** (the pattern the codebase already lives by), so `authhero`
+  stays ignorant of Stripe/kernel/plans. The control plane supplies the implementation; a default
+  adapter returns "everything" for self-hosted/OSS users.
+- Read at enforcement points via the existing hook/middleware seam. Cache per tenant; the control
+  plane pushes invalidation (or short TTL) on plan change.
+- **The only modification to the `authhero` package, and it's additive.**
+
+---
+
+## 6. Auth for admins: already built
+
+Platform/tenant admins sign in via **AuthHero OIDC**, as a relying party — not as a tenant inside
+AuthHero. Substrat's `@substrat-run/vertical-auth` already implements this: its
+`oidc-rp-provider` lists issuers as *"a team's Auth Server app, Supabase, Auth0, **AuthHero**,
+Keycloak"* ("one script, many issuers"), and maps `sub → principal`. So the console's own login is
+largely pre-wired. (One thing to reconcile: Substrat also ships `demos/auth-server` — decide
+"AuthHero vs Substrat's auth-server" as the issuer.)
+
+---
+
+## 7. What lives where — the wrap-vs-modify table
+
+| Concern | Moves to control plane (kernel vertical) | Touches `authhero` package | Stays in `authhero`, unchanged |
+|---|---|---|---|
+| Tenant provisioning / lifecycle (#1026) | ✅ | — | (auth-core D1 provisioned via delegated WFP) |
+| Tenant members & invites (#1137) | ✅ authority | possibly: `tenant-members` becomes a projection/delegate | — |
+| Custom domains / proxy routes (#1080) | ✅ authority | thin delegating adapter (as today) | — |
+| Plans / subscriptions / Stripe | ✅ billing module + connector | — | — |
+| Plan **enforcement** (limits/features) | policy defined here | ✅ **`entitlements` read-port (only change)** | enforcement *points* already exist |
+| Usage signals (MAU, counts) | consumed here | mostly none (existing outbox) | `stats` / outbox already emit |
+| **Auth0 Organization invitations** | — | — | ✅ `Invite.ts` — end-user/org feature, different layer |
+| OAuth/OIDC, users, clients, connections, per-tenant D1 | — | — | ✅ entirely (WFP-hosted) |
+
+### The invitation distinction (important)
+
+AuthHero has **two** things that both sound like "members/invites":
+
+1. **Organization invitations** ([`Invite.ts`](../../packages/adapter-interfaces/src/types/Invite.ts),
+   `organization_id`, `client_id`) — a *customer inviting their own end-users* into an
+   organization inside their tenant. An **Auth0-compatible product feature of the auth core. Stays
+   in AuthHero, untouched.**
+2. **Tenant members** ([`tenant-members.ts`](../../packages/authhero/src/routes/management-api/tenant-members.ts),
+   #1137) — the *people who administer the tenant/account itself*. **The control plane's concern.**
+
+Only (2) moves. Conflating the two is the main way this goes wrong.
+
+---
+
+## 8. Hosting & platform state (verified 2026-07-28)
+
+Substrat is **two separable layers**:
+
+1. **Substrat-the-kernel** — the framework the control-plane vertical and billing module are
+   built against. AuthHero's OAuth core is **not** a kernel module and won't become one.
+2. **Substrat-the-platform** — a hosting layer on **Cloudflare WFP**. `control-plane-api/wfp.ts`
+   uploads a built worker **bundle** into a dispatch namespace (exactly `wrangler deploy`'s
+   multipart shape); the author never holds a CF token; a **sandbox contract**
+   (`docs/design/self-serve-deploy.md`) admits opaque bundles safely.
+
+What's now real (was speculative in earlier drafts):
+
+- **CLI** (`@substrat-run/cli`, published): `login/whoami/push/versions/promote/publish/hostnames/scope`.
+  Deploy model = **push (pending) → admission (human console decision) → serve**; immutable
+  content-addressed versions; in-place deploy with data-follows-version + PITR backout.
+- **Hosts arbitrary Workers, not just kernel modules.** A vertical declares `substrat.runtimeNeeds`
+  (entry/build/`needsNodeCompat`/own-`stores` incl. **D1**) and the CLI derives the wrangler
+  config — so **AuthHero can be hosted as a Worker without a kernel rewrite**; the real work is
+  fitting its bindings to the sandbox contract.
+- **Custom hostnames = built/in-flight** (not "not built"): `substrat hostnames` binds a hostname
+  to a **surface** of an install — platform hostname rides the wildcard cert (live now), a custom
+  domain lands `pending`. This *is* the `domain → (tenant, surface)` model this doc wanted.
+
+### AuthHero as the platform's first dogfood test
+
+AuthHero is a *demanding* first guest — latency-sensitive OAuth hot path, per-tenant D1 at scale,
+custom hostnames, and a **non-kernel guest**. Staged cheapest-first (this is the entry point of
+the phased plan):
+
+1. **CLI deploy, no custom domains** — push AuthHero (few tenants) onto a `substrat.run` host.
+   Proves CLI + WFP dispatch + per-tenant D1 + auth flows end-to-end.
+2. **Provisioning at count** — prove isolation and cold-start/latency at real tenant counts.
+3. **Custom hostnames** — `auth.customer.com` end-to-end (the ACM/PSL test).
+
+---
+
+## 9. Key flows
+
+### 9.1 Plan upgrade → enforceable entitlement
+
+```mermaid
+sequenceDiagram
+  actor Admin as Tenant admin
+  participant CP as Control plane (billing module)
+  participant Conn as Stripe connector
+  participant Stripe
+  participant Auth as AuthHero (entitlements port)
+
+  Admin->>CP: choose "Pro" (perm-checked, audited)
+  CP->>CP: state machine + grant Pro entitlements (in-scope, no network)
+  CP-->>Conn: billing.plan-changed (event)
+  Conn->>Stripe: update subscription (idempotent)
+  Stripe-->>Conn: webhook: subscription.updated (Web-Crypto verified)
+  Conn->>CP: reconcile → confirm active
+  Auth->>CP: entitlements.get(tenant) → {pro-features}
+  Note over Auth: next enforcement point sees the new capability set
+```
+
+### 9.2 Tenant provisioning (replaces the magic-tenant + afterCreate path)
+
+Control plane provisions a tenant → brings up the auth-core D1 (delegated WFP) **and** its
+control-plane scope on one audited lifecycle event → binds a platform hostname → the tenant is
+serving. No `control_plane`-tenant seeding, no ready-but-empty-D1 race.
+
+### 9.3 Reconciliation backstop
+
+Alarm fires → connector lists Stripe subscriptions for known customers → diffs against scope
+state → emits corrective events for drift. Not a v2 nicety — it's what makes billing trustworthy.
+
+---
+
+## 10. Risks & hard problems
+
+- **Bootstrap / break-glass.** Admins log in via AuthHero while the CP manages AuthHero. The auth
+  core already cold-starts independently (it's the IdP), but the CP needs a **break-glass** path
+  so a broken AuthHero can't lock out platform operators.
+- **Migration off the `control_plane` tenant.** Live data/behaviour (cp signing keys #1181,
+  members #1137, custom domains, proxy routes) must move without downtime. Sequence it.
+- **Entitlement read on the hot path.** `entitlements.get` sits in the auth core's request path —
+  must be cheap (cache per tenant, CP-pushed invalidation).
+- **Webhook idempotency & ordering.** Kernel event log + reconciliation sweep + outbound
+  idempotency keys. Don't ship the happy-path handler alone.
+- **Web Crypto signature verification.** stripe-node's `constructEvent` won't run on Workers.
+- **Hot-path latency of hosting.** WFP dispatch cold-start for the auth core — the stage-2 test.
+
+---
+
+## 11. Open decisions
+
+1. **Boundary is settled: two separate control planes, one-way dependency.** AuthHero's CP is a
+   vertical hosted on the platform, consuming Substrat's generic CP API (`createTenant`/
+   `provisionScope`/`grant`+`listEntitlements`); Substrat takes **no** dependency on AuthHero. The
+   remaining question is only *how much* AuthHero's CP leans on the platform CP vs. carries its
+   own — not whether to merge.
+2. **The in-flight fork, now.** #1137 (members) and #1026 (tenant-ops) are being built *in the
+   `control_plane` tenant today.* Do they keep landing there, or pivot onto the kernel CP? Deciding
+   late means migrating twice.
+3. **Break-glass model** for CP access when AuthHero is unavailable.
+4. **Issuer for admin login** — AuthHero vs Substrat's `demos/auth-server`.
+5. **Billing shape** = Stripe subscriptions (invoice-document billing deferred).
+
+---
+
+## 12. Phased plan
+
+1. **Stage 1 — hosting spike (dogfood test).** Push AuthHero as a Worker onto the platform via
+   the CLI, few tenants, no custom domains. Proves the platform *and* gives a running
+   AuthHero-on-Substrat to build the CP against. Prereq: bindings-vs-sandbox-contract diff +
+   AuthHero's `runtimeNeeds`.
+2. **Stage 2 — control-plane skeleton + entitlements seam.** Stand up the kernel CP with a tenant
+   registry + provisioning of one tenant; AuthHero `entitlements` read-port with a default
+   "allow-all" adapter. Prove: CP provisions a tenant, and a capability it sets is read by the
+   auth core. No Stripe, no UI.
+3. **Stage 3 — move the cross-tenant concerns off the magic tenant.** Members (#1137), custom
+   domains (#1080), proxy routes, tenant-ops (#1026) become CP operations. Retire
+   `control_plane`-tenant reliance behind the CP.
+4. **Stage 4 — billing.** Subscription state machine + plan→entitlement, then the Stripe connector
+   (outbound + webhook + reconciliation alarm).
+5. **Stage 5 — console screens & custom hostnames.** Plan picker, billing history, team; bind
+   `auth.customer.com` via `substrat hostnames`.
+6. **Later — unified invoicing**, if unified documents across charge sources are ever needed.

--- a/docs/design/billing-and-console-on-substrat.md
+++ b/docs/design/billing-and-console-on-substrat.md
@@ -2,7 +2,7 @@
 
 - **Status:** Draft / for discussion
 - **Author:** Markus Ahlstrand
-- **Created:** 2026-07-23 · **Revised:** 2026-07-28 (verified against Substrat repo at `/Users/markus/Projects/private/substrat`)
+- **Created:** 2026-07-23 · **Revised:** 2026-07-28 (verified against the private Substrat repository)
 - **Related:** AuthHero #1026 (tenant operations), #1057 (transactional outbox), #1080 (control-plane authority / delegating adapters), #1137 (tenant self-manage members), #1181 (cp signing keys); Substrat `@substrat-run/cli`, `control-plane-api` (`wfp.ts`), `@substrat-run/vertical-auth`, `substrat hostnames`
 
 ---
@@ -194,7 +194,7 @@ A plan isn't real unless something enforces it, and enforcement lives where the 
 is created — **inside the auth core** (Nth active user, MFA-as-paid-feature, custom-domain
 gating, connection count, …). So AuthHero gains a **read-only** capability:
 
-```
+```text
 entitlements.get(tenantId) -> Set<capability>   // "what is this tenant entitled to?"
 ```
 

--- a/packages/adapter-interfaces/src/types/codeHookApiShapes.ts
+++ b/packages/adapter-interfaces/src/types/codeHookApiShapes.ts
@@ -1,0 +1,61 @@
+/**
+ * The per-trigger allowlist of namespaced API methods exposed to user-authored
+ * code hooks. Each entry maps a trigger id to `{ namespace: [method, ...] }`.
+ *
+ * Code hooks run in an isolate with a **recording** `api` proxy: user code calls
+ * `api.<namespace>.<method>(...)`, the call is captured as
+ * `{ method: "<namespace>.<method>", args }`, and the host replays it against
+ * the real API objects after the isolate returns. This shape is what the proxy
+ * is built from, so it is the single source of truth for *which* verbs a trigger
+ * exposes.
+ *
+ * It lives here (not in an executor) because both executors need an identical
+ * copy: the local `LocalCodeExecutor` builds the proxy in-process, and the
+ * Cloudflare `WorkerLoaderCodeExecutor` serializes this object into the
+ * generated worker script. Duplicating it risked the two drifting; importing
+ * this const keeps them byte-identical by construction.
+ */
+export const TRIGGER_API_SHAPES: Record<string, Record<string, string[]>> = {
+  "post-user-login": {
+    accessToken: ["setCustomClaim"],
+    idToken: ["setCustomClaim"],
+    access: ["deny"],
+    prompt: ["render"],
+    redirect: ["sendUserTo"],
+    // Programmable account linking: an action reads `event.link_candidates`
+    // and calls `api.user.setLinkedTo(candidate.user_id)`. The write is guarded
+    // host-side (candidate allowlist + verified-email gate) — see the
+    // post-user-login dispatch.
+    user: ["setLinkedTo"],
+  },
+  "credentials-exchange": {
+    accessToken: ["setCustomClaim"],
+    idToken: ["setCustomClaim"],
+    access: ["deny"],
+  },
+  "pre-user-registration": {
+    user: ["setUserMetadata", "setLinkedTo"],
+    access: ["deny"],
+  },
+  "post-user-registration": {},
+};
+
+/**
+ * A single candidate primary the built-in email-based linking policy would
+ * consider, pre-resolved into a `post-user-login` code-hook event as
+ * `event.link_candidates`. Code hooks have no return channel and no data
+ * adapter, so link targets must be pushed *into* the event rather than looked
+ * up from user code. The shape is intentionally minimal and JSON-serializable.
+ */
+export interface LinkCandidate {
+  user_id: string;
+  email: string;
+  email_verified: boolean;
+  provider: string;
+  connection: string;
+  created_at: string;
+  /** No `linked_to` set — this user is itself a primary. */
+  is_primary: boolean;
+  /** The candidate the built-in "oldest account wins" policy would pick. */
+  is_oldest: boolean;
+}

--- a/packages/adapter-interfaces/src/types/codeHookApiShapes.ts
+++ b/packages/adapter-interfaces/src/types/codeHookApiShapes.ts
@@ -15,7 +15,9 @@
  * generated worker script. Duplicating it risked the two drifting; importing
  * this const keeps them byte-identical by construction.
  */
-export const TRIGGER_API_SHAPES: Record<string, Record<string, string[]>> = {
+export const TRIGGER_API_SHAPES: Readonly<
+  Record<string, Readonly<Record<string, readonly string[]>>>
+> = {
   "post-user-login": {
     accessToken: ["setCustomClaim"],
     idToken: ["setCustomClaim"],

--- a/packages/adapter-interfaces/src/types/index.ts
+++ b/packages/adapter-interfaces/src/types/index.ts
@@ -104,3 +104,5 @@ export * from "./CustomText";
 export * from "./Strategy";
 export * from "./AuthenticationMethod";
 export * from "./ImportMetadata";
+
+export * from "./codeHookApiShapes";

--- a/packages/authhero/src/helpers/link-candidates.ts
+++ b/packages/authhero/src/helpers/link-candidates.ts
@@ -1,0 +1,87 @@
+import {
+  LinkCandidate,
+  User,
+  UserDataAdapter,
+} from "@authhero/adapter-interfaces";
+import { compareUsersByAge } from "./users";
+
+/**
+ * Resolve the ordered pool of candidate *primary* users that the built-in
+ * email-based account-linking policy would consider for `user`, excluding the
+ * user themselves.
+ *
+ * Mirrors the selection in `hooks/pre-defined/account-linking.ts`:
+ *  - prefer direct unlinked primaries that share the (normalized) email;
+ *  - otherwise resolve each secondary's `linked_to` chain to its root and
+ *    dedupe, so multiple chains for the same email collapse onto one primary;
+ *  - sort by age (oldest first) so duplicate-primary races converge in a single
+ *    pass.
+ *
+ * Returns `[]` when there is nothing to link to. The first element (if any) is
+ * the candidate the built-in "oldest account wins" policy would pick.
+ */
+export async function resolveLinkCandidates(params: {
+  userAdapter: UserDataAdapter;
+  tenantId: string;
+  user: User;
+}): Promise<User[]> {
+  const { userAdapter, tenantId, user } = params;
+
+  if (!user.email) return [];
+
+  const normalizedEmail = user.email.toLowerCase();
+  const { users: matchingUsers } = await userAdapter.list(tenantId, {
+    page: 0,
+    per_page: 10,
+    include_totals: false,
+    q: `email:${normalizedEmail}`,
+  });
+
+  const otherUsers = matchingUsers.filter((u) => u.user_id !== user.user_id);
+  if (otherUsers.length === 0) return [];
+
+  const directPrimaries = otherUsers.filter((u) => !u.linked_to);
+  if (directPrimaries.length > 0) {
+    return [...directPrimaries].sort(compareUsersByAge);
+  }
+
+  // No direct primaries — resolve every secondary's linked_to chain to its
+  // root and pick the roots, deduped, so multiple chains collapse onto a
+  // single primary.
+  const roots: User[] = [];
+  const seen = new Set<string>();
+  for (const u of otherUsers) {
+    if (!u.linked_to) continue;
+    const resolved = await userAdapter.get(tenantId, u.linked_to);
+    if (
+      resolved &&
+      resolved.user_id !== user.user_id &&
+      !seen.has(resolved.user_id)
+    ) {
+      seen.add(resolved.user_id);
+      roots.push(resolved);
+    }
+  }
+
+  return roots.sort(compareUsersByAge);
+}
+
+/**
+ * Serialize resolved candidate primaries into the minimal, JSON-safe
+ * `event.link_candidates` shape exposed to `post-user-login` code hooks. The
+ * first candidate (oldest) is flagged `is_oldest` — the one the built-in policy
+ * would pick.
+ */
+export function toLinkCandidates(candidates: User[]): LinkCandidate[] {
+  const oldest = candidates[0];
+  return candidates.map((c) => ({
+    user_id: c.user_id,
+    email: c.email ?? "",
+    email_verified: c.email_verified ?? false,
+    provider: c.provider ?? "",
+    connection: c.connection ?? "",
+    created_at: c.created_at ?? "",
+    is_primary: !c.linked_to,
+    is_oldest: oldest ? c.user_id === oldest.user_id : false,
+  }));
+}

--- a/packages/authhero/src/helpers/link-candidates.ts
+++ b/packages/authhero/src/helpers/link-candidates.ts
@@ -30,12 +30,26 @@ export async function resolveLinkCandidates(params: {
   if (!user.email) return [];
 
   const normalizedEmail = user.email.toLowerCase();
-  const { users: matchingUsers } = await userAdapter.list(tenantId, {
-    page: 0,
-    per_page: 10,
-    include_totals: false,
-    q: `email:${normalizedEmail}`,
-  });
+
+  // Fetch *every* user sharing this email — not just the first page. A single
+  // fixed page could drop the oldest matching account (an email with many
+  // provider identities), which would silently violate the "oldest account
+  // wins" invariant the sort below relies on. Mirrors the pagination loop in
+  // `repointPrimary` (helpers/users.ts).
+  const pageSize = 100;
+  const matchingUsers: User[] = [];
+  let page = 0;
+  while (true) {
+    const { users } = await userAdapter.list(tenantId, {
+      page,
+      per_page: pageSize,
+      include_totals: false,
+      q: `email:${normalizedEmail}`,
+    });
+    matchingUsers.push(...users);
+    if (users.length < pageSize) break;
+    page++;
+  }
 
   const otherUsers = matchingUsers.filter((u) => u.user_id !== user.user_id);
   if (otherUsers.length === 0) return [];

--- a/packages/authhero/src/helpers/users.ts
+++ b/packages/authhero/src/helpers/users.ts
@@ -3,6 +3,7 @@ import { EnrichedClient } from "./client";
 import { Context } from "hono";
 import { Bindings, Variables } from "../types";
 import { userIdGenerate } from "../utils/user-id";
+import { isUsernamePasswordProvider } from "../utils/username-password-provider";
 
 export async function getUsersByEmail(
   userAdapter: UserDataAdapter,
@@ -178,6 +179,107 @@ export async function repointPrimary({
   await userAdapter.update(tenant_id, formerPrimary.user_id, {
     linked_to: newPrimaryId,
   });
+}
+
+/**
+ * True for identities whose *login identifier* is the email address: the native
+ * username-password providers (`auth0`/`auth2`) and the passwordless `email`
+ * connection. For these, `email` is a credential — it's how the login row is
+ * found (`getUserByProvider`), so it must stay consistent across a linked
+ * cluster.
+ *
+ * Social identities carry `email` as ordinary profile data (re-synced from the
+ * IdP on every login) and sms identities are keyed by `phone_number`, so neither
+ * is email-identified and neither should have its `email` rewritten by a cascade.
+ */
+export function isEmailIdentifiedUser(
+  user: Pick<User, "provider" | "connection">,
+): boolean {
+  if (isUsernamePasswordProvider(user.provider)) return true;
+  return user.provider === "email" || user.connection === "email";
+}
+
+interface CascadeEmailParams {
+  userAdapter: UserDataAdapter;
+  tenant_id: string;
+  /** The cluster root (primary) user_id — its secondaries are enumerated. */
+  primaryUserId: string;
+  /** The row whose email the caller already updated; skipped by the cascade. */
+  sourceUserId: string;
+  email: string;
+  email_verified: boolean;
+}
+
+/**
+ * Propagate an email change across every *email-identified* identity in a linked
+ * cluster so a merged user keeps a single login email.
+ *
+ * Because account-linking matches on a shared email, at link time every
+ * email-identified identity in a cluster carries the same address. The only way
+ * they diverge is a later email change on one of them — and when they diverge,
+ * the login row for the *other* email-identified identities still carries the
+ * old address, so the user can no longer sign in with the address now shown on
+ * their profile (the classic "changed my email, can't log in with my password"
+ * bug).
+ *
+ * This re-establishes the invariant: only email-identified rows are touched
+ * ({@link isEmailIdentifiedUser}); sms (`phone_number`) and social (provider
+ * sub) identifiers are never rewritten. `sourceUserId` is skipped (the caller
+ * already wrote it). Each cascaded write goes through the normal decorated
+ * `update`, so every affected identity emits its own `user.updated` event for
+ * downstream propagation, and `email_verified` moves in lock-step so the whole
+ * cluster shares one verification state.
+ */
+export async function cascadeEmailToLinkedIdentities({
+  userAdapter,
+  tenant_id,
+  primaryUserId,
+  sourceUserId,
+  email,
+  email_verified,
+}: CascadeEmailParams): Promise<void> {
+  const normalizedEmail = email.toLowerCase();
+
+  const applyTo = async (member: User) => {
+    if (member.user_id === sourceUserId) return;
+    if (!isEmailIdentifiedUser(member)) return;
+    // Skip no-op writes so we don't bump updated_at / emit a spurious event.
+    if (
+      member.email?.toLowerCase() === normalizedEmail &&
+      member.email_verified === email_verified
+    ) {
+      return;
+    }
+    await userAdapter.update(tenant_id, member.user_id, {
+      email: normalizedEmail,
+      email_verified,
+    });
+  };
+
+  // The cluster root, unless it's the row the caller already updated.
+  if (primaryUserId !== sourceUserId) {
+    const primary = await userAdapter.get(tenant_id, primaryUserId);
+    if (primary) await applyTo(primary);
+  }
+
+  // Every secondary of the primary. Paginate — a cluster can exceed one page,
+  // mirroring the loop in `repointPrimary`.
+  const pageSize = 100;
+  let page = 0;
+  while (true) {
+    const { users: secondaries } = await userAdapter.list(tenant_id, {
+      page,
+      per_page: pageSize,
+      include_totals: false,
+      q: `linked_to:${primaryUserId}`,
+    });
+    if (secondaries.length === 0) break;
+    for (const sec of secondaries) {
+      await applyTo(sec);
+    }
+    if (secondaries.length < pageSize) break;
+    page++;
+  }
 }
 
 interface GetPrimaryUserByProviderParams {

--- a/packages/authhero/src/hooks/code-executor/local.ts
+++ b/packages/authhero/src/hooks/code-executor/local.ts
@@ -2,6 +2,7 @@ import {
   CodeExecutionLog,
   CodeExecutionResult,
   CodeExecutor,
+  TRIGGER_API_SHAPES,
 } from "@authhero/adapter-interfaces";
 
 const MAX_LOG_ENTRIES = 50;
@@ -44,28 +45,9 @@ function createRecordingApiProxy(triggerId: string): {
 } {
   const calls: Array<{ method: string; args: unknown[] }> = [];
 
-  // Define the API shape per trigger type
-  const apiShapes: Record<string, Record<string, string[]>> = {
-    "post-user-login": {
-      accessToken: ["setCustomClaim"],
-      idToken: ["setCustomClaim"],
-      access: ["deny"],
-      prompt: ["render"],
-      redirect: ["sendUserTo"],
-    },
-    "credentials-exchange": {
-      accessToken: ["setCustomClaim"],
-      idToken: ["setCustomClaim"],
-      access: ["deny"],
-    },
-    "pre-user-registration": {
-      user: ["setUserMetadata", "setLinkedTo"],
-      access: ["deny"],
-    },
-    "post-user-registration": {},
-  };
-
-  const shape = apiShapes[triggerId] || {};
+  // Per-trigger API shape is shared with the production (Worker Loader)
+  // executor via `TRIGGER_API_SHAPES` so the two can never drift.
+  const shape = TRIGGER_API_SHAPES[triggerId] || {};
   const api: Record<string, unknown> = {};
 
   for (const [namespace, methods] of Object.entries(shape)) {

--- a/packages/authhero/src/hooks/codehooks.ts
+++ b/packages/authhero/src/hooks/codehooks.ts
@@ -103,11 +103,19 @@ export type CodeHookApi = Record<string, CodeHookApiNamespace>;
 /**
  * Replay recorded API calls from code hook execution against real API objects.
  * Handles calls like "accessToken.setCustomClaim" by navigating the api object.
+ *
+ * Awaits each replayed call. Most registered methods are synchronous (they
+ * mutate a token or throw), but some do async work — notably
+ * `user.setLinkedTo` at `post-user-login`, which paginates and writes user rows
+ * to perform the link. Since replay runs *after* the isolate returns, the login
+ * response is built from whatever this resolves to; awaiting guarantees such
+ * work completes before the caller proceeds. Synchronous methods return
+ * non-thenables, so awaiting them is a no-op.
  */
-export function replayApiCalls(
+export async function replayApiCalls(
   apiCalls: Array<{ method: string; args: unknown[] }>,
   api: CodeHookApi,
-): void {
+): Promise<void> {
   for (const call of apiCalls) {
     const parts = call.method.split(".");
     if (parts.length !== 2) continue;
@@ -115,7 +123,7 @@ export function replayApiCalls(
     const namespace = parts[0]!;
     const method = parts[1]!;
     if (api[namespace] && typeof api[namespace][method] === "function") {
-      api[namespace][method](...call.args);
+      await api[namespace][method](...call.args);
     }
   }
 }
@@ -290,8 +298,8 @@ export async function executeCodeHook(params: {
 
   // Replay the recorded API calls against the real api objects. This is where
   // api.access.deny fires (throws), where setCustomClaim mutates the real
-  // token, etc.
-  replayApiCalls(execResult.apiCalls, api);
+  // token, and where user.setLinkedTo performs (and awaits) the link.
+  await replayApiCalls(execResult.apiCalls, api);
 
   const denied = execResult.apiCalls.some((c) => c.method === "access.deny");
 

--- a/packages/authhero/src/hooks/helpers/post-login-account-linking.ts
+++ b/packages/authhero/src/hooks/helpers/post-login-account-linking.ts
@@ -1,0 +1,126 @@
+import { Context } from "hono";
+import { DataAdapters, LogTypes, User } from "@authhero/adapter-interfaces";
+import { Bindings, Variables } from "../../types";
+import { logMessage } from "../../helpers/logging";
+import { compareUsersByAge, repointPrimary } from "../../helpers/users";
+
+/**
+ * The `user` namespace exposed to `post-user-login` code hooks. `setLinkedTo`
+ * is the programmable account-linking verb (issue #1184): an action reads
+ * `event.link_candidates` and calls `api.user.setLinkedTo(candidate.user_id)`.
+ */
+export interface PostLoginUserApi {
+  user: {
+    setLinkedTo: (primaryUserId: string) => Promise<void>;
+  };
+}
+
+/**
+ * Builds the guarded `api.user.setLinkedTo` implementation for the
+ * `post-user-login` trigger, plus a getter for the resulting primary user id.
+ *
+ * The recording proxy captures the action's `setLinkedTo(id)` call; the host
+ * replays it against this implementation *after* the isolate returns
+ * (`replayApiCalls`, which awaits — so the DB writes complete before the login
+ * response is built).
+ *
+ * Guards, all enforced server-side so a malicious/buggy action cannot escalate:
+ *  - **Candidate allowlist.** `primaryUserId` must be one of `candidates`
+ *    (the same set serialized into `event.link_candidates`). Without this an
+ *    action could link the current user to an arbitrary `user_id` —
+ *    account-takeover. Rejections log `FAILED_HOOK` and mutate nothing.
+ *  - **Verified-email gate.** When `requireVerifiedEmail` (the default), the
+ *    logging-in user must have a verified email, regardless of what the action
+ *    asserts.
+ *  - **Direction.** Older account wins (`compareUsersByAge`): if the logging-in
+ *    user pre-dates the target, the target is demoted via `repointPrimary`
+ *    (avoiding 2-hop chains) instead.
+ *  - **Idempotency.** A no-op when the user is already linked to the target.
+ */
+export function createPostLoginUserApi(params: {
+  ctx: Context<{ Bindings: Bindings; Variables: Variables }>;
+  data: DataAdapters;
+  tenantId: string;
+  user: User;
+  /** Resolved candidate primaries (same set as `event.link_candidates`). */
+  candidates: User[];
+  /** @default true */
+  requireVerifiedEmail?: boolean;
+}): {
+  api: PostLoginUserApi;
+  /** The user id of the primary after linking, or null if nothing linked. */
+  getLinkedPrimaryId: () => string | null;
+} {
+  const { ctx, data, tenantId, candidates } = params;
+  const requireVerifiedEmail = params.requireVerifiedEmail ?? true;
+
+  // `currentUser` tracks the logging-in user's `linked_to` across multiple
+  // setLinkedTo calls within one execution so repeats resolve to a no-op.
+  let currentUser = params.user;
+  let linkedPrimaryId: string | null = null;
+
+  const setLinkedTo = async (primaryUserId: string): Promise<void> => {
+    // Guard: only users pushed into event.link_candidates are linkable.
+    const target = candidates.find((c) => c.user_id === primaryUserId);
+    if (!target) {
+      logMessage(ctx, tenantId, {
+        type: LogTypes.FAILED_HOOK,
+        description: `post-user-login action tried to link ${currentUser.user_id} to non-candidate ${primaryUserId}`,
+        userId: currentUser.user_id,
+        details: {
+          trigger_id: "post-user-login",
+          reason: "not_a_link_candidate",
+          primary_user_id: primaryUserId,
+        },
+      });
+      return;
+    }
+
+    // Verified-email gate enforced host-side, never trusting the action.
+    if (
+      requireVerifiedEmail &&
+      (!currentUser.email || !currentUser.email_verified)
+    ) {
+      logMessage(ctx, tenantId, {
+        type: LogTypes.FAILED_HOOK,
+        description: `post-user-login action link refused: ${currentUser.user_id} has no verified email`,
+        userId: currentUser.user_id,
+        details: {
+          trigger_id: "post-user-login",
+          reason: "unverified_email",
+          primary_user_id: primaryUserId,
+        },
+      });
+      return;
+    }
+
+    // Idempotent: already linked to this target.
+    if (currentUser.linked_to === target.user_id) {
+      linkedPrimaryId = target.user_id;
+      return;
+    }
+
+    // Older account wins. If the logging-in user pre-dates the target, demote
+    // the target rather than turning the older user into a secondary.
+    if (compareUsersByAge(currentUser, target) < 0) {
+      await repointPrimary({
+        userAdapter: data.users,
+        tenant_id: tenantId,
+        formerPrimary: target,
+        newPrimaryId: currentUser.user_id,
+      });
+      linkedPrimaryId = currentUser.user_id;
+    } else {
+      await data.users.update(tenantId, currentUser.user_id, {
+        linked_to: target.user_id,
+      });
+      currentUser = { ...currentUser, linked_to: target.user_id };
+      linkedPrimaryId = target.user_id;
+    }
+  };
+
+  return {
+    api: { user: { setLinkedTo } },
+    getLinkedPrimaryId: () => linkedPrimaryId,
+  };
+}

--- a/packages/authhero/src/hooks/helpers/post-login-account-linking.ts
+++ b/packages/authhero/src/hooks/helpers/post-login-account-linking.ts
@@ -9,11 +9,11 @@ import { compareUsersByAge, repointPrimary } from "../../helpers/users";
  * is the programmable account-linking verb (issue #1184): an action reads
  * `event.link_candidates` and calls `api.user.setLinkedTo(candidate.user_id)`.
  */
-export interface PostLoginUserApi {
+export type PostLoginUserApi = {
   user: {
     setLinkedTo: (primaryUserId: string) => Promise<void>;
   };
-}
+};
 
 /**
  * Builds the guarded `api.user.setLinkedTo` implementation for the
@@ -111,8 +111,17 @@ export function createPostLoginUserApi(params: {
       });
       linkedPrimaryId = currentUser.user_id;
     } else {
-      await data.users.update(tenantId, currentUser.user_id, {
-        linked_to: target.user_id,
+      // Demote the logging-in user under the (older) target. Use
+      // `repointPrimary` — not a bare `linked_to` update — so any accounts
+      // already linked to `currentUser` are repointed at `target`, keeping the
+      // graph a single hop deep. A plain update would strand them behind a
+      // now-secondary `currentUser`, producing 2-hop chains that
+      // `getPrimaryUserByProvider` can't follow.
+      await repointPrimary({
+        userAdapter: data.users,
+        tenant_id: tenantId,
+        formerPrimary: currentUser,
+        newPrimaryId: target.user_id,
       });
       currentUser = { ...currentUser, linked_to: target.user_id };
       linkedPrimaryId = target.user_id;

--- a/packages/authhero/src/hooks/post-user-login.ts
+++ b/packages/authhero/src/hooks/post-user-login.ts
@@ -20,9 +20,15 @@ import {
   handleCodeHook,
   persistActionExecution,
   HandleCodeHookOutcome,
+  CodeHookApi,
 } from "./codehooks";
 import { invokeHooks } from "./webhooks";
 import { createTokenAPI } from "./helpers/token-api";
+import { createPostLoginUserApi } from "./helpers/post-login-account-linking";
+import {
+  resolveLinkCandidates,
+  toLinkCandidates,
+} from "../helpers/link-candidates";
 import {
   getConnectionInfo,
   resolveConnectionName,
@@ -444,6 +450,34 @@ export async function postUserLoginHook(
       (h: any) => h.enabled && isCodeHook(h),
     );
     if (enhancedEvent && codeHooks.length > 0) {
+      // Programmable account linking (issue #1184). Only tenants that opted in
+      // via `metadata.resolve_link_candidates` on a code hook pay the extra
+      // user-list query and get `event.link_candidates` — existing code hooks
+      // see no behaviour or latency change. `setLinkedTo` is still guarded
+      // host-side, so an action can't link to a user outside this set.
+      const linkingOptedIn = codeHooks.some(
+        (h: any) => h.metadata?.resolve_link_candidates === true,
+      );
+      const linkCandidates = linkingOptedIn
+        ? await resolveLinkCandidates({
+            userAdapter: data.users,
+            tenantId: tenant_id,
+            user,
+          })
+        : [];
+      if (linkingOptedIn) {
+        (enhancedEvent as Record<string, unknown>).link_candidates =
+          toLinkCandidates(linkCandidates);
+      }
+
+      const linkingApi = createPostLoginUserApi({
+        ctx,
+        data,
+        tenantId: tenant_id,
+        user,
+        candidates: linkCandidates,
+      });
+
       const outcomes: HandleCodeHookOutcome[] = [];
       for (const hook of codeHooks) {
         if (!isCodeHook(hook)) continue;
@@ -454,7 +488,7 @@ export async function postUserLoginHook(
             hook,
             enhancedEvent,
             "post-user-login",
-            {},
+            linkingApi.api as unknown as CodeHookApi,
           );
           if (outcome) outcomes.push(outcome);
         } catch (err) {
@@ -471,6 +505,15 @@ export async function postUserLoginHook(
           });
         }
       }
+
+      // If an action linked the user, re-fetch the resulting primary so
+      // downstream token building sees it — matching `handleTemplateHook`.
+      const linkedPrimaryId = linkingApi.getLinkedPrimaryId();
+      if (linkedPrimaryId && linkedPrimaryId !== user.user_id) {
+        const primary = await data.users.get(tenant_id, linkedPrimaryId);
+        if (primary) user = primary;
+      }
+
       const persistedExecutionId = await persistActionExecution(
         data,
         tenant_id,

--- a/packages/authhero/src/hooks/post-user-login.ts
+++ b/packages/authhero/src/hooks/post-user-login.ts
@@ -20,8 +20,8 @@ import {
   handleCodeHook,
   persistActionExecution,
   HandleCodeHookOutcome,
-  CodeHookApi,
 } from "./codehooks";
+import { HookEvent } from "../types/Hooks";
 import { invokeHooks } from "./webhooks";
 import { createTokenAPI } from "./helpers/token-api";
 import { createPostLoginUserApi } from "./helpers/post-login-account-linking";
@@ -456,7 +456,7 @@ export async function postUserLoginHook(
       // see no behaviour or latency change. `setLinkedTo` is still guarded
       // host-side, so an action can't link to a user outside this set.
       const linkingOptedIn = codeHooks.some(
-        (h: any) => h.metadata?.resolve_link_candidates === true,
+        (h) => h.metadata?.resolve_link_candidates === true,
       );
       const linkCandidates = linkingOptedIn
         ? await resolveLinkCandidates({
@@ -465,10 +465,11 @@ export async function postUserLoginHook(
             user,
           })
         : [];
-      if (linkingOptedIn) {
-        (enhancedEvent as Record<string, unknown>).link_candidates =
-          toLinkCandidates(linkCandidates);
-      }
+      // Serialize once; attached per hook below rather than mutated onto the
+      // shared event, so only opted-in hooks receive it.
+      const serializedCandidates = linkingOptedIn
+        ? toLinkCandidates(linkCandidates)
+        : [];
 
       const linkingApi = createPostLoginUserApi({
         ctx,
@@ -481,14 +482,21 @@ export async function postUserLoginHook(
       const outcomes: HandleCodeHookOutcome[] = [];
       for (const hook of codeHooks) {
         if (!isCodeHook(hook)) continue;
+        // Only hooks that opted in see `link_candidates` — otherwise an
+        // unrelated action would receive other accounts' ids/emails just
+        // because a *different* hook on the same tenant opted in.
+        const eventForHook: HookEvent =
+          hook.metadata?.resolve_link_candidates === true
+            ? { ...enhancedEvent, link_candidates: serializedCandidates }
+            : enhancedEvent;
         try {
           const outcome = await handleCodeHook(
             ctx,
             data,
             hook,
-            enhancedEvent,
+            eventForHook,
             "post-user-login",
-            linkingApi.api as unknown as CodeHookApi,
+            linkingApi.api,
           );
           if (outcome) outcomes.push(outcome);
         } catch (err) {

--- a/packages/authhero/src/hooks/pre-defined/account-linking.ts
+++ b/packages/authhero/src/hooks/pre-defined/account-linking.ts
@@ -1,6 +1,7 @@
 import { User } from "@authhero/adapter-interfaces";
 import { HookEvent, OnExecutePostLogin } from "../../types/Hooks";
 import { compareUsersByAge, repointPrimary } from "../../helpers/users";
+import { resolveLinkCandidates } from "../../helpers/link-candidates";
 
 /**
  * Coerce a possibly-serialised `user_metadata` blob into a plain record.
@@ -122,54 +123,16 @@ export function accountLinking(
 
     const data = ctx.env.data;
 
-    // List all users with the same email and pick a candidate that is NOT
-    // the current user. Using getPrimaryUserByEmail here would return the
-    // oldest primary — which may be the current user itself — and then
-    // miss any newer duplicate primaries that should be demoted.
-    const normalizedEmail = user.email.toLowerCase();
-    const { users: matchingUsers } = await data.users.list(tenantId, {
-      page: 0,
-      per_page: 10,
-      include_totals: false,
-      q: `email:${normalizedEmail}`,
+    // Resolve the candidate primaries for this email (oldest first), excluding
+    // the current user. Shared with the programmable `post-user-login` code
+    // hook path so both see identical selection semantics. The built-in policy
+    // picks the oldest, i.e. the first element.
+    const candidates = await resolveLinkCandidates({
+      userAdapter: data.users,
+      tenantId,
+      user,
     });
-
-    const otherUsers = matchingUsers.filter((u) => u.user_id !== user.user_id);
-    if (otherUsers.length === 0) return;
-
-    // Prefer the OLDEST unlinked primary so duplicate-primary races converge
-    // in a single pass — picking the first match from adapter list ordering
-    // can demote the older canonical account if the newer duplicate happens
-    // to come first.
-    const directPrimaries = otherUsers.filter((u) => !u.linked_to);
-    let candidate: User | undefined =
-      directPrimaries.length > 0
-        ? [...directPrimaries].sort(compareUsersByAge)[0]
-        : undefined;
-
-    if (!candidate) {
-      // No direct primaries — resolve every secondary's linked_to chain to
-      // its root and pick the oldest root so multiple chains for the same
-      // email collapse onto a single primary.
-      const roots: User[] = [];
-      const seen = new Set<string>();
-      for (const u of otherUsers) {
-        if (!u.linked_to) continue;
-        const resolved = await data.users.get(tenantId, u.linked_to);
-        if (
-          resolved &&
-          resolved.user_id !== user.user_id &&
-          !seen.has(resolved.user_id)
-        ) {
-          seen.add(resolved.user_id);
-          roots.push(resolved);
-        }
-      }
-      if (roots.length > 0) {
-        candidate = roots.sort(compareUsersByAge)[0];
-      }
-    }
-
+    const candidate = candidates[0];
     if (!candidate) return;
 
     // Older account wins. If the currently logging-in user pre-dates the

--- a/packages/authhero/src/hooks/pre-defined/account-linking.ts
+++ b/packages/authhero/src/hooks/pre-defined/account-linking.ts
@@ -48,6 +48,61 @@ export interface AccountLinkingOptions {
    * @default false
    */
   copyUserMetadata?: boolean;
+
+  /**
+   * When the link is performed, fill in *absent* root profile fields on the
+   * primary from the secondary — e.g. a secondary that has a `birthdate` the
+   * primary lacks, or a phone number an email primary doesn't carry.
+   *
+   * Fill-if-absent only: a field already set on the primary is never
+   * overwritten (primary stays authoritative), matching `copyUserMetadata`.
+   * Identifier and verification fields are never touched — `email`,
+   * `email_verified`, `phone_verified`, `username`, `provider`, `connection`
+   * are excluded — so this can't rewrite a login identifier. In particular an
+   * sms primary already carries a `phone_number`, so its identifier is never
+   * filled over; the promotion only reaches a primary that has no phone yet.
+   *
+   * Off by default to match Auth0, which keeps a linked identity's own
+   * attributes under `identities[].profileData` rather than promoting them to
+   * the merged user's root profile.
+   *
+   * @default false
+   */
+  copyProfileFields?: boolean;
+}
+
+/**
+ * Root profile fields that {@link AccountLinkingOptions.copyProfileFields} may
+ * fill in on the primary. Deliberately excludes every identifier/credential and
+ * verification field (`email`, `email_verified`, `phone_verified`, `username`,
+ * `provider`, `connection`, `linked_to`, metadata) so a profile promotion can
+ * never mutate how an identity logs in.
+ */
+const PROMOTABLE_PROFILE_FIELDS = [
+  "name",
+  "given_name",
+  "family_name",
+  "middle_name",
+  "nickname",
+  "preferred_username",
+  "picture",
+  "profile",
+  "website",
+  "gender",
+  "birthdate",
+  "zoneinfo",
+  "locale",
+  "phone_number",
+  "address",
+] as const;
+
+/**
+ * True when `value` is "absent" for promotion purposes — undefined, null, or an
+ * empty string. A field in this state on the primary may be filled from the
+ * secondary; any other value is authoritative and left untouched.
+ */
+function isAbsent(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
 }
 
 /**
@@ -105,6 +160,7 @@ export function accountLinking(
 ): OnExecutePostLogin & AccountLinkingHandler {
   const requireVerifiedEmail = options?.requireVerifiedEmail ?? true;
   const copyUserMetadata = options?.copyUserMetadata ?? false;
+  const copyProfileFields = options?.copyProfileFields ?? false;
 
   const handler = async (event: HookEvent) => {
     const { ctx, user } = event;
@@ -182,6 +238,30 @@ export function accountLinking(
             user_metadata: merged,
           });
         }
+      }
+    }
+
+    if (copyProfileFields) {
+      // Fill absent root profile fields on the primary from the secondary.
+      // Never overwrites a value already present on the primary, and only the
+      // allow-listed non-identifier fields are eligible, so this can't touch a
+      // login identifier (email/username) or a verification flag.
+      const primaryRecord = primaryUser as unknown as Record<string, unknown>;
+      const secondaryRecord = secondaryUser as unknown as Record<
+        string,
+        unknown
+      >;
+      const fills: Record<string, unknown> = {};
+      for (const field of PROMOTABLE_PROFILE_FIELDS) {
+        if (
+          isAbsent(primaryRecord[field]) &&
+          !isAbsent(secondaryRecord[field])
+        ) {
+          fills[field] = secondaryRecord[field];
+        }
+      }
+      if (Object.keys(fills).length > 0) {
+        await data.users.update(tenantId, primaryUser.user_id, fills);
       }
     }
   };

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -1,7 +1,11 @@
 import { HTTPException } from "hono/http-exception";
 import { userIdGenerate, userIdParse } from "../../utils/user-id";
 import { Bindings, Variables } from "../../types";
-import { getUsersByEmail, getUserByProvider } from "../../helpers/users";
+import {
+  getUsersByEmail,
+  getUserByProvider,
+  cascadeEmailToLinkedIdentities,
+} from "../../helpers/users";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { querySchema } from "../../types/auth0/Query";
 import { parseSort } from "../../utils/sort";
@@ -557,6 +561,17 @@ const patchByUser_id = defineRoute({
               .extend({
                 verify_email: z.boolean(),
                 password: z.string(),
+                // PATCH is pass-through: a field the caller omits must stay
+                // untouched. `userInsertSchema` gives these create-time
+                // defaults (`email_verified: false`, metadata `{}`), and
+                // `.partial()` does NOT strip a `.default()` — so without
+                // overriding them here, omitting the field would silently reset
+                // `email_verified` to false (locking out enforced-verification
+                // clients after any edit) and wipe `app_metadata`/
+                // `user_metadata` on every update.
+                email_verified: z.boolean(),
+                app_metadata: z.any(),
+                user_metadata: z.any(),
               })
               .partial(),
           },
@@ -711,6 +726,25 @@ const patchByUser_id = defineRoute({
     }
 
     await ctx.env.data.users.update(tenantId, targetUserId, userFields);
+
+    // Keep a merged user's login email consistent: when the email of one
+    // email-identified identity changes, propagate it to the cluster's other
+    // email-identified identities (username-password / passwordless-email) so a
+    // linked password account isn't left logging in with the old address. sms
+    // and social identifiers are never rewritten. `user_id` is the cluster root
+    // (patching a secondary is rejected with 404 above). See
+    // cascadeEmailToLinkedIdentities.
+    if (userFields.email && userFields.email !== targetUser.email) {
+      await cascadeEmailToLinkedIdentities({
+        userAdapter: ctx.env.data.users,
+        tenant_id: tenantId,
+        primaryUserId: user_id,
+        sourceUserId: targetUserId,
+        email: userFields.email,
+        email_verified:
+          userFields.email_verified ?? targetUser.email_verified ?? false,
+      });
+    }
 
     if (password) {
       // When updating password with a connection specified, use that connection

--- a/packages/authhero/src/types/Hooks.ts
+++ b/packages/authhero/src/types/Hooks.ts
@@ -2,6 +2,7 @@ import {
   AuthorizationResponseMode,
   AuthorizationResponseType,
   DataAdapters,
+  LinkCandidate,
   RolePermissionInsert,
   User,
 } from "@authhero/adapter-interfaces";
@@ -166,6 +167,13 @@ export type HookEvent = {
     ja3?: string;
     ja4?: string;
   };
+  /**
+   * Candidate primary accounts the built-in email-linking policy would consider,
+   * exposed only to `post-user-login` code hooks that opt in via
+   * `metadata.resolve_link_candidates`. Absent on the event for every other hook
+   * (and trigger).
+   */
+  link_candidates?: LinkCandidate[];
 };
 
 export type TokenAPI = {

--- a/packages/authhero/test/hooks/account-linking-profile-promotion.spec.ts
+++ b/packages/authhero/test/hooks/account-linking-profile-promotion.spec.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+import { accountLinking } from "../../src/hooks/pre-defined/account-linking";
+import type { AccountLinkingOptions } from "../../src/hooks/pre-defined/account-linking";
+
+/**
+ * Tests for the opt-in `copyProfileFields` promotion (issues #3/#4, Invariant
+ * 4). When enabled, linking fills *absent* root profile fields on the primary
+ * from the secondary — fill-if-absent, never overwrite, and never an identifier
+ * or verification field. Off by default (Auth0-faithful: a linked identity's
+ * own attributes stay under `identities[].profileData`).
+ *
+ * The `accountLinking` handler picks the OLDEST account as primary. Provider
+ * prefixes are chosen so the email identity sorts oldest by the user_id
+ * tie-break ("email" < "google-oauth2" < "sms"), making the email row the
+ * primary deterministically without fixture timestamps.
+ */
+describe("accountLinking copyProfileFields promotion", () => {
+  const tenantId = "tenantId";
+
+  function mockCtx(data: any): any {
+    return {
+      env: { data },
+      req: { method: "POST", url: "http://test", header: () => tenantId },
+      var: { tenant_id: tenantId, ip: "127.0.0.1" },
+      get: (key: string) => (key === "ip" ? "127.0.0.1" : undefined),
+    };
+  }
+
+  function invokeHook(ctx: any, user: any, options?: AccountLinkingOptions) {
+    const hook = accountLinking(options);
+    return hook(
+      {
+        ctx,
+        user,
+        tenant: { id: tenantId },
+        request: { ip: "127.0.0.1", url: "http://test" },
+      } as any,
+      {
+        prompt: { render: () => {} },
+        redirect: {
+          sendUserTo: () => {},
+          encodeToken: () => "",
+          validateToken: () => null,
+        },
+        token: { createServiceToken: async () => "" },
+      } as any,
+    );
+  }
+
+  async function makeEmailPrimary(
+    env: any,
+    extra: Record<string, unknown> = {},
+  ) {
+    await env.data.users.create(tenantId, {
+      user_id: "email|promo-primary",
+      email: "promo@example.com",
+      email_verified: true,
+      name: "Promo Primary",
+      provider: "email",
+      connection: "email",
+      is_social: false,
+      login_count: 0,
+      ...extra,
+    });
+    return env.data.users.get(tenantId, "email|promo-primary");
+  }
+
+  it("fills an absent birthdate on the primary from a linked social identity", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env);
+    await env.data.users.create(tenantId, {
+      user_id: "google-oauth2|promo-social",
+      email: "promo@example.com",
+      email_verified: true,
+      birthdate: "2000-05-05",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      login_count: 0,
+    });
+    const social = await env.data.users.get(
+      tenantId,
+      "google-oauth2|promo-social",
+    );
+
+    await invokeHook(mockCtx(env.data), social, { copyProfileFields: true });
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    expect(primary!.birthdate).toBe("2000-05-05");
+    // The link was established (secondary points at the primary).
+    const secondary = await env.data.users.get(
+      tenantId,
+      "google-oauth2|promo-social",
+    );
+    expect(secondary!.linked_to).toBe("email|promo-primary");
+  });
+
+  it("does NOT overwrite a birthdate already set on the primary", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env, { birthdate: "1990-01-01" });
+    await env.data.users.create(tenantId, {
+      user_id: "google-oauth2|promo-social",
+      email: "promo@example.com",
+      email_verified: true,
+      birthdate: "2000-05-05",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      login_count: 0,
+    });
+    const social = await env.data.users.get(
+      tenantId,
+      "google-oauth2|promo-social",
+    );
+
+    await invokeHook(mockCtx(env.data), social, { copyProfileFields: true });
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    expect(primary!.birthdate).toBe("1990-01-01");
+  });
+
+  it("does not promote anything when copyProfileFields is off (Auth0 default)", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env);
+    await env.data.users.create(tenantId, {
+      user_id: "google-oauth2|promo-social",
+      email: "promo@example.com",
+      email_verified: true,
+      birthdate: "2000-05-05",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      login_count: 0,
+    });
+    const social = await env.data.users.get(
+      tenantId,
+      "google-oauth2|promo-social",
+    );
+
+    await invokeHook(mockCtx(env.data), social);
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    expect(primary!.birthdate).toBeUndefined();
+  });
+
+  it("promotes an sms secondary's phone to an email primary that has none, without touching the sms identifier", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env);
+    await env.data.users.create(tenantId, {
+      user_id: "sms|promo-sms",
+      email: "promo@example.com",
+      email_verified: true,
+      phone_number: "+46700000009",
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+      login_count: 0,
+    });
+    const sms = await env.data.users.get(tenantId, "sms|promo-sms");
+
+    await invokeHook(mockCtx(env.data), sms, { copyProfileFields: true });
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    const smsAfter = await env.data.users.get(tenantId, "sms|promo-sms");
+    // Primary gains the phone as profile data...
+    expect(primary!.phone_number).toBe("+46700000009");
+    // ...its email identifier is untouched...
+    expect(primary!.email).toBe("promo@example.com");
+    // ...and the sms row's identifier phone is never rewritten.
+    expect(smsAfter!.phone_number).toBe("+46700000009");
+  });
+
+  it("does NOT overwrite a phone the primary already carries", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env, { phone_number: "+46711111111" });
+    await env.data.users.create(tenantId, {
+      user_id: "sms|promo-sms",
+      email: "promo@example.com",
+      email_verified: true,
+      phone_number: "+46722222222",
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+      login_count: 0,
+    });
+    const sms = await env.data.users.get(tenantId, "sms|promo-sms");
+
+    await invokeHook(mockCtx(env.data), sms, { copyProfileFields: true });
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    expect(primary!.phone_number).toBe("+46711111111");
+  });
+});

--- a/packages/authhero/test/hooks/post-login-account-linking.spec.ts
+++ b/packages/authhero/test/hooks/post-login-account-linking.spec.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
+import { Context } from "hono";
 import {
   Strategy,
   TRIGGER_API_SHAPES,
   User,
 } from "@authhero/adapter-interfaces";
+import { Bindings, Variables } from "../../src/types";
 import { getTestServer } from "../helpers/test-server";
 import { addDataHooks } from "../../src/hooks";
 import { USERNAME_PASSWORD_PROVIDER } from "../../src/constants";
@@ -12,16 +14,20 @@ import {
   toLinkCandidates,
 } from "../../src/helpers/link-candidates";
 import { createPostLoginUserApi } from "../../src/hooks/helpers/post-login-account-linking";
-import { executeCodeHook, CodeHookApi } from "../../src/hooks/codehooks";
+import { executeCodeHook } from "../../src/hooks/codehooks";
 import { LocalCodeExecutor } from "../../src/hooks/code-executor/local";
 
 const tenantId = "tenantId";
 
-function createMockCtx(env: any): any {
+function createMockCtx(
+  env: Bindings,
+): Context<{ Bindings: Bindings; Variables: Variables }> {
   const vars: Record<string, unknown> = {
     tenant_id: tenantId,
     ip: "127.0.0.1",
   };
+  // Hand-rolled partial context — narrow through `unknown` since it only
+  // implements the members these tests exercise.
   return {
     req: {
       method: "POST",
@@ -36,11 +42,11 @@ function createMockCtx(env: any): any {
     set: (key: string, value: unknown) => {
       vars[key] = value;
     },
-  };
+  } as unknown as Context<{ Bindings: Bindings; Variables: Variables }>;
 }
 
 async function seedUser(
-  env: any,
+  env: Bindings,
   overrides: Partial<User> & { user_id: string },
 ) {
   return env.data.users.create(tenantId, {
@@ -377,7 +383,7 @@ exports.onExecutePostLogin = async (event, api) => {
         link_candidates: toLinkCandidates(candidates),
       },
       triggerId: "post-user-login",
-      api: linking.api as unknown as CodeHookApi,
+      api: linking.api,
     });
 
     expect(outcome.result.error).toBeNull();
@@ -426,7 +432,7 @@ exports.onExecutePostLogin = async (event, api) => {
       hook: { code_id: hookCode.id },
       event: { user: current, link_candidates: [] },
       triggerId: "post-user-login",
-      api: linking.api as unknown as CodeHookApi,
+      api: linking.api,
     });
 
     expect(linking.getLinkedPrimaryId()).toBeNull();

--- a/packages/authhero/test/hooks/post-login-account-linking.spec.ts
+++ b/packages/authhero/test/hooks/post-login-account-linking.spec.ts
@@ -1,0 +1,461 @@
+import { describe, it, expect } from "vitest";
+import {
+  Strategy,
+  TRIGGER_API_SHAPES,
+  User,
+} from "@authhero/adapter-interfaces";
+import { getTestServer } from "../helpers/test-server";
+import { addDataHooks } from "../../src/hooks";
+import { USERNAME_PASSWORD_PROVIDER } from "../../src/constants";
+import {
+  resolveLinkCandidates,
+  toLinkCandidates,
+} from "../../src/helpers/link-candidates";
+import { createPostLoginUserApi } from "../../src/hooks/helpers/post-login-account-linking";
+import { executeCodeHook, CodeHookApi } from "../../src/hooks/codehooks";
+import { LocalCodeExecutor } from "../../src/hooks/code-executor/local";
+
+const tenantId = "tenantId";
+
+function createMockCtx(env: any): any {
+  const vars: Record<string, unknown> = {
+    tenant_id: tenantId,
+    ip: "127.0.0.1",
+  };
+  return {
+    req: {
+      method: "POST",
+      url: "http://test",
+      path: "/test",
+      header: (name?: string) => (name === "tenant-id" ? tenantId : undefined),
+      raw: { headers: new Headers() },
+    },
+    env,
+    var: vars,
+    get: (key: string) => vars[key],
+    set: (key: string, value: unknown) => {
+      vars[key] = value;
+    },
+  };
+}
+
+async function seedUser(
+  env: any,
+  overrides: Partial<User> & { user_id: string },
+) {
+  return env.data.users.create(tenantId, {
+    email: "shared@example.com",
+    email_verified: true,
+    provider: USERNAME_PASSWORD_PROVIDER,
+    connection: Strategy.USERNAME_PASSWORD,
+    created_at: "2025-01-01T00:00:00.000Z",
+    updated_at: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  });
+}
+
+describe("resolveLinkCandidates", () => {
+  it("picks the oldest unlinked primary and excludes the current user", async () => {
+    const { env } = await getTestServer();
+
+    const current = await seedUser(env, {
+      user_id: "google-oauth2|current",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      created_at: "2025-06-01T00:00:00.000Z",
+    });
+    // Distinct providers so both can be primaries sharing the same email
+    // (the adapter enforces uniqueness on provider+email).
+    await seedUser(env, {
+      user_id: "facebook|newer-primary",
+      provider: "facebook",
+      connection: "facebook",
+      is_social: true,
+      created_at: "2024-01-01T00:00:00.000Z",
+    });
+    await seedUser(env, {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|older-primary`,
+      created_at: "2020-01-01T00:00:00.000Z",
+    });
+
+    const candidates = await resolveLinkCandidates({
+      userAdapter: env.data.users,
+      tenantId,
+      user: current,
+    });
+
+    expect(candidates.map((c) => c.user_id)).not.toContain(
+      "google-oauth2|current",
+    );
+    // Oldest first.
+    expect(candidates[0]?.user_id).toBe(
+      `${USERNAME_PASSWORD_PROVIDER}|older-primary`,
+    );
+    const serialized = toLinkCandidates(candidates);
+    expect(serialized[0]).toMatchObject({
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|older-primary`,
+      is_primary: true,
+      is_oldest: true,
+    });
+    expect(serialized.filter((c) => c.is_oldest)).toHaveLength(1);
+  });
+
+  it("resolves linked_to chains to their roots when there is no direct primary", async () => {
+    const { env } = await getTestServer();
+
+    const primary = await seedUser(env, {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|root`,
+      created_at: "2020-01-01T00:00:00.000Z",
+    });
+    // Only a secondary shares the email directly; its root is `primary`.
+    await seedUser(env, {
+      user_id: "facebook|secondary",
+      provider: "facebook",
+      connection: "facebook",
+      is_social: true,
+      linked_to: primary.user_id,
+      created_at: "2025-02-01T00:00:00.000Z",
+    });
+
+    const current = await seedUser(env, {
+      user_id: "google-oauth2|current2",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      created_at: "2025-06-01T00:00:00.000Z",
+    });
+
+    const candidates = await resolveLinkCandidates({
+      userAdapter: env.data.users,
+      tenantId,
+      user: current,
+    });
+
+    expect(candidates.map((c) => c.user_id)).toEqual([primary.user_id]);
+  });
+
+  it("returns an empty list when nothing else shares the email", async () => {
+    const { env } = await getTestServer();
+    const current = await seedUser(env, {
+      user_id: "google-oauth2|lonely",
+      email: "unique@example.com",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+    });
+    const candidates = await resolveLinkCandidates({
+      userAdapter: env.data.users,
+      tenantId,
+      user: current,
+    });
+    expect(candidates).toEqual([]);
+  });
+});
+
+describe("createPostLoginUserApi.setLinkedTo", () => {
+  it("rejects a user_id that is not among the candidates and mutates nothing", async () => {
+    const { env } = await getTestServer();
+    const data = addDataHooks(createMockCtx(env), env.data);
+
+    const current = await seedUser(env, {
+      user_id: "google-oauth2|reject",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+    });
+    // A real user that is NOT a candidate — the guard must still refuse it.
+    const bystander = await seedUser(env, {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|bystander`,
+      email: "someone-else@example.com",
+    });
+
+    const { api, getLinkedPrimaryId } = createPostLoginUserApi({
+      ctx: createMockCtx(env),
+      data,
+      tenantId,
+      user: current,
+      candidates: [],
+    });
+
+    await api.user.setLinkedTo(bystander.user_id);
+
+    expect(getLinkedPrimaryId()).toBeNull();
+    const after = await env.data.users.get(tenantId, current.user_id);
+    expect(after?.linked_to).toBeFalsy();
+  });
+
+  it("links the logging-in user to an older candidate (current user is newer)", async () => {
+    const { env } = await getTestServer();
+    const data = addDataHooks(createMockCtx(env), env.data);
+
+    const older = await seedUser(env, {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|older`,
+      created_at: "2020-01-01T00:00:00.000Z",
+    });
+    const current = await seedUser(env, {
+      user_id: "google-oauth2|newer",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      created_at: "2025-06-01T00:00:00.000Z",
+    });
+
+    const { api, getLinkedPrimaryId } = createPostLoginUserApi({
+      ctx: createMockCtx(env),
+      data,
+      tenantId,
+      user: current,
+      candidates: [older],
+    });
+
+    await api.user.setLinkedTo(older.user_id);
+
+    expect(getLinkedPrimaryId()).toBe(older.user_id);
+    const currentAfter = await env.data.users.get(tenantId, current.user_id);
+    const olderAfter = await env.data.users.get(tenantId, older.user_id);
+    expect(currentAfter?.linked_to).toBe(older.user_id);
+    expect(olderAfter?.linked_to).toBeFalsy();
+  });
+
+  it("demotes the candidate when the logging-in user pre-dates it (direction)", async () => {
+    const { env } = await getTestServer();
+    const data = addDataHooks(createMockCtx(env), env.data);
+
+    const current = await seedUser(env, {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|older-current`,
+      created_at: "2020-01-01T00:00:00.000Z",
+    });
+    const newerCandidate = await seedUser(env, {
+      user_id: "google-oauth2|newer-candidate",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      created_at: "2025-06-01T00:00:00.000Z",
+    });
+
+    const { api, getLinkedPrimaryId } = createPostLoginUserApi({
+      ctx: createMockCtx(env),
+      data,
+      tenantId,
+      user: current,
+      candidates: [newerCandidate],
+    });
+
+    await api.user.setLinkedTo(newerCandidate.user_id);
+
+    expect(getLinkedPrimaryId()).toBe(current.user_id);
+    const currentAfter = await env.data.users.get(tenantId, current.user_id);
+    const candidateAfter = await env.data.users.get(
+      tenantId,
+      newerCandidate.user_id,
+    );
+    expect(currentAfter?.linked_to).toBeFalsy();
+    expect(candidateAfter?.linked_to).toBe(current.user_id);
+  });
+
+  it("is idempotent — running twice leaves the same end state", async () => {
+    const { env } = await getTestServer();
+    const data = addDataHooks(createMockCtx(env), env.data);
+
+    const older = await seedUser(env, {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|idem-older`,
+      created_at: "2020-01-01T00:00:00.000Z",
+    });
+    const current = await seedUser(env, {
+      user_id: "google-oauth2|idem-current",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      created_at: "2025-06-01T00:00:00.000Z",
+    });
+
+    const { api } = createPostLoginUserApi({
+      ctx: createMockCtx(env),
+      data,
+      tenantId,
+      user: current,
+      candidates: [older],
+    });
+
+    await api.user.setLinkedTo(older.user_id);
+    await api.user.setLinkedTo(older.user_id);
+
+    const currentAfter = await env.data.users.get(tenantId, current.user_id);
+    expect(currentAfter?.linked_to).toBe(older.user_id);
+    // Exactly one secondary points at the primary.
+    const { users: secondaries } = await env.data.users.list(tenantId, {
+      page: 0,
+      per_page: 10,
+      include_totals: false,
+      q: `linked_to:${older.user_id}`,
+    });
+    expect(secondaries.map((u) => u.user_id)).toEqual([current.user_id]);
+  });
+
+  it("refuses to link an unverified-email user regardless of candidate", async () => {
+    const { env } = await getTestServer();
+    const data = addDataHooks(createMockCtx(env), env.data);
+
+    const older = await seedUser(env, {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|verified-older`,
+      created_at: "2020-01-01T00:00:00.000Z",
+    });
+    const current = await seedUser(env, {
+      user_id: "google-oauth2|unverified",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      email_verified: false,
+      created_at: "2025-06-01T00:00:00.000Z",
+    });
+
+    const { api, getLinkedPrimaryId } = createPostLoginUserApi({
+      ctx: createMockCtx(env),
+      data,
+      tenantId,
+      user: current,
+      candidates: [older],
+    });
+
+    await api.user.setLinkedTo(older.user_id);
+
+    expect(getLinkedPrimaryId()).toBeNull();
+    const after = await env.data.users.get(tenantId, current.user_id);
+    expect(after?.linked_to).toBeFalsy();
+  });
+});
+
+describe("post-user-login code hook linking (end-to-end via executeCodeHook)", () => {
+  it("an action reads event.link_candidates and links through the async replay path", async () => {
+    const { env } = await getTestServer();
+    const data = addDataHooks(createMockCtx(env), env.data);
+
+    const older = await seedUser(env, {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|e2e-older`,
+      created_at: "2020-01-01T00:00:00.000Z",
+    });
+    const current = await seedUser(env, {
+      user_id: "google-oauth2|e2e-current",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      created_at: "2025-06-01T00:00:00.000Z",
+    });
+
+    const candidates = await resolveLinkCandidates({
+      userAdapter: env.data.users,
+      tenantId,
+      user: current,
+    });
+    expect(candidates.map((c) => c.user_id)).toContain(older.user_id);
+
+    const linking = createPostLoginUserApi({
+      ctx: createMockCtx(env),
+      data,
+      tenantId,
+      user: current,
+      candidates,
+    });
+
+    const hookCode = await env.data.hookCode.create(tenantId, {
+      code: `
+exports.onExecutePostLogin = async (event, api) => {
+  const target = event.link_candidates.find((c) => c.is_oldest);
+  if (target) api.user.setLinkedTo(target.user_id);
+};
+`,
+    });
+
+    const outcome = await executeCodeHook({
+      codeExecutor: new LocalCodeExecutor(),
+      data: env.data,
+      tenantId,
+      hook: { code_id: hookCode.id },
+      event: {
+        user: current,
+        link_candidates: toLinkCandidates(candidates),
+      },
+      triggerId: "post-user-login",
+      api: linking.api as unknown as CodeHookApi,
+    });
+
+    expect(outcome.result.error).toBeNull();
+    // The link must have completed *before* executeCodeHook resolved — the
+    // whole point of awaiting replay.
+    expect(linking.getLinkedPrimaryId()).toBe(older.user_id);
+    const currentAfter = await env.data.users.get(tenantId, current.user_id);
+    expect(currentAfter?.linked_to).toBe(older.user_id);
+  });
+
+  it("an action linking to a non-candidate user_id is rejected and mutates nothing", async () => {
+    const { env } = await getTestServer();
+    const data = addDataHooks(createMockCtx(env), env.data);
+
+    const current = await seedUser(env, {
+      user_id: "google-oauth2|e2e-reject",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+    });
+    const bystander = await seedUser(env, {
+      user_id: `${USERNAME_PASSWORD_PROVIDER}|e2e-bystander`,
+      email: "bystander@example.com",
+    });
+
+    const linking = createPostLoginUserApi({
+      ctx: createMockCtx(env),
+      data,
+      tenantId,
+      user: current,
+      candidates: [],
+    });
+
+    const hookCode = await env.data.hookCode.create(tenantId, {
+      code: `
+exports.onExecutePostLogin = async (event, api) => {
+  api.user.setLinkedTo(${JSON.stringify(bystander.user_id)});
+};
+`,
+    });
+
+    await executeCodeHook({
+      codeExecutor: new LocalCodeExecutor(),
+      data: env.data,
+      tenantId,
+      hook: { code_id: hookCode.id },
+      event: { user: current, link_candidates: [] },
+      triggerId: "post-user-login",
+      api: linking.api as unknown as CodeHookApi,
+    });
+
+    expect(linking.getLinkedPrimaryId()).toBeNull();
+    const after = await env.data.users.get(tenantId, current.user_id);
+    expect(after?.linked_to).toBeFalsy();
+  });
+});
+
+describe("shared code-hook API shapes", () => {
+  it("exposes user.setLinkedTo at post-user-login", () => {
+    expect(TRIGGER_API_SHAPES["post-user-login"]?.user).toContain(
+      "setLinkedTo",
+    );
+  });
+
+  it("the local executor records user.setLinkedTo calls (uses the shared shape)", async () => {
+    const exec = new LocalCodeExecutor();
+    const result = await exec.execute({
+      code: `
+exports.onExecutePostLogin = async (event, api) => {
+  api.user.setLinkedTo("auth2|primary");
+};
+`,
+      triggerId: "post-user-login",
+      event: {},
+    });
+    expect(result.success).toBe(true);
+    expect(result.apiCalls).toEqual([
+      { method: "user.setLinkedTo", args: ["auth2|primary"] },
+    ]);
+  });
+});

--- a/packages/authhero/test/hooks/post-user-login-linking.spec.ts
+++ b/packages/authhero/test/hooks/post-user-login-linking.spec.ts
@@ -6,11 +6,13 @@ import { LocalCodeExecutor } from "../../src/hooks/code-executor/local";
 import { flushBackgroundPromises } from "../../src/helpers/wait-until";
 import { USERNAME_PASSWORD_PROVIDER } from "../../src/constants";
 import { Bindings, Variables } from "../../src/types";
+import { EnrichedClient } from "../../src/helpers/client";
 import { getTestServer } from "../helpers/test-server";
 
 const tenantId = "tenantId";
 
-function makeEnrichedClient() {
+function makeEnrichedClient(): EnrichedClient {
+  // Minimal shape for the hook path under test — narrow through `unknown`.
   return {
     id: "clientId",
     name: "Test",
@@ -21,10 +23,10 @@ function makeEnrichedClient() {
     web_origins: [],
     grant_types: ["authorization_code" as const],
     connections: [],
-  };
+  } as unknown as EnrichedClient;
 }
 
-async function makeLoginSession(env: any) {
+async function makeLoginSession(env: Bindings) {
   return env.data.loginSessions.create(tenantId, {
     csrf_token: "csrf",
     authParams: {
@@ -43,10 +45,13 @@ async function makeLoginSession(env: any) {
  * query `resolveLinkCandidates` issues. Lets us assert the opt-in gate: tenants
  * that didn't opt in pay no extra query.
  */
-function countEmailListCalls(env: any): () => number {
+function countEmailListCalls(env: Bindings): () => number {
   let count = 0;
   const original = env.data.users.list.bind(env.data.users);
-  env.data.users.list = async (tid: string, opts: any) => {
+  env.data.users.list = async (
+    tid: string,
+    opts: Parameters<typeof original>[1],
+  ) => {
     if (typeof opts?.q === "string" && opts.q.startsWith("email:")) count++;
     return original(tid, opts);
   };
@@ -122,7 +127,7 @@ exports.onExecutePostLogin = async (event, api) => {
         current,
         loginSession,
         {
-          client: makeEnrichedClient() as any,
+          client: makeEnrichedClient(),
           authParams: loginSession.authParams,
         },
       );
@@ -203,7 +208,7 @@ exports.onExecutePostLogin = async (event, api) => {
       ctx.set("client_id", "clientId");
 
       await postUserLoginHook(ctx, env.data, tenantId, current, loginSession, {
-        client: makeEnrichedClient() as any,
+        client: makeEnrichedClient(),
         authParams: loginSession.authParams,
       });
       await flushBackgroundPromises(ctx);

--- a/packages/authhero/test/hooks/post-user-login-linking.spec.ts
+++ b/packages/authhero/test/hooks/post-user-login-linking.spec.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { Strategy, User } from "@authhero/adapter-interfaces";
+import { postUserLoginHook } from "../../src/hooks";
+import { LocalCodeExecutor } from "../../src/hooks/code-executor/local";
+import { flushBackgroundPromises } from "../../src/helpers/wait-until";
+import { USERNAME_PASSWORD_PROVIDER } from "../../src/constants";
+import { Bindings, Variables } from "../../src/types";
+import { getTestServer } from "../helpers/test-server";
+
+const tenantId = "tenantId";
+
+function makeEnrichedClient() {
+  return {
+    id: "clientId",
+    name: "Test",
+    client_id: "clientId",
+    tenant: { id: tenantId },
+    callbacks: ["http://localhost/cb"],
+    allowed_logout_urls: [],
+    web_origins: [],
+    grant_types: ["authorization_code" as const],
+    connections: [],
+  };
+}
+
+async function makeLoginSession(env: any) {
+  return env.data.loginSessions.create(tenantId, {
+    csrf_token: "csrf",
+    authParams: {
+      client_id: "clientId",
+      response_type: "code",
+      redirect_uri: "http://localhost/cb",
+      scope: "openid",
+      audience: "https://example.com",
+    },
+    expires_at: new Date(Date.now() + 600_000).toISOString(),
+  });
+}
+
+/**
+ * Wrap `data.users.list` to count same-email lookups (`q: "email:…"`) — the
+ * query `resolveLinkCandidates` issues. Lets us assert the opt-in gate: tenants
+ * that didn't opt in pay no extra query.
+ */
+function countEmailListCalls(env: any): () => number {
+  let count = 0;
+  const original = env.data.users.list.bind(env.data.users);
+  env.data.users.list = async (tid: string, opts: any) => {
+    if (typeof opts?.q === "string" && opts.q.startsWith("email:")) count++;
+    return original(tid, opts);
+  };
+  return () => count;
+}
+
+describe("post-user-login programmable account linking (integration)", () => {
+  it("an opted-in code hook links the user via event.link_candidates; the returned user is the primary", async () => {
+    const server = await getTestServer({
+      codeExecutor: new LocalCodeExecutor(),
+    });
+    const env = server.env;
+
+    // Older canonical primary (password) sharing the email.
+    const olderId = `${USERNAME_PASSWORD_PROVIDER}|int-older`;
+    await env.data.users.create(tenantId, {
+      user_id: olderId,
+      email: "int-shared@example.com",
+      email_verified: true,
+      provider: USERNAME_PASSWORD_PROVIDER,
+      connection: Strategy.USERNAME_PASSWORD,
+      created_at: "2020-01-01T00:00:00.000Z",
+      updated_at: "2020-01-01T00:00:00.000Z",
+    });
+
+    // The logging-in (newer, social) user with the same verified email.
+    const current: User = {
+      user_id: "google-oauth2|int-current",
+      email: "int-shared@example.com",
+      email_verified: true,
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      created_at: "2025-06-01T00:00:00.000Z",
+      updated_at: "2025-06-01T00:00:00.000Z",
+      last_ip: "",
+      last_login: "",
+      login_count: 0,
+    };
+    await env.data.users.create(tenantId, current);
+
+    const action = await env.data.actions.create(tenantId, {
+      name: "custom-account-linking",
+      code: `
+exports.onExecutePostLogin = async (event, api) => {
+  const target = (event.link_candidates || []).find((c) => c.is_oldest);
+  if (target) api.user.setLinkedTo(target.user_id);
+};
+`,
+    });
+    await env.data.hooks.create(tenantId, {
+      trigger_id: "post-user-login",
+      enabled: true,
+      code_id: action.id,
+      synchronous: true,
+      metadata: { resolve_link_candidates: true },
+    });
+
+    const loginSession = await makeLoginSession(env);
+
+    const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+    app.post("/run", async (ctx) => {
+      Object.assign(ctx.env, env);
+      ctx.set("tenant_id", tenantId);
+      ctx.set("ip", "1.2.3.4");
+      ctx.set("useragent", "test");
+      ctx.set("client_id", "clientId");
+
+      const result = await postUserLoginHook(
+        ctx,
+        env.data,
+        tenantId,
+        current,
+        loginSession,
+        {
+          client: makeEnrichedClient() as any,
+          authParams: loginSession.authParams,
+        },
+      );
+      await flushBackgroundPromises(ctx);
+      const user = result as User;
+      return ctx.json({
+        user_id: user.user_id,
+        linked_to: user.linked_to ?? null,
+      });
+    });
+
+    const res = await app.request(
+      "/run",
+      { method: "POST", headers: { "tenant-id": tenantId } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      user_id: string;
+      linked_to: string | null;
+    };
+
+    // Downstream sees the primary (older account won).
+    expect(body.user_id).toBe(olderId);
+    expect(body.linked_to).toBeNull();
+
+    // And the link persisted: the logging-in user is now a secondary.
+    const currentAfter = await env.data.users.get(tenantId, current.user_id);
+    expect(currentAfter?.linked_to).toBe(olderId);
+  });
+
+  it("a post-login code hook that only sets a claim triggers no candidate query (not opted in)", async () => {
+    const server = await getTestServer({
+      codeExecutor: new LocalCodeExecutor(),
+    });
+    const env = server.env;
+
+    const current: User = {
+      user_id: "google-oauth2|int-noopt",
+      email: "int-noopt@example.com",
+      email_verified: true,
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      created_at: "2025-06-01T00:00:00.000Z",
+      updated_at: "2025-06-01T00:00:00.000Z",
+      last_ip: "",
+      last_login: "",
+      login_count: 0,
+    };
+    await env.data.users.create(tenantId, current);
+
+    const action = await env.data.actions.create(tenantId, {
+      name: "claims-only",
+      code: `
+exports.onExecutePostLogin = async (event, api) => {
+  api.idToken.setCustomClaim("hello", "world");
+};
+`,
+    });
+    // No resolve_link_candidates metadata → opted out.
+    await env.data.hooks.create(tenantId, {
+      trigger_id: "post-user-login",
+      enabled: true,
+      code_id: action.id,
+      synchronous: true,
+    });
+
+    const loginSession = await makeLoginSession(env);
+    const getEmailListCalls = countEmailListCalls(env);
+
+    const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+    app.post("/run", async (ctx) => {
+      Object.assign(ctx.env, env);
+      ctx.set("tenant_id", tenantId);
+      ctx.set("ip", "1.2.3.4");
+      ctx.set("useragent", "test");
+      ctx.set("client_id", "clientId");
+
+      await postUserLoginHook(ctx, env.data, tenantId, current, loginSession, {
+        client: makeEnrichedClient() as any,
+        authParams: loginSession.authParams,
+      });
+      await flushBackgroundPromises(ctx);
+      return ctx.json({ ok: true });
+    });
+
+    const res = await app.request(
+      "/run",
+      { method: "POST", headers: { "tenant-id": tenantId } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(getEmailListCalls()).toBe(0);
+  });
+});

--- a/packages/authhero/test/routes/management-api/user-email-cascade.spec.ts
+++ b/packages/authhero/test/routes/management-api/user-email-cascade.spec.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "vitest";
+import { testClient } from "hono/testing";
+import { getAdminToken } from "../../helpers/token";
+import { getTestServer } from "../../helpers/test-server";
+import { getUserByProvider } from "../../../src/helpers/users";
+
+/**
+ * Regression suite for issue #1 (Invariants 2 & 3): changing the email of one
+ * email-identified identity in a linked cluster must propagate to the other
+ * email-identified identities, so a linked password account isn't orphaned on
+ * its old address, and the whole cluster shares one verification state. sms and
+ * social identifiers are never rewritten.
+ *
+ * The seeded `email|userId` (foo@example.com, provider "email", verified) is the
+ * cluster primary; we attach secondaries via the raw adapter (bypassing hooks)
+ * and drive the change through the management PATCH.
+ */
+describe("management PATCH email cascade across linked identities", () => {
+  const tenantId = "tenantId";
+  const primaryId = "email|userId";
+
+  async function seedCluster(env: any) {
+    // Linked username-password identity — email IS its login identifier.
+    await env.data.users.create(tenantId, {
+      user_id: "auth2|pw-secondary",
+      email: "foo@example.com",
+      email_verified: true,
+      provider: "auth2",
+      connection: "Username-Password-Authentication",
+      is_social: false,
+      login_count: 0,
+      linked_to: primaryId,
+    });
+    // Linked sms identity — phone_number is its identifier; email is incidental.
+    await env.data.users.create(tenantId, {
+      user_id: "sms|sms-secondary",
+      phone_number: "+46700000001",
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+      login_count: 0,
+      linked_to: primaryId,
+    });
+    // Linked social identity — provider sub is the identifier; email is synced
+    // from the IdP on each login, so a cascade must not rewrite it.
+    await env.data.users.create(tenantId, {
+      user_id: "google-oauth2|social-secondary",
+      email: "foo@example.com",
+      email_verified: true,
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      login_count: 0,
+      linked_to: primaryId,
+    });
+  }
+
+  function patchPrimaryEmail(
+    managementClient: any,
+    token: string,
+    json: Record<string, unknown>,
+  ) {
+    return managementClient.users[":user_id"].$patch(
+      {
+        param: { user_id: primaryId },
+        json,
+        header: { "tenant-id": tenantId },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+  }
+
+  it("propagates a primary email change to a linked password identity", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+    await seedCluster(env);
+
+    const res = await patchPrimaryEmail(managementClient, token, {
+      email: "new@example.com",
+    });
+    expect(res.status).toBe(200);
+
+    const primary = await env.data.users.get(tenantId, primaryId);
+    const pw = await env.data.users.get(tenantId, "auth2|pw-secondary");
+    expect(primary!.email).toBe("new@example.com");
+    // The linked password identity now carries the new address...
+    expect(pw!.email).toBe("new@example.com");
+    // ...and stays verified in lock-step with the primary (was verified).
+    expect(pw!.email_verified).toBe(true);
+
+    // The precise mechanism that fixes login: the password row is now findable
+    // by (new email, auth2), so getUserByProvider resolves it.
+    const found = await getUserByProvider({
+      userAdapter: env.data.users,
+      tenant_id: tenantId,
+      username: "new@example.com",
+      provider: "auth2",
+    });
+    expect(found?.user_id).toBe("auth2|pw-secondary");
+  });
+
+  it("never rewrites an sms identity's phone or a social identity's email", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+    await seedCluster(env);
+
+    const res = await patchPrimaryEmail(managementClient, token, {
+      email: "new@example.com",
+    });
+    expect(res.status).toBe(200);
+
+    const sms = await env.data.users.get(tenantId, "sms|sms-secondary");
+    const social = await env.data.users.get(
+      tenantId,
+      "google-oauth2|social-secondary",
+    );
+    // sms identifier untouched (and the cascade didn't stamp the new email
+    // onto it).
+    expect(sms!.phone_number).toBe("+46700000001");
+    expect(sms!.email).not.toBe("new@example.com");
+    // social email is IdP-owned — not rewritten by the cascade.
+    expect(social!.email).toBe("foo@example.com");
+  });
+
+  it("cascades a verification reset to email-identified identities", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+    await seedCluster(env);
+
+    // Admin changes the email AND marks it unverified (self-service-style
+    // re-verification): the flag moves in lock-step across the cluster.
+    const res = await patchPrimaryEmail(managementClient, token, {
+      email: "new@example.com",
+      email_verified: false,
+    });
+    expect(res.status).toBe(200);
+
+    const primary = await env.data.users.get(tenantId, primaryId);
+    const pw = await env.data.users.get(tenantId, "auth2|pw-secondary");
+    expect(primary!.email_verified).toBe(false);
+    expect(pw!.email).toBe("new@example.com");
+    expect(pw!.email_verified).toBe(false);
+  });
+
+  it("still rejects changing to an email owned by an unrelated user (409)", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+    await seedCluster(env);
+
+    // A separate, unlinked primary owns this address.
+    await env.data.users.create(tenantId, {
+      user_id: "email|other-cluster",
+      email: "taken@example.com",
+      email_verified: true,
+      provider: "email",
+      connection: "email",
+      is_social: false,
+      login_count: 0,
+    });
+
+    const res = await patchPrimaryEmail(managementClient, token, {
+      email: "taken@example.com",
+    });
+    expect(res.status).toBe(409);
+  });
+
+  // Issue #2: the management PATCH must be pass-through — omitting
+  // email_verified / metadata must not silently mutate them. (Regression for
+  // the zod `.default()` leaking through `.partial()`.)
+  describe("pass-through of omitted fields (issue #2)", () => {
+    it("does not flip email_verified when the field is omitted", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      // Seeded primary is verified. Change only the email.
+      const res = await patchPrimaryEmail(managementClient, token, {
+        email: "renamed@example.com",
+      });
+      expect(res.status).toBe(200);
+
+      const primary = await env.data.users.get(tenantId, primaryId);
+      expect(primary!.email).toBe("renamed@example.com");
+      expect(primary!.email_verified).toBe(true);
+    });
+
+    it("does not wipe metadata when it is omitted", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      await env.data.users.update(tenantId, primaryId, {
+        user_metadata: { favourite_colour: "green" },
+        app_metadata: { plan: "pro" },
+      });
+
+      const res = await patchPrimaryEmail(managementClient, token, {
+        name: "New Name",
+      } as Record<string, unknown>);
+      expect(res.status).toBe(200);
+
+      const primary = await env.data.users.get(tenantId, primaryId);
+      expect(primary!.name).toBe("New Name");
+      expect(primary!.user_metadata).toEqual({ favourite_colour: "green" });
+      expect(primary!.app_metadata).toEqual({ plan: "pro" });
+    });
+  });
+});

--- a/packages/cloudflare/src/code-executor/worker-loader.ts
+++ b/packages/cloudflare/src/code-executor/worker-loader.ts
@@ -1,6 +1,7 @@
 import {
   CodeExecutionResult,
   CodeExecutor,
+  TRIGGER_API_SHAPES,
 } from "@authhero/adapter-interfaces";
 
 /**
@@ -36,25 +37,9 @@ const TRIGGER_FN_NAMES: Record<string, string> = {
   "post-user-registration": "onExecutePostUserRegistration",
 };
 
-const API_SHAPES: Record<string, Record<string, string[]>> = {
-  "post-user-login": {
-    accessToken: ["setCustomClaim"],
-    idToken: ["setCustomClaim"],
-    access: ["deny"],
-    prompt: ["render"],
-    redirect: ["sendUserTo"],
-  },
-  "credentials-exchange": {
-    accessToken: ["setCustomClaim"],
-    idToken: ["setCustomClaim"],
-    access: ["deny"],
-  },
-  "pre-user-registration": {
-    user: ["setUserMetadata", "setLinkedTo"],
-    access: ["deny"],
-  },
-  "post-user-registration": {},
-};
+// Shared with the local executor via `TRIGGER_API_SHAPES` so the two executors
+// expose an identical surface. Serialized into the generated worker below.
+const API_SHAPES = TRIGGER_API_SHAPES;
 
 /**
  * SHA-256 digest of the code, hex-encoded. Used as part of the worker cache key

--- a/packages/cloudflare/src/code-executor/worker-template.ts
+++ b/packages/cloudflare/src/code-executor/worker-template.ts
@@ -1,3 +1,5 @@
+import { TRIGGER_API_SHAPES } from "@authhero/adapter-interfaces";
+
 /**
  * Generates a Cloudflare Worker script that wraps user-authored code.
  *
@@ -17,25 +19,9 @@ const fnNames = {
   "post-user-registration": "onExecutePostUserRegistration",
 };
 
-const apiShapes = {
-  "post-user-login": {
-    accessToken: ["setCustomClaim"],
-    idToken: ["setCustomClaim"],
-    access: ["deny"],
-    prompt: ["render"],
-    redirect: ["sendUserTo"],
-  },
-  "credentials-exchange": {
-    accessToken: ["setCustomClaim"],
-    idToken: ["setCustomClaim"],
-    access: ["deny"],
-  },
-  "pre-user-registration": {
-    user: ["setUserMetadata", "setLinkedTo"],
-    access: ["deny"],
-  },
-  "post-user-registration": {},
-};
+// Shared source of truth for the per-trigger API allowlist — see
+// TRIGGER_API_SHAPES in @authhero/adapter-interfaces.
+const apiShapes = ${JSON.stringify(TRIGGER_API_SHAPES)};
 
 function createRecordingApiProxy(triggerId) {
   const calls = [];

--- a/packages/cloudflare/test/code-hook-api-shapes.spec.ts
+++ b/packages/cloudflare/test/code-hook-api-shapes.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { TRIGGER_API_SHAPES } from "@authhero/adapter-interfaces";
+import { generateWorkerScript } from "../src/code-executor/worker-template";
+
+/**
+ * The per-trigger API allowlist is duplicated across executors (the local
+ * `LocalCodeExecutor` in `authhero` and the Cloudflare worker generators here).
+ * They must stay identical, so all of them now consume the single
+ * `TRIGGER_API_SHAPES` source of truth in `@authhero/adapter-interfaces`. This
+ * asserts the generated production worker embeds exactly that shape — if the
+ * two ever drift, this fails.
+ */
+describe("code-hook API shapes parity", () => {
+  it("the generated worker embeds the shared TRIGGER_API_SHAPES verbatim", () => {
+    const script = generateWorkerScript("// user code");
+    expect(script).toContain(JSON.stringify(TRIGGER_API_SHAPES));
+  });
+
+  it("post-user-login exposes the programmable account-linking verb", () => {
+    expect(TRIGGER_API_SHAPES["post-user-login"]?.user).toContain(
+      "setLinkedTo",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1184.

Adds a **programmable** account-linking path as a `post-user-login` code hook (action), alongside the existing built-in `account-linking` template hook (which is unchanged). An opted-in action reads `event.link_candidates` and calls `api.user.setLinkedTo(candidate.user_id)` — for tenants that need custom linking policy (link only within a domain, only for certain connections, only when an `app_metadata` flag is set, …).

## How it works

- **Opt-in** — set `metadata.resolve_link_candidates: true` on the code hook. Only then does AuthHero run the extra same-email lookup and populate `event.link_candidates` (the primaries the built-in policy would consider, oldest flagged `is_oldest`). Existing code hooks see no behaviour/latency change and pay no extra query.
- **New verb** — `api.user.setLinkedTo(primaryUserId)` at `post-user-login`.
- **Guarded host-side** (the action is never trusted):
  - Candidate allowlist — rejects any `primaryUserId` not in `event.link_candidates`, logging `FAILED_HOOK`, so it can't become an account-takeover primitive.
  - Verified-email gate enforced server-side regardless of what the action asserts.
  - Direction — "older account wins" via `repointPrimary` (no 2-hop chains).
  - Idempotent; the resulting primary is re-fetched so downstream token building sees it.

## Decisions (per the issue)

- `userLinkingMode: "off"` still only suppresses the built-in email→primary lookup; explicit action/template linking stays available.
- Unverified users may appear in `link_candidates` honestly, but the write refuses them.

## Internals

- The per-trigger code-hook API allowlist (previously duplicated across the local and Cloudflare executors) is now a single `TRIGGER_API_SHAPES` source of truth in `@authhero/adapter-interfaces`, plus a `LinkCandidate` type. A cloudflare test asserts the generated worker embeds it verbatim.
- Candidate resolution is extracted to a shared `resolveLinkCandidates` helper; the built-in template hook now reuses it.
- Code-hook API replay now **awaits** each call so `setLinkedTo`'s writes complete before the login response is built (the subtle async-replay concern called out in the issue).

## Tests

- Unit: candidate resolution (oldest primary, chain→root, excludes current user); `setLinkedTo` guard (non-candidate rejected), direction (both ways), idempotency, verified-email refusal.
- E2E via `executeCodeHook` with the real `LocalCodeExecutor`.
- Integration through the real `post-user-login` dispatch: links and returns the primary; and a regression asserting a claims-only hook triggers **no** candidate query.
- Shape-parity test across the two executors.

All authhero `test/hooks` (196+), cloudflare (131), and auth-flow/actions suites pass; all touched packages typecheck clean.

## Note

When an action links, `postUserLoginHook` reassigns the returned user to the primary (so tokens and the `SUCCESS_LOGIN` log reflect the primary) — consistent with how the existing `account-linking` template hook already behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in programmable account linking via `post-user-login` hooks, including same-email candidate resolution and a new linking API verb.
  * Introduced opt-in profile field promotion (`copyProfileFields`) during account linking.
  * Added email-change cascade across linked email-identified identities.
* **Improvements**
  * Updated code-hook API recording to use a shared allowlist; ensured recorded API replays complete before login proceeds.
  * Hardened management API PATCH behavior to preserve omitted fields and cascade email updates when applicable.
* **Documentation**
  * Added a design document for billing and console architecture restructuring.
* **Tests**
  * Added end-to-end and regression tests covering linking, candidate selection, replay ordering, and email-cascade invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->