### PR TITLE
fix(authhero): exclude Storybook stories from the declaration build

### DIFF
--- a/.changeset/authhero-build-exclude-stories.md
+++ b/.changeset/authhero-build-exclude-stories.md
@@ -1,0 +1,10 @@
+---
+"authhero": patch
+---
+
+Exclude Storybook `*.stories.tsx` fixtures from the package declaration build
+(`tsconfig.types.json`). The stories were pulled into the shipped build via
+`include: ["src"]`, and a `Meta<typeof Component>` typing quirk (Storybook 10 +
+React 19) that only surfaces in CI's clean install was failing `pnpm build`.
+Stories are dev-only and never part of the bundle, so a dev-only typing
+artifact should not gate the release build.

--- a/packages/authhero/tsconfig.types.json
+++ b/packages/authhero/tsconfig.types.json
@@ -7,5 +7,18 @@
     "declarationMap": false,
     "sourceMap": false,
     "outDir": "./dist/types"
-  }
+  },
+  // Storybook `*.stories.tsx` fixtures are dev-only and never shipped in the
+  // bundle, but `include: ["src"]` (inherited from tsconfig.json) pulls them
+  // into this declaration build. Their `Meta<typeof Component>` inference trips
+  // a Storybook 10 + React 19 typing quirk that surfaces in CI's clean install
+  // and fails the package build. Exclude them here so a dev-only typing artifact
+  // can't gate the release build. NOTE: an explicit `exclude` replaces the
+  // TypeScript default, so node_modules/outDir are listed to keep them out.
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.stories.tsx",
+    "src/**/*.stories.ts"
+  ]
 }


### PR DESCRIPTION
## Problem

`node-test` (the `authhero` package build) is failing on **every** open PR — including ones that touch no `authhero` code — with TypeScript errors in `src/components/stories/*.stories.tsx` (`AccountForm`, `LoginForm`, `ImpersonateForm`):

```
error TS2322: Type 'FC<LoginFormProps>' is not assignable to type 'ComponentType<FC<LoginFormProps>>'
```

The "missing" props (`state`, `email`, `client`) actually exist on the components — it's a `Meta<typeof Component>` inference quirk (Storybook 10 + React 19 types) that only manifests in CI's clean, frozen-lockfile install. The identical build (`pnpm --filter authhero build`, and a cache-cleared `tsc -p tsconfig.types.json`) passes locally.

Root cause of why a dev-only fixture can break the release build: `tsconfig.json` has `include: ["src"]`, so `tsconfig.types.json` (which extends it) pulls the Storybook stories into the shipped **declaration** build.

## Fix

Exclude `*.stories.tsx` / `*.stories.ts` from `tsconfig.types.json`. Stories are dev-only Storybook fixtures — never part of the published bundle — so they shouldn't gate `pnpm build`. Storybook uses its own build config and is unaffected.

An explicit `exclude` replaces TypeScript's default, so `node_modules`/`dist` are listed to keep them excluded.

## Verified

- `tsc -p tsconfig.types.json --listFilesOnly`: stories now **0** files in scope; real sources (e.g. `LoginForm.tsx`) still present.
- Clean `tsc -p tsconfig.types.json`: exit 0, 0 errors.

## Alternative considered

Fixing the `Meta` typings directly — but the error doesn't reproduce locally (env-specific), so excluding the dev-only fixtures from the release build is the robust, verifiable fix. Note: this is a pre-existing break on `main` (main pushes don't run `node-test`), not introduced by any current PR.