### PR TITLE
fix(keys): rotation preserves projected control-plane verify keys

### DIFF
--- a/.changeset/rotate-preserve-projected-cp-keys.md
+++ b/.changeset/rotate-preserve-projected-cp-keys.md
@@ -1,0 +1,10 @@
+---
+"authhero": patch
+---
+
+Signing-key rotation no longer revokes public-only control-plane keys. In a WFP
+tenant, the control plane's verify keys are projected with private material
+stripped (`pkcs7` null). Rotating in control-plane scope previously revoked
+those projected copies too, severing verification of control-plane admin tokens
+while the control plane kept signing with them. Rotation now only revokes keys
+the scope actually signs with (private material present).

--- a/packages/authhero/src/helpers/signing-keys.ts
+++ b/packages/authhero/src/helpers/signing-keys.ts
@@ -140,7 +140,7 @@ export async function resolveSigningKeys(
 }
 
 /** A key is signable only if it carries private material, not just a cert. */
-function isSignable(key: SigningKey): boolean {
+export function isSignable(key: SigningKey): boolean {
   return Boolean(key.pkcs7 && key.cert);
 }
 

--- a/packages/authhero/src/routes/management-api/keys.ts
+++ b/packages/authhero/src/routes/management-api/keys.ts
@@ -4,7 +4,7 @@ import { createX509Certificate } from "../../utils/encryption";
 import { HTTPException } from "hono/http-exception";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { signingKeySchema } from "@authhero/adapter-interfaces";
-import { resolveSigningKeyMode } from "../../helpers/signing-keys";
+import { isSignable, resolveSigningKeyMode } from "../../helpers/signing-keys";
 
 import { defineRoute } from "../../utils/define-route";
 const DAY = 1000 * 60 * 60 * 24;
@@ -175,6 +175,16 @@ const postSigningRotate = defineRoute({
         per_page: perPage,
       });
       for (const key of signingKeys) {
+        // Never revoke a public-only key: in control-plane scope a WFP tenant's
+        // keyset also holds the control plane's PUBLIC verify keys, projected
+        // with private material stripped (`pkcs7` null). Those are copies the
+        // tenant doesn't own and the real control plane is still signing with —
+        // revoking them here severs verification of control-plane admin tokens
+        // while the control plane keeps issuing them. Only rotate out keys this
+        // scope actually signs with (private material present).
+        if (!isSignable(key)) {
+          continue;
+        }
         await ctx.env.data.keys.update(key.kid, {
           revoked_at: new Date(Date.now() + DAY).toISOString(),
         });

--- a/packages/authhero/test/routes/management-api/keys.spec.ts
+++ b/packages/authhero/test/routes/management-api/keys.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { testClient } from "hono/testing";
 import { getAdminToken } from "../../helpers/token";
 import { getTestServer } from "../../helpers/test-server";
+import { createX509Certificate } from "../../../src/utils/encryption";
 
 describe("keys", () => {
   it("should rotate a key", async () => {
@@ -39,6 +40,52 @@ describe("keys", () => {
     expect(keysResponse.status).toBe(200);
     const keys = await keysResponse.json();
     expect(keys).toHaveLength(2);
+  });
+
+  it("rotate does not revoke public-only control-plane keys", async () => {
+    const { managementApp, env } = await getTestServer();
+    const managementClient = testClient(managementApp, env);
+
+    // Simulate a WFP tenant's projected control-plane verify key: a
+    // control-plane-scoped key (no tenant_id) with private material stripped
+    // (no pkcs7), exactly what `toPublicControlPlaneKey` writes.
+    const generated = await createX509Certificate({ name: "CN=control-plane" });
+    const projectedKid = generated.kid;
+    await env.data.keys.create({
+      kid: projectedKid,
+      cert: generated.cert,
+      fingerprint: generated.fingerprint,
+      thumbprint: generated.thumbprint,
+      type: "jwt_signing",
+      created_at: new Date().toISOString(),
+    });
+
+    // The signable key the seed created for this tenant (has pkcs7).
+    const before = await env.data.keys.list({ q: "type:jwt_signing" });
+    const signableBefore = before.signingKeys.find((k) => k.pkcs7 && k.cert);
+    expect(signableBefore).toBeDefined();
+
+    const token = await getAdminToken();
+    const rotateResponse = await managementClient.keys.signing.rotate.$post(
+      { header: { "tenant-id": "tenantId" } },
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(rotateResponse.status).toBe(201);
+
+    const after = await env.data.keys.list({ q: "type:jwt_signing" });
+
+    // The projected public key must be left untouched — the control plane is
+    // still signing with it, and the tenant doesn't own it.
+    const projectedAfter = after.signingKeys.find(
+      (k) => k.kid === projectedKid,
+    );
+    expect(projectedAfter?.revoked_at).toBeFalsy();
+
+    // The tenant's own signable key is rotated out (revoked).
+    const signableAfter = after.signingKeys.find(
+      (k) => k.kid === signableBefore!.kid,
+    );
+    expect(signableAfter?.revoked_at).toBeTruthy();
   });
 
   it("should reovke a key", async () => {


### PR DESCRIPTION
## Problem

In a WFP tenant, the control plane's signing keys are **projected** into the tenant DB as public verify keys — private material stripped (`pkcs7` null), stored control-plane-scoped (no `tenant_id`) so `listControlPlaneKeys` resolves them. This is what lets a control-plane admin token verify against a tenant's management API.

The signing-key **rotate** endpoint (`POST /api/v2/keys/signing/rotate`), in control-plane scope, revoked *every* control-plane-scoped key in the tenant DB — including those projected verify keys. Because it revokes with a 1-day grace and mints a new local signer, a rotate against a WFP tenant would:

1. Revoke the projected control-plane verify key locally, and
2. Mint a new local signable key as the tenant's signer.

But the real control plane never rotated — it keeps signing admin tokens with the now-"revoked" kid. Result: the tenant rejects control-plane admin tokens with **"No matching kid found"** (the key is present but filtered out by `nonRevoked`), while the control plane is still actively using it. Observed in dev for a WFP tenant whose projected control-plane `jwt_signing` key showed `revoked_at` ≈ its creation + 1 day.

## Fix

Skip public-only keys in the rotate loop — only revoke keys the scope actually signs with (private material present). Projected verify-only keys are copies the tenant doesn't own and the control plane is still signing with; retiring them is the control plane's job, not the tenant's.

- `keys.ts`: `if (!isSignable(key)) continue;` before revoking in the rotate loop.
- `signing-keys.ts`: export the existing `isSignable` predicate so rotate shares one definition with `resolveSigningKeys` (no second copy of "has private material").

Normal control-plane rotation is unaffected: the real control plane's own key carries private material, so it still rotates as before.

## Test

Added a case that seeds a projected public-only control-plane key (no `pkcs7`, no `tenant_id`) alongside the tenant's signable key, rotates, and asserts the projected key stays un-revoked while the signable key is rotated out.

## Notes

- This prevents *future* rotations from severing cross-tenant admin. Any tenant already in the broken state needs its wrongly-revoked projected key un-revoked in its own DB (`UPDATE keys SET revoked_at = NULL WHERE kid = '<cp-kid>'`); `sync-defaults` won't repair it (create-if-missing by kid, never clears `revoked_at`).
- The explicit single-kid revoke (`PUT /signing/{kid}/revoke`) is intentionally left unchanged — it's a deliberate targeted action, not the accidental bulk sweep.
- Follow-up worth considering: verify control-plane admin tokens against the control plane's authoritative JWKS rather than the tenant's mutable local copy, so a local rotate can't sever them at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated signing-key rotation to preserve public-only projected keys.
  * Rotation now revokes only keys containing private signing material.
  * Added coverage to verify that tenant signing keys are revoked while public-only keys remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->