### PR TITLE
feat(authhero): record login redirect_uri on authentication logs

### DIFF
--- a/.changeset/log-login-redirect-uri.md
+++ b/.changeset/log-login-redirect-uri.md
@@ -1,0 +1,13 @@
+---
+"@authhero/adapter-interfaces": patch
+"authhero": patch
+---
+
+Record the login target (`redirect_uri`) on authentication logs. The
+`SUCCESS_LOGIN` event now carries the RP `redirect_uri` on its request details
+(`details.request.redirect_uri` in flat logs, `request.redirect_uri` on the
+outbox audit event), so a login can be attributed to a specific destination
+even when several flows share one `client_id` — e.g. a browser SPA and a
+server-side OIDC plugin authorizing as the same client. `logMessage` gains an
+optional `redirect_uri` param and `requestContextSchema` gains an optional
+`redirect_uri` field.

--- a/packages/adapter-interfaces/src/types/AuditEvent.ts
+++ b/packages/adapter-interfaces/src/types/AuditEvent.ts
@@ -41,6 +41,8 @@ export const requestContextSchema = z.object({
   ip: z.string(),
   user_agent: z.string().optional(),
   correlation_id: z.string().optional(),
+  /** The RP `redirect_uri` this authorization is completing for, when known. */
+  redirect_uri: z.string().optional(),
 });
 
 export type RequestContext = z.infer<typeof requestContextSchema>;

--- a/packages/authhero/src/helpers/logging.ts
+++ b/packages/authhero/src/helpers/logging.ts
@@ -105,6 +105,14 @@ export type LogParams = {
   audience?: string;
   scope?: string;
   /**
+   * The login target — the RP's `redirect_uri` the authorization is completing
+   * for. Recorded on the request block so a `Successful Login` (or other auth
+   * event) can be attributed to a specific destination even when several flows
+   * share one `client_id` (e.g. a browser SPA and a server-side OIDC plugin
+   * both authorizing as the same client).
+   */
+  redirect_uri?: string;
+  /**
    * Response details to include in the log (for Management API operations)
    */
   response?: {
@@ -344,6 +352,7 @@ function buildAuditEvent(
       body: redactBody(params.body || ctx.var.body || undefined),
       ip: ctx.var.ip || "",
       user_agent: ctx.var.useragent || undefined,
+      ...(params.redirect_uri ? { redirect_uri: params.redirect_uri } : {}),
     },
 
     response: params.response
@@ -458,6 +467,9 @@ export async function logMessage(
           path: ctx.req.path,
           qs: ctx.req.queries(),
           body: redactBody(params.body || ctx.var.body || ""),
+          ...(params.redirect_uri
+            ? { redirect_uri: params.redirect_uri }
+            : {}),
         },
         ...(params.response && {
           response: params.response,

--- a/packages/authhero/src/hooks/post-user-login.ts
+++ b/packages/authhero/src/hooks/post-user-login.ts
@@ -558,6 +558,7 @@ export async function postUserLoginHook(
       connection,
       audience: params?.authParams?.audience,
       scope: params?.authParams?.scope,
+      redirect_uri: params?.authParams?.redirect_uri,
       ...(executionId ? { details: { execution_id: executionId } } : {}),
     });
   }

--- a/packages/authhero/test/hooks/post-user-login-execution-id.spec.ts
+++ b/packages/authhero/test/hooks/post-user-login-execution-id.spec.ts
@@ -207,4 +207,75 @@ describe("postUserLoginHook → SUCCESS_LOGIN log carries details.execution_id",
       | undefined;
     expect(details?.execution_id).toBeUndefined();
   });
+
+  it("records the login redirect_uri on the SUCCESS_LOGIN request details", async () => {
+    const server = await getTestServer();
+
+    const user: User = {
+      user_id: "auth2|redir-user",
+      email: "redir@example.com",
+      email_verified: true,
+      provider: "auth2",
+      connection: "Username-Password-Authentication",
+      is_social: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      last_ip: "",
+      last_login: "",
+      login_count: 0,
+    };
+    await server.env.data.users.create("tenantId", user);
+
+    const redirectUri = "https://account.example.com/subscriptions/app";
+
+    const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+    app.post("/run", async (ctx) => {
+      Object.assign(ctx.env, server.env);
+      ctx.set("tenant_id", "tenantId");
+      ctx.set("ip", "1.2.3.4");
+      ctx.set("useragent", "test");
+      ctx.set("client_id", "clientId");
+
+      // No code hook → the log keeps its auto-built request snapshot, so the
+      // redirect_uri we thread through authParams should land on it.
+      await postUserLoginHook(
+        ctx,
+        server.env.data,
+        "tenantId",
+        user,
+        undefined,
+        {
+          authParams: {
+            client_id: "clientId",
+            redirect_uri: redirectUri,
+            scope: "openid",
+            audience: "https://example.com",
+          },
+        } as any,
+      );
+      await flushBackgroundPromises(ctx);
+      return ctx.json({ ok: true });
+    });
+
+    const res = await app.request(
+      "/run",
+      { method: "POST", headers: { "tenant-id": "tenantId" } },
+      server.env,
+    );
+    expect(res.status).toBe(200);
+
+    const { logs } = await server.env.data.logs.list("tenantId", {
+      page: 0,
+      per_page: 100,
+      include_totals: true,
+    });
+    const successLogs = logs.filter(
+      (log) => log.type === LogTypes.SUCCESS_LOGIN,
+    );
+    expect(successLogs).toHaveLength(1);
+    const details = successLogs[0]?.details as
+      | { request?: { redirect_uri?: string } }
+      | undefined;
+    expect(details?.request?.redirect_uri).toBe(redirectUri);
+  });
 });


### PR DESCRIPTION
## What

The `SUCCESS_LOGIN` log now records the RP **`redirect_uri`** (the login's target destination) on its request context:
- flat logs → `details.request.redirect_uri`
- outbox audit event → `request.redirect_uri`

Implemented via a new optional `redirect_uri` param on `logMessage`, threaded into the request block of both logging paths, plus an optional `redirect_uri` field on `requestContextSchema`. `postUserLoginHook` passes `authParams.redirect_uri`.

## Why

Today a login is attributable to an application only via `client_id`/`client_name`. When multiple flows share a single client — e.g. a browser SPA and a server-side OIDC plugin both authorizing as the same `client_id` — you can't tell from a `Successful Login` which destination it was for. Capturing `redirect_uri` closes that gap. This came directly out of a support investigation where account-page logins and WordPress-OIDC logins shared one client and couldn't be told apart.

The field is additive and Auth0-shape-compatible (it lives inside the existing request details, no new top-level log column, no `type` change).

## Notes / limitations

- Known pre-existing gap (unchanged here): when a post-login **action** runs, the `SUCCESS_LOGIN` log's `details` is replaced with `{ execution_id }`, so `redirect_uri` won't appear in that case. Tenants without post-login actions (the common case) get it. Fixing the clobber is a separate change.

## Tests

- Added a case to `post-user-login-execution-id.spec.ts` asserting `details.request.redirect_uri` is populated from `authParams`. Full file (3 tests) passes; `authhero` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login logs and audit events now capture the optional authorization redirect URI, improving attribution of authentication activity to specific destinations, especially when multiple flows share one client ID.
  * Redirect URI details are consistently propagated through login events and related audit records when available.

* **Tests**
  * Added validation ensuring redirect URIs are correctly recorded in successful login event logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->