### PR TITLE
ci: use repo pnpm (packageManager) instead of pinned pnpm 8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
+      # No version input — pnpm/action-setup v4+ reads the packageManager
+      # field from package.json. A pinned older pnpm (8) can't read the
+      # lockfileVersion 9 lockfile, silently ignores it, and fresh-resolves
+      # into whatever the registry serves (e.g. a broken upstream release).
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,10 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No version input — pnpm/action-setup v4+ reads the packageManager
+      # field from package.json. A pinned older pnpm (8) can't read the
+      # lockfileVersion 9 lockfile, silently ignores it, and fresh-resolves
+      # into whatever the registry serves (e.g. a broken upstream release).
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

`pnpm install` is failing in CI:
```
WARN Ignoring not compatible lockfile at .../pnpm-lock.yaml
ERR_PNPM_NO_MATCHING_VERSION No matching version found for @vue/compiler-sfc@3.5.41
  (installing vitepress@1.6.4 → vue@3.5.41; latest @vue/compiler-sfc is 3.5.40)
```

## Root cause

`unit-tests.yml` and `release.yml` pin **pnpm 8** (`pnpm/action-setup@v2` + `version: 8`), but the repo is on **`pnpm@10.20.0`** with a **`lockfileVersion: '9.0'`** lockfile. pnpm 8 can't read a v9 lockfile, so it prints *"Ignoring not compatible lockfile"* and **resolves dependencies fresh from the registry** instead of honouring the lockfile.

That fresh resolve is non-reproducible — it pulls whatever the registry currently serves. It worked by luck until today, when an unusable `vue@3.5.41` (its `@vue/compiler-sfc@3.5.41` was never published) landed upstream and got selected, breaking install for every workflow on this runner.

The lockfile itself is fine — it pins the working `vue@3.5.26` / `@vue/compiler-sfc@3.5.26`.

## Fix

Drop the `version` pin and bump to `pnpm/action-setup@v6`, so CI reads `packageManager` from `package.json` (pnpm 10), honours the v9 lockfile, and installs the pinned working versions. This matches `conformance.yml` and `deploy-docs.yml`, which already migrated. Also makes CI installs reproducible rather than registry-dependent.

Applied to both `unit-tests.yml` (gates every PR) and `release.yml` (same latent bug).

## Impact

This is the current blocker for `node-test` on all open PRs — install fails before build/test even run. With this merged, #1193 and #1192 (rebased on main, which already has the Storybook + refresh-token fixes from #1195) go green.