### PR TITLE
feat(account-linking): harden identifier semantics for merged users

### DIFF
--- a/.changeset/account-linking-identifier-invariants.md
+++ b/.changeset/account-linking-identifier-invariants.md
@@ -1,0 +1,9 @@
+---
+"authhero": minor
+---
+
+Harden account-linking identifier semantics for merged users.
+
+- **Email cascade (fixes the "changed my email, can't log in with my password" bug).** When the email of one email-identified identity in a linked cluster changes via the management API, the new address now propagates to the cluster's other email-identified identities (username-password / passwordless-email) so a linked password account isn't left logging in with the old address. sms (`phone_number`) and social (provider sub) identifiers are never rewritten. `email_verified` moves in lock-step so the cluster shares one verification state. New exported helpers `cascadeEmailToLinkedIdentities` and `isEmailIdentifiedUser`.
+- **PATCH is now pass-through.** The user PATCH body schema stopped letting `userInsertSchema`'s create-time defaults leak through `.partial()`: omitting `email_verified` no longer silently flips it to `false` (which locked out `email_validation: "enforced"` clients after any edit), and omitting `app_metadata` / `user_metadata` no longer wipes them.
+- **Opt-in profile promotion.** New `copyProfileFields` option on the `account-linking` template fills *absent* root profile fields on the primary from the secondary (e.g. a `birthdate` or phone the primary lacks) — fill-if-absent, never overwrite, and never an identifier or verification field. Off by default, matching Auth0 (a linked identity's own attributes otherwise stay under `identities[].profileData`).

--- a/packages/authhero/src/helpers/users.ts
+++ b/packages/authhero/src/helpers/users.ts
@@ -3,6 +3,7 @@ import { EnrichedClient } from "./client";
 import { Context } from "hono";
 import { Bindings, Variables } from "../types";
 import { userIdGenerate } from "../utils/user-id";
+import { isUsernamePasswordProvider } from "../utils/username-password-provider";
 
 export async function getUsersByEmail(
   userAdapter: UserDataAdapter,
@@ -178,6 +179,107 @@ export async function repointPrimary({
   await userAdapter.update(tenant_id, formerPrimary.user_id, {
     linked_to: newPrimaryId,
   });
+}
+
+/**
+ * True for identities whose *login identifier* is the email address: the native
+ * username-password providers (`auth0`/`auth2`) and the passwordless `email`
+ * connection. For these, `email` is a credential — it's how the login row is
+ * found (`getUserByProvider`), so it must stay consistent across a linked
+ * cluster.
+ *
+ * Social identities carry `email` as ordinary profile data (re-synced from the
+ * IdP on every login) and sms identities are keyed by `phone_number`, so neither
+ * is email-identified and neither should have its `email` rewritten by a cascade.
+ */
+export function isEmailIdentifiedUser(
+  user: Pick<User, "provider" | "connection">,
+): boolean {
+  if (isUsernamePasswordProvider(user.provider)) return true;
+  return user.provider === "email" || user.connection === "email";
+}
+
+interface CascadeEmailParams {
+  userAdapter: UserDataAdapter;
+  tenant_id: string;
+  /** The cluster root (primary) user_id — its secondaries are enumerated. */
+  primaryUserId: string;
+  /** The row whose email the caller already updated; skipped by the cascade. */
+  sourceUserId: string;
+  email: string;
+  email_verified: boolean;
+}
+
+/**
+ * Propagate an email change across every *email-identified* identity in a linked
+ * cluster so a merged user keeps a single login email.
+ *
+ * Because account-linking matches on a shared email, at link time every
+ * email-identified identity in a cluster carries the same address. The only way
+ * they diverge is a later email change on one of them — and when they diverge,
+ * the login row for the *other* email-identified identities still carries the
+ * old address, so the user can no longer sign in with the address now shown on
+ * their profile (the classic "changed my email, can't log in with my password"
+ * bug).
+ *
+ * This re-establishes the invariant: only email-identified rows are touched
+ * ({@link isEmailIdentifiedUser}); sms (`phone_number`) and social (provider
+ * sub) identifiers are never rewritten. `sourceUserId` is skipped (the caller
+ * already wrote it). Each cascaded write goes through the normal decorated
+ * `update`, so every affected identity emits its own `user.updated` event for
+ * downstream propagation, and `email_verified` moves in lock-step so the whole
+ * cluster shares one verification state.
+ */
+export async function cascadeEmailToLinkedIdentities({
+  userAdapter,
+  tenant_id,
+  primaryUserId,
+  sourceUserId,
+  email,
+  email_verified,
+}: CascadeEmailParams): Promise<void> {
+  const normalizedEmail = email.toLowerCase();
+
+  const applyTo = async (member: User) => {
+    if (member.user_id === sourceUserId) return;
+    if (!isEmailIdentifiedUser(member)) return;
+    // Skip no-op writes so we don't bump updated_at / emit a spurious event.
+    if (
+      member.email?.toLowerCase() === normalizedEmail &&
+      member.email_verified === email_verified
+    ) {
+      return;
+    }
+    await userAdapter.update(tenant_id, member.user_id, {
+      email: normalizedEmail,
+      email_verified,
+    });
+  };
+
+  // The cluster root, unless it's the row the caller already updated.
+  if (primaryUserId !== sourceUserId) {
+    const primary = await userAdapter.get(tenant_id, primaryUserId);
+    if (primary) await applyTo(primary);
+  }
+
+  // Every secondary of the primary. Paginate — a cluster can exceed one page,
+  // mirroring the loop in `repointPrimary`.
+  const pageSize = 100;
+  let page = 0;
+  while (true) {
+    const { users: secondaries } = await userAdapter.list(tenant_id, {
+      page,
+      per_page: pageSize,
+      include_totals: false,
+      q: `linked_to:${primaryUserId}`,
+    });
+    if (secondaries.length === 0) break;
+    for (const sec of secondaries) {
+      await applyTo(sec);
+    }
+    if (secondaries.length < pageSize) break;
+    page++;
+  }
 }
 
 interface GetPrimaryUserByProviderParams {

--- a/packages/authhero/src/hooks/pre-defined/account-linking.ts
+++ b/packages/authhero/src/hooks/pre-defined/account-linking.ts
@@ -48,6 +48,61 @@ export interface AccountLinkingOptions {
    * @default false
    */
   copyUserMetadata?: boolean;
+
+  /**
+   * When the link is performed, fill in *absent* root profile fields on the
+   * primary from the secondary — e.g. a secondary that has a `birthdate` the
+   * primary lacks, or a phone number an email primary doesn't carry.
+   *
+   * Fill-if-absent only: a field already set on the primary is never
+   * overwritten (primary stays authoritative), matching `copyUserMetadata`.
+   * Identifier and verification fields are never touched — `email`,
+   * `email_verified`, `phone_verified`, `username`, `provider`, `connection`
+   * are excluded — so this can't rewrite a login identifier. In particular an
+   * sms primary already carries a `phone_number`, so its identifier is never
+   * filled over; the promotion only reaches a primary that has no phone yet.
+   *
+   * Off by default to match Auth0, which keeps a linked identity's own
+   * attributes under `identities[].profileData` rather than promoting them to
+   * the merged user's root profile.
+   *
+   * @default false
+   */
+  copyProfileFields?: boolean;
+}
+
+/**
+ * Root profile fields that {@link AccountLinkingOptions.copyProfileFields} may
+ * fill in on the primary. Deliberately excludes every identifier/credential and
+ * verification field (`email`, `email_verified`, `phone_verified`, `username`,
+ * `provider`, `connection`, `linked_to`, metadata) so a profile promotion can
+ * never mutate how an identity logs in.
+ */
+const PROMOTABLE_PROFILE_FIELDS = [
+  "name",
+  "given_name",
+  "family_name",
+  "middle_name",
+  "nickname",
+  "preferred_username",
+  "picture",
+  "profile",
+  "website",
+  "gender",
+  "birthdate",
+  "zoneinfo",
+  "locale",
+  "phone_number",
+  "address",
+] as const;
+
+/**
+ * True when `value` is "absent" for promotion purposes — undefined, null, or an
+ * empty string. A field in this state on the primary may be filled from the
+ * secondary; any other value is authoritative and left untouched.
+ */
+function isAbsent(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
 }
 
 /**
@@ -105,6 +160,7 @@ export function accountLinking(
 ): OnExecutePostLogin & AccountLinkingHandler {
   const requireVerifiedEmail = options?.requireVerifiedEmail ?? true;
   const copyUserMetadata = options?.copyUserMetadata ?? false;
+  const copyProfileFields = options?.copyProfileFields ?? false;
 
   const handler = async (event: HookEvent) => {
     const { ctx, user } = event;
@@ -182,6 +238,30 @@ export function accountLinking(
             user_metadata: merged,
           });
         }
+      }
+    }
+
+    if (copyProfileFields) {
+      // Fill absent root profile fields on the primary from the secondary.
+      // Never overwrites a value already present on the primary, and only the
+      // allow-listed non-identifier fields are eligible, so this can't touch a
+      // login identifier (email/username) or a verification flag.
+      const primaryRecord = primaryUser as unknown as Record<string, unknown>;
+      const secondaryRecord = secondaryUser as unknown as Record<
+        string,
+        unknown
+      >;
+      const fills: Record<string, unknown> = {};
+      for (const field of PROMOTABLE_PROFILE_FIELDS) {
+        if (
+          isAbsent(primaryRecord[field]) &&
+          !isAbsent(secondaryRecord[field])
+        ) {
+          fills[field] = secondaryRecord[field];
+        }
+      }
+      if (Object.keys(fills).length > 0) {
+        await data.users.update(tenantId, primaryUser.user_id, fills);
       }
     }
   };

--- a/packages/authhero/src/routes/management-api/users.ts
+++ b/packages/authhero/src/routes/management-api/users.ts
@@ -1,7 +1,11 @@
 import { HTTPException } from "hono/http-exception";
 import { userIdGenerate, userIdParse } from "../../utils/user-id";
 import { Bindings, Variables } from "../../types";
-import { getUsersByEmail, getUserByProvider } from "../../helpers/users";
+import {
+  getUsersByEmail,
+  getUserByProvider,
+  cascadeEmailToLinkedIdentities,
+} from "../../helpers/users";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { querySchema } from "../../types/auth0/Query";
 import { parseSort } from "../../utils/sort";
@@ -557,6 +561,17 @@ const patchByUser_id = defineRoute({
               .extend({
                 verify_email: z.boolean(),
                 password: z.string(),
+                // PATCH is pass-through: a field the caller omits must stay
+                // untouched. `userInsertSchema` gives these create-time
+                // defaults (`email_verified: false`, metadata `{}`), and
+                // `.partial()` does NOT strip a `.default()` — so without
+                // overriding them here, omitting the field would silently reset
+                // `email_verified` to false (locking out enforced-verification
+                // clients after any edit) and wipe `app_metadata`/
+                // `user_metadata` on every update.
+                email_verified: z.boolean(),
+                app_metadata: z.any(),
+                user_metadata: z.any(),
               })
               .partial(),
           },
@@ -711,6 +726,25 @@ const patchByUser_id = defineRoute({
     }
 
     await ctx.env.data.users.update(tenantId, targetUserId, userFields);
+
+    // Keep a merged user's login email consistent: when the email of one
+    // email-identified identity changes, propagate it to the cluster's other
+    // email-identified identities (username-password / passwordless-email) so a
+    // linked password account isn't left logging in with the old address. sms
+    // and social identifiers are never rewritten. `user_id` is the cluster root
+    // (patching a secondary is rejected with 404 above). See
+    // cascadeEmailToLinkedIdentities.
+    if (userFields.email && userFields.email !== targetUser.email) {
+      await cascadeEmailToLinkedIdentities({
+        userAdapter: ctx.env.data.users,
+        tenant_id: tenantId,
+        primaryUserId: user_id,
+        sourceUserId: targetUserId,
+        email: userFields.email,
+        email_verified:
+          userFields.email_verified ?? targetUser.email_verified ?? false,
+      });
+    }
 
     if (password) {
       // When updating password with a connection specified, use that connection

--- a/packages/authhero/test/hooks/account-linking-profile-promotion.spec.ts
+++ b/packages/authhero/test/hooks/account-linking-profile-promotion.spec.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+import { accountLinking } from "../../src/hooks/pre-defined/account-linking";
+import type { AccountLinkingOptions } from "../../src/hooks/pre-defined/account-linking";
+
+/**
+ * Tests for the opt-in `copyProfileFields` promotion (issues #3/#4, Invariant
+ * 4). When enabled, linking fills *absent* root profile fields on the primary
+ * from the secondary — fill-if-absent, never overwrite, and never an identifier
+ * or verification field. Off by default (Auth0-faithful: a linked identity's
+ * own attributes stay under `identities[].profileData`).
+ *
+ * The `accountLinking` handler picks the OLDEST account as primary. Provider
+ * prefixes are chosen so the email identity sorts oldest by the user_id
+ * tie-break ("email" < "google-oauth2" < "sms"), making the email row the
+ * primary deterministically without fixture timestamps.
+ */
+describe("accountLinking copyProfileFields promotion", () => {
+  const tenantId = "tenantId";
+
+  function mockCtx(data: any): any {
+    return {
+      env: { data },
+      req: { method: "POST", url: "http://test", header: () => tenantId },
+      var: { tenant_id: tenantId, ip: "127.0.0.1" },
+      get: (key: string) => (key === "ip" ? "127.0.0.1" : undefined),
+    };
+  }
+
+  function invokeHook(ctx: any, user: any, options?: AccountLinkingOptions) {
+    const hook = accountLinking(options);
+    return hook(
+      {
+        ctx,
+        user,
+        tenant: { id: tenantId },
+        request: { ip: "127.0.0.1", url: "http://test" },
+      } as any,
+      {
+        prompt: { render: () => {} },
+        redirect: {
+          sendUserTo: () => {},
+          encodeToken: () => "",
+          validateToken: () => null,
+        },
+        token: { createServiceToken: async () => "" },
+      } as any,
+    );
+  }
+
+  async function makeEmailPrimary(
+    env: any,
+    extra: Record<string, unknown> = {},
+  ) {
+    await env.data.users.create(tenantId, {
+      user_id: "email|promo-primary",
+      email: "promo@example.com",
+      email_verified: true,
+      name: "Promo Primary",
+      provider: "email",
+      connection: "email",
+      is_social: false,
+      login_count: 0,
+      ...extra,
+    });
+    return env.data.users.get(tenantId, "email|promo-primary");
+  }
+
+  it("fills an absent birthdate on the primary from a linked social identity", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env);
+    await env.data.users.create(tenantId, {
+      user_id: "google-oauth2|promo-social",
+      email: "promo@example.com",
+      email_verified: true,
+      birthdate: "2000-05-05",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      login_count: 0,
+    });
+    const social = await env.data.users.get(
+      tenantId,
+      "google-oauth2|promo-social",
+    );
+
+    await invokeHook(mockCtx(env.data), social, { copyProfileFields: true });
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    expect(primary!.birthdate).toBe("2000-05-05");
+    // The link was established (secondary points at the primary).
+    const secondary = await env.data.users.get(
+      tenantId,
+      "google-oauth2|promo-social",
+    );
+    expect(secondary!.linked_to).toBe("email|promo-primary");
+  });
+
+  it("does NOT overwrite a birthdate already set on the primary", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env, { birthdate: "1990-01-01" });
+    await env.data.users.create(tenantId, {
+      user_id: "google-oauth2|promo-social",
+      email: "promo@example.com",
+      email_verified: true,
+      birthdate: "2000-05-05",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      login_count: 0,
+    });
+    const social = await env.data.users.get(
+      tenantId,
+      "google-oauth2|promo-social",
+    );
+
+    await invokeHook(mockCtx(env.data), social, { copyProfileFields: true });
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    expect(primary!.birthdate).toBe("1990-01-01");
+  });
+
+  it("does not promote anything when copyProfileFields is off (Auth0 default)", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env);
+    await env.data.users.create(tenantId, {
+      user_id: "google-oauth2|promo-social",
+      email: "promo@example.com",
+      email_verified: true,
+      birthdate: "2000-05-05",
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      login_count: 0,
+    });
+    const social = await env.data.users.get(
+      tenantId,
+      "google-oauth2|promo-social",
+    );
+
+    await invokeHook(mockCtx(env.data), social);
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    expect(primary!.birthdate).toBeUndefined();
+  });
+
+  it("promotes an sms secondary's phone to an email primary that has none, without touching the sms identifier", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env);
+    await env.data.users.create(tenantId, {
+      user_id: "sms|promo-sms",
+      email: "promo@example.com",
+      email_verified: true,
+      phone_number: "+46700000009",
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+      login_count: 0,
+    });
+    const sms = await env.data.users.get(tenantId, "sms|promo-sms");
+
+    await invokeHook(mockCtx(env.data), sms, { copyProfileFields: true });
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    const smsAfter = await env.data.users.get(tenantId, "sms|promo-sms");
+    // Primary gains the phone as profile data...
+    expect(primary!.phone_number).toBe("+46700000009");
+    // ...its email identifier is untouched...
+    expect(primary!.email).toBe("promo@example.com");
+    // ...and the sms row's identifier phone is never rewritten.
+    expect(smsAfter!.phone_number).toBe("+46700000009");
+  });
+
+  it("does NOT overwrite a phone the primary already carries", async () => {
+    const { env } = await getTestServer();
+    await makeEmailPrimary(env, { phone_number: "+46711111111" });
+    await env.data.users.create(tenantId, {
+      user_id: "sms|promo-sms",
+      email: "promo@example.com",
+      email_verified: true,
+      phone_number: "+46722222222",
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+      login_count: 0,
+    });
+    const sms = await env.data.users.get(tenantId, "sms|promo-sms");
+
+    await invokeHook(mockCtx(env.data), sms, { copyProfileFields: true });
+
+    const primary = await env.data.users.get(tenantId, "email|promo-primary");
+    expect(primary!.phone_number).toBe("+46711111111");
+  });
+});

--- a/packages/authhero/test/routes/management-api/user-email-cascade.spec.ts
+++ b/packages/authhero/test/routes/management-api/user-email-cascade.spec.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "vitest";
+import { testClient } from "hono/testing";
+import { getAdminToken } from "../../helpers/token";
+import { getTestServer } from "../../helpers/test-server";
+import { getUserByProvider } from "../../../src/helpers/users";
+
+/**
+ * Regression suite for issue #1 (Invariants 2 & 3): changing the email of one
+ * email-identified identity in a linked cluster must propagate to the other
+ * email-identified identities, so a linked password account isn't orphaned on
+ * its old address, and the whole cluster shares one verification state. sms and
+ * social identifiers are never rewritten.
+ *
+ * The seeded `email|userId` (foo@example.com, provider "email", verified) is the
+ * cluster primary; we attach secondaries via the raw adapter (bypassing hooks)
+ * and drive the change through the management PATCH.
+ */
+describe("management PATCH email cascade across linked identities", () => {
+  const tenantId = "tenantId";
+  const primaryId = "email|userId";
+
+  async function seedCluster(env: any) {
+    // Linked username-password identity — email IS its login identifier.
+    await env.data.users.create(tenantId, {
+      user_id: "auth2|pw-secondary",
+      email: "foo@example.com",
+      email_verified: true,
+      provider: "auth2",
+      connection: "Username-Password-Authentication",
+      is_social: false,
+      login_count: 0,
+      linked_to: primaryId,
+    });
+    // Linked sms identity — phone_number is its identifier; email is incidental.
+    await env.data.users.create(tenantId, {
+      user_id: "sms|sms-secondary",
+      phone_number: "+46700000001",
+      provider: "sms",
+      connection: "sms",
+      is_social: false,
+      login_count: 0,
+      linked_to: primaryId,
+    });
+    // Linked social identity — provider sub is the identifier; email is synced
+    // from the IdP on each login, so a cascade must not rewrite it.
+    await env.data.users.create(tenantId, {
+      user_id: "google-oauth2|social-secondary",
+      email: "foo@example.com",
+      email_verified: true,
+      provider: "google-oauth2",
+      connection: "google-oauth2",
+      is_social: true,
+      login_count: 0,
+      linked_to: primaryId,
+    });
+  }
+
+  function patchPrimaryEmail(
+    managementClient: any,
+    token: string,
+    json: Record<string, unknown>,
+  ) {
+    return managementClient.users[":user_id"].$patch(
+      {
+        param: { user_id: primaryId },
+        json,
+        header: { "tenant-id": tenantId },
+      },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+  }
+
+  it("propagates a primary email change to a linked password identity", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+    await seedCluster(env);
+
+    const res = await patchPrimaryEmail(managementClient, token, {
+      email: "new@example.com",
+    });
+    expect(res.status).toBe(200);
+
+    const primary = await env.data.users.get(tenantId, primaryId);
+    const pw = await env.data.users.get(tenantId, "auth2|pw-secondary");
+    expect(primary!.email).toBe("new@example.com");
+    // The linked password identity now carries the new address...
+    expect(pw!.email).toBe("new@example.com");
+    // ...and stays verified in lock-step with the primary (was verified).
+    expect(pw!.email_verified).toBe(true);
+
+    // The precise mechanism that fixes login: the password row is now findable
+    // by (new email, auth2), so getUserByProvider resolves it.
+    const found = await getUserByProvider({
+      userAdapter: env.data.users,
+      tenant_id: tenantId,
+      username: "new@example.com",
+      provider: "auth2",
+    });
+    expect(found?.user_id).toBe("auth2|pw-secondary");
+  });
+
+  it("never rewrites an sms identity's phone or a social identity's email", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+    await seedCluster(env);
+
+    const res = await patchPrimaryEmail(managementClient, token, {
+      email: "new@example.com",
+    });
+    expect(res.status).toBe(200);
+
+    const sms = await env.data.users.get(tenantId, "sms|sms-secondary");
+    const social = await env.data.users.get(
+      tenantId,
+      "google-oauth2|social-secondary",
+    );
+    // sms identifier untouched (and the cascade didn't stamp the new email
+    // onto it).
+    expect(sms!.phone_number).toBe("+46700000001");
+    expect(sms!.email).not.toBe("new@example.com");
+    // social email is IdP-owned — not rewritten by the cascade.
+    expect(social!.email).toBe("foo@example.com");
+  });
+
+  it("cascades a verification reset to email-identified identities", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+    await seedCluster(env);
+
+    // Admin changes the email AND marks it unverified (self-service-style
+    // re-verification): the flag moves in lock-step across the cluster.
+    const res = await patchPrimaryEmail(managementClient, token, {
+      email: "new@example.com",
+      email_verified: false,
+    });
+    expect(res.status).toBe(200);
+
+    const primary = await env.data.users.get(tenantId, primaryId);
+    const pw = await env.data.users.get(tenantId, "auth2|pw-secondary");
+    expect(primary!.email_verified).toBe(false);
+    expect(pw!.email).toBe("new@example.com");
+    expect(pw!.email_verified).toBe(false);
+  });
+
+  it("still rejects changing to an email owned by an unrelated user (409)", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+    const token = await getAdminToken();
+    await seedCluster(env);
+
+    // A separate, unlinked primary owns this address.
+    await env.data.users.create(tenantId, {
+      user_id: "email|other-cluster",
+      email: "taken@example.com",
+      email_verified: true,
+      provider: "email",
+      connection: "email",
+      is_social: false,
+      login_count: 0,
+    });
+
+    const res = await patchPrimaryEmail(managementClient, token, {
+      email: "taken@example.com",
+    });
+    expect(res.status).toBe(409);
+  });
+
+  // Issue #2: the management PATCH must be pass-through — omitting
+  // email_verified / metadata must not silently mutate them. (Regression for
+  // the zod `.default()` leaking through `.partial()`.)
+  describe("pass-through of omitted fields (issue #2)", () => {
+    it("does not flip email_verified when the field is omitted", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      // Seeded primary is verified. Change only the email.
+      const res = await patchPrimaryEmail(managementClient, token, {
+        email: "renamed@example.com",
+      });
+      expect(res.status).toBe(200);
+
+      const primary = await env.data.users.get(tenantId, primaryId);
+      expect(primary!.email).toBe("renamed@example.com");
+      expect(primary!.email_verified).toBe(true);
+    });
+
+    it("does not wipe metadata when it is omitted", async () => {
+      const { managementApp, env } = await getTestServer();
+      const managementClient = testClient(managementApp, env);
+      const token = await getAdminToken();
+
+      await env.data.users.update(tenantId, primaryId, {
+        user_metadata: { favourite_colour: "green" },
+        app_metadata: { plan: "pro" },
+      });
+
+      const res = await patchPrimaryEmail(managementClient, token, {
+        name: "New Name",
+      } as Record<string, unknown>);
+      expect(res.status).toBe(200);
+
+      const primary = await env.data.users.get(tenantId, primaryId);
+      expect(primary!.name).toBe("New Name");
+      expect(primary!.user_metadata).toEqual({ favourite_colour: "green" });
+      expect(primary!.app_metadata).toEqual({ plan: "pro" });
+    });
+  });
+});


### PR DESCRIPTION
Stacked on #1185. Fixes three ways a linked user's identity could silently drift or break, plus a latent PATCH bug found along the way. Follows a design discussion that established the guiding invariant: **a field that identifies an identity's login is never mutated as a side effect of linking or profile merge.**

## What & why

### 1. Email cascade — the "changed my email, can't log in with my password" bug
AuthHero stores each identity as its own row joined by `linked_to`, and the login identifier lives on that row (`email`+`provider` for password/passwordless-email). Changing the *primary's* email left a linked password identity authenticating with its **old** address, while the user now sees the new one → login fails.

Fix: `cascadeEmailToLinkedIdentities` propagates an email change to the cluster's other **email-identified** identities (username-password / passwordless-email). sms (`phone_number`) and social (provider sub) identifiers are **never** rewritten. `email_verified` moves in lock-step so the cluster shares one verification state. New helpers `cascadeEmailToLinkedIdentities` + `isEmailIdentifiedUser`.

### 2. PATCH pass-through — the "email flips to unverified" bug (+ metadata wipe)
The user PATCH body is `userInsertSchema.extend(...).partial()`, and `.partial()` does **not** strip a Zod `.default()`. So omitting `email_verified` silently wrote `false` (locking out `email_validation: "enforced"` clients after *any* edit), and omitting `app_metadata`/`user_metadata` wrote `{}`, **wiping** them. The PATCH schema now overrides those fields so omitted values are truly untouched (Auth0-style pass-through).

### 3/4. Opt-in profile promotion (birthdate, phone across email/sms)
Confirmed AuthHero already matches Auth0: linking does **not** promote a secondary's root profile (e.g. `birthdate`) to the primary — it stays under `identities[].profileData`. Added opt-in `copyProfileFields` on the `account-linking` template that fills **absent** root profile fields on the primary from the secondary (fill-if-absent, never overwrite, never an identifier/verification field — so an sms identity's phone is never rewritten). Off by default.

## Tests
- `test/routes/management-api/user-email-cascade.spec.ts` — cascade to password identity + `getUserByProvider` resolves the new address; sms/social identifiers untouched; verification reset cascades; unrelated-email 409 preserved; **pass-through regressions** (no verified-flip, no metadata-wipe on omit).
- `test/hooks/account-linking-profile-promotion.spec.ts` — birthdate fill-if-absent, no-overwrite, default-off; sms phone promoted to an email primary without touching the sms identifier.

Full `authhero` suite green (1934 passed). Changeset included (`minor`).

## Notes for review
- Cascade currently runs on the **management PATCH** path (where the bug was reported). A future self-service email-change flow should reuse the same helper (flip verified + send verification) — kept standalone for that reason.
- The `minor` bump covers the new `copyProfileFields` option + exported helpers and the pass-through behavior change; happy to split the pass-through fix into a separate `patch` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)