### PR TITLE
fix(org): consistent global admin:organizations bypass across grants and adapters

### DIFF
--- a/.changeset/global-org-admin-consistency.md
+++ b/.changeset/global-org-admin-consistency.md
@@ -1,11 +1,13 @@
 ---
 "authhero": patch
 "@authhero/drizzle": patch
+"@authhero/multi-tenancy": patch
 ---
 
-Make the global `admin:organizations` org-membership bypass consistent across grants and adapters (#1198).
+Make the global `admin:organizations` org-membership bypass consistent across grants and adapters, and close a related privilege-escalation on the Drizzle adapter (#1198).
 
 - **Parity across all three org gates.** The refresh-token grant, token-exchange grant, and `calculateScopesAndPermissions` now share one `userHasGlobalOrgAdminPermission` helper. Previously the scopes-permissions gate only checked *role-derived* global permissions, so a user granted `admin:organizations` **directly** (not via a role) passed the refresh-token gate but was still rejected with 403 once an `audience` was present. All three now honor both directly-assigned and role-derived global permissions, matched against the Management API audience.
-- **Drizzle `userRoles.list` scope fix.** `list(..., "")` (global / tenant-level roles) guarded on truthiness, so the empty-string scope fell through to "all scopes" and leaked org-scoped roles into global lookups. It now filters on `organization_id = ""`, matching the Kysely adapter and the documented contract (`undefined` = all scopes, `""` = global only, `"<id>"` = that org).
+- **Drizzle `userRoles.list` scope fix (privilege escalation).** `list(..., "")` (global / tenant-level roles) guarded on truthiness, so the empty-string scope fell through to "all scopes" and returned the user's roles across *every* organization. Consumers that read global roles this way — the `admin:organizations` bypass and the `globalRoles` bucket in `calculateScopesAndPermissions` — would therefore apply an **org-scoped** user's role permissions at the tenant level, letting an admin of a single organization mint a token carrying those permissions globally (e.g. listing every organization without any global grant). Only affected Drizzle (SQLite/D1) deployments; Kysely already scoped correctly. `list(..., "")` now filters `organization_id = ""`, matching Kysely and the documented contract (`undefined` = all scopes, `""` = global only, `"<id>"` = that org).
+- **Audience tightening in tenant provisioning.** `@authhero/multi-tenancy`'s global-admin check now requires `admin:organizations` to be granted on the Management API audience, so an identically named permission on an unrelated resource server can no longer masquerade as the global escape hatch.
 
 Note: this repairs the code paths, but a user must still actually hold `admin:organizations` on a global role/permission (and the tenant must enable `inherit_global_permissions_in_organizations`) to bypass org membership. A "tenant-admin"-style global role that lacks that specific permission is still rejected by design.

--- a/.changeset/global-org-admin-consistency.md
+++ b/.changeset/global-org-admin-consistency.md
@@ -1,0 +1,11 @@
+---
+"authhero": patch
+"@authhero/drizzle": patch
+---
+
+Make the global `admin:organizations` org-membership bypass consistent across grants and adapters (#1198).
+
+- **Parity across all three org gates.** The refresh-token grant, token-exchange grant, and `calculateScopesAndPermissions` now share one `userHasGlobalOrgAdminPermission` helper. Previously the scopes-permissions gate only checked *role-derived* global permissions, so a user granted `admin:organizations` **directly** (not via a role) passed the refresh-token gate but was still rejected with 403 once an `audience` was present. All three now honor both directly-assigned and role-derived global permissions, matched against the Management API audience.
+- **Drizzle `userRoles.list` scope fix.** `list(..., "")` (global / tenant-level roles) guarded on truthiness, so the empty-string scope fell through to "all scopes" and leaked org-scoped roles into global lookups. It now filters on `organization_id = ""`, matching the Kysely adapter and the documented contract (`undefined` = all scopes, `""` = global only, `"<id>"` = that org).
+
+Note: this repairs the code paths, but a user must still actually hold `admin:organizations` on a global role/permission (and the tenant must enable `inherit_global_permissions_in_organizations`) to bypass org membership. A "tenant-admin"-style global role that lacks that specific permission is still rejected by design.

--- a/packages/adapter-interfaces/src/adapters/UserRoles.ts
+++ b/packages/adapter-interfaces/src/adapters/UserRoles.ts
@@ -24,12 +24,25 @@ export interface ListRoleUsersResponse {
 }
 
 export interface UserRolesAdapter {
+  /**
+   * List the roles assigned to a user, returned as a flat array.
+   *
+   * `organizationId` selects the scope and adapters MUST honor it exactly:
+   *   - `undefined` — roles across every organization scope (no filter)
+   *   - `""`        — global / tenant-level roles only
+   *   - `"<id>"`    — that organization's roles only
+   *
+   * The empty-string case is load-bearing: callers pass `""` to read a user's
+   * global roles (e.g. the org-membership `admin:organizations` bypass), so an
+   * adapter that treats `""` as "all scopes" leaks org-scoped roles into global
+   * lookups (see #1198).
+   */
   list(
     tenantId: string,
     userId: string,
     params?: ListParams,
     organizationId?: string,
-  ): Promise<Role[]>; // return a flat list of roles
+  ): Promise<Role[]>;
   /**
    * List the distinct users assigned to a role, across all organization
    * scopes (a user holding the role in several organizations appears once).

--- a/packages/authhero/src/authentication-flows/refresh-token.ts
+++ b/packages/authhero/src/authentication-flows/refresh-token.ts
@@ -10,7 +10,6 @@ import { z } from "@hono/zod-openapi";
 import { safeCompare } from "../utils/safe-compare";
 import { appendLog } from "../utils/append-log";
 import { getEnrichedClient } from "../helpers/client";
-import { MANAGEMENT_API_AUDIENCE } from "../middlewares/authentication";
 import { ssrfFetchOptionsFromEnv } from "../utils/ssrf-fetch";
 import { logMessage } from "../helpers/logging";
 import {
@@ -22,6 +21,7 @@ import {
 } from "../utils/refresh-token-format";
 import { ulid } from "../utils/ulid";
 import { tryUpstreamRemint } from "./refresh-token-migration";
+import { userHasGlobalOrgAdminPermission } from "../helpers/scopes-permissions";
 
 export const refreshTokenParamsSchema = z.object({
   grant_type: z.literal("refresh_token"),
@@ -253,52 +253,16 @@ export async function refreshTokenGrant(
     // bypasses the membership check. This is a management-plane permission, so
     // it is always matched against the Management API audience — never against
     // the requested token's audience (which may be an app resource server).
+    // Shared with the scopes-permissions gate so both stay in parity (#1198).
     let hasGlobalOrgAdminPermission = false;
     const currentTenant = await ctx.env.data.tenants.get(client.tenant.id);
 
     if (currentTenant?.flags?.inherit_global_permissions_in_organizations) {
-      // Check direct user permissions at tenant level
-      const globalUserPermissions = await ctx.env.data.userPermissions.list(
+      hasGlobalOrgAdminPermission = await userHasGlobalOrgAdminPermission(
+        ctx,
         client.tenant.id,
         user.user_id,
-        undefined,
-        "", // Empty string for tenant-level (global) permissions
       );
-
-      hasGlobalOrgAdminPermission = globalUserPermissions.some(
-        (permission) =>
-          permission.permission_name === "admin:organizations" &&
-          permission.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
-      );
-
-      // Check role-derived permissions at tenant level
-      if (!hasGlobalOrgAdminPermission) {
-        const globalRoles = await ctx.env.data.userRoles.list(
-          client.tenant.id,
-          user.user_id,
-          undefined,
-          "", // Empty string for tenant-level (global) roles
-        );
-
-        for (const role of globalRoles) {
-          const rolePermissions = await ctx.env.data.rolePermissions.list(
-            client.tenant.id,
-            role.id,
-            { per_page: 1000 },
-          );
-
-          const hasAdminOrg = rolePermissions.some(
-            (permission) =>
-              permission.permission_name === "admin:organizations" &&
-              permission.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
-          );
-
-          if (hasAdminOrg) {
-            hasGlobalOrgAdminPermission = true;
-            break;
-          }
-        }
-      }
     }
 
     // Verify the user is a member of the organization (unless they have global admin permission)

--- a/packages/authhero/src/authentication-flows/token-exchange.ts
+++ b/packages/authhero/src/authentication-flows/token-exchange.ts
@@ -5,7 +5,7 @@ import { JSONHTTPException } from "../errors/json-http-exception";
 import { Bindings, Variables, GrantFlowUserResult } from "../types";
 import { safeCompare } from "../utils/safe-compare";
 import { getEnrichedClient } from "../helpers/client";
-import { MANAGEMENT_API_AUDIENCE } from "../middlewares/authentication";
+import { userHasGlobalOrgAdminPermission } from "../helpers/scopes-permissions";
 import { logMessage } from "../helpers/logging";
 import {
   JwtExpiredError,
@@ -253,45 +253,16 @@ export async function tokenExchangeGrant(
   // API (gated by tenant flag); otherwise require membership. This is a
   // management-plane permission, so it is matched against the Management API
   // audience, never the requested token's audience.
+  // Shared with the refresh-token and scopes-permissions gates so all three
+  // agree on what "global org admin" means (#1198).
   let hasGlobalOrgAdminPermission = false;
   const tenant = await ctx.env.data.tenants.get(client.tenant.id);
   if (tenant?.flags?.inherit_global_permissions_in_organizations) {
-    const globalUserPermissions = await ctx.env.data.userPermissions.list(
+    hasGlobalOrgAdminPermission = await userHasGlobalOrgAdminPermission(
+      ctx,
       client.tenant.id,
       user.user_id,
-      undefined,
-      "", // tenant-level (global) permissions
     );
-    hasGlobalOrgAdminPermission = globalUserPermissions.some(
-      (p) =>
-        p.permission_name === "admin:organizations" &&
-        p.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
-    );
-
-    if (!hasGlobalOrgAdminPermission) {
-      const globalRoles = await ctx.env.data.userRoles.list(
-        client.tenant.id,
-        user.user_id,
-        undefined,
-        "",
-      );
-      for (const role of globalRoles) {
-        const rolePermissions = await ctx.env.data.rolePermissions.list(
-          client.tenant.id,
-          role.id,
-          { per_page: 1000 },
-        );
-        const hasAdminOrg = rolePermissions.some(
-          (p) =>
-            p.permission_name === "admin:organizations" &&
-            p.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
-        );
-        if (hasAdminOrg) {
-          hasGlobalOrgAdminPermission = true;
-          break;
-        }
-      }
-    }
   }
 
   if (!hasGlobalOrgAdminPermission) {

--- a/packages/authhero/src/helpers/scopes-permissions.ts
+++ b/packages/authhero/src/helpers/scopes-permissions.ts
@@ -121,6 +121,71 @@ async function getTenantPermissionsForOrganization(
 }
 
 /**
+ * True when the user holds the global `admin:organizations` escape hatch — the
+ * single canonical key for "may act on any organization without being a
+ * member". It is a management-plane permission, so it is always matched against
+ * the Management API audience, never the requested token's audience.
+ *
+ * "Global" means an assignment with an empty organization scope (`""`). Both
+ * directly-assigned user permissions AND role-derived permissions count, so a
+ * user granted the permission either way is treated consistently (see #1198).
+ *
+ * The caller is responsible for gating on the
+ * `inherit_global_permissions_in_organizations` tenant flag; this helper only
+ * answers whether the permission is present.
+ */
+export async function userHasGlobalOrgAdminPermission(
+  ctx: Context<{ Bindings: Bindings; Variables: Variables }>,
+  tenantId: string,
+  userId: string,
+): Promise<boolean> {
+  // Directly-assigned global user permissions.
+  const globalUserPermissions = await ctx.env.data.userPermissions.list(
+    tenantId,
+    userId,
+    undefined,
+    "", // Empty string for tenant-level (global) permissions
+  );
+
+  const hasDirect = globalUserPermissions.some(
+    (permission) =>
+      permission.permission_name === "admin:organizations" &&
+      permission.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
+  );
+  if (hasDirect) {
+    return true;
+  }
+
+  // Role-derived global permissions.
+  const globalRoles = await ctx.env.data.userRoles.list(
+    tenantId,
+    userId,
+    undefined,
+    "", // Empty string for tenant-level (global) roles
+  );
+
+  for (const role of globalRoles) {
+    const rolePermissions = await ctx.env.data.rolePermissions.list(
+      tenantId,
+      role.id,
+      { per_page: 1000 },
+    );
+
+    const hasAdminOrg = rolePermissions.some(
+      (permission) =>
+        permission.permission_name === "admin:organizations" &&
+        permission.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
+    );
+
+    if (hasAdminOrg) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Calculates scopes and permissions for client_credentials grant type based on client grants.
  *
  * Auth0 behavior for client_credentials:
@@ -318,35 +383,13 @@ export async function calculateScopesAndPermissions(
 
   if (organizationId) {
     if (currentTenant?.flags?.inherit_global_permissions_in_organizations) {
-      // Check if user has admin:organizations permission at the global level
-      const globalRoles = await ctx.env.data.userRoles.list(
+      // Checks both directly-assigned and role-derived global permissions, so
+      // this gate stays in parity with the refresh-token grant's gate (#1198).
+      hasGlobalOrgAdminPermission = await userHasGlobalOrgAdminPermission(
+        ctx,
         tenantId,
         userId,
-        undefined,
-        "", // Empty string for tenant-level (global) roles
       );
-
-      // Get permissions from each global role
-      for (const role of globalRoles) {
-        const rolePermissions = await ctx.env.data.rolePermissions.list(
-          tenantId,
-          role.id,
-          { per_page: 1000 },
-        );
-
-        // admin:organizations is a management-plane permission: match it against
-        // the Management API audience, never the requested token's audience.
-        const hasAdminOrg = rolePermissions.some(
-          (permission) =>
-            permission.permission_name === "admin:organizations" &&
-            permission.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
-        );
-
-        if (hasAdminOrg) {
-          hasGlobalOrgAdminPermission = true;
-          break;
-        }
-      }
     }
 
     // Only check membership if user doesn't have global admin:organizations permission

--- a/packages/authhero/test/helpers/scopes-permissions.spec.ts
+++ b/packages/authhero/test/helpers/scopes-permissions.spec.ts
@@ -1244,6 +1244,91 @@ describe("scopes-permissions helper", () => {
         });
       });
 
+      it("should bypass membership when admin:organizations is assigned directly (not via a role)", async () => {
+        // Regression for #1198: the org-membership gate must honor a
+        // directly-assigned global admin:organizations user permission, in
+        // parity with the refresh-token grant's gate (which already did).
+        const { env } = await getTestServer();
+        const ctx = {
+          env,
+          var: {},
+        } as Context<{
+          Bindings: Bindings;
+          Variables: Variables;
+        }>;
+
+        const resourceServer = await env.data.resourceServers.create(
+          "tenantId",
+          {
+            name: "Test API for Direct Perm",
+            identifier: "https://direct-perm-api.example.com",
+            scopes: [{ value: "read:users", description: "Read users" }],
+            options: {
+              enforce_policies: true,
+              token_dialect: "access_token_authz",
+            },
+          },
+        );
+
+        // Organization the user is NOT a member of
+        const organization = await env.data.organizations.create("tenantId", {
+          name: "Direct Perm Target Org",
+          display_name: "Direct Perm Target",
+        });
+
+        // admin:organizations assigned DIRECTLY at the global level (no role),
+        // on the Management API audience.
+        await env.data.userPermissions.create(
+          "tenantId",
+          "directAdminUserId",
+          {
+            user_id: "directAdminUserId",
+            resource_server_identifier: "urn:authhero:management",
+            permission_name: "admin:organizations",
+          },
+          "", // Global (tenant-level) permission
+        );
+
+        // A held app permission so there is something to return in the token.
+        await env.data.userPermissions.create(
+          "tenantId",
+          "directAdminUserId",
+          {
+            user_id: "directAdminUserId",
+            resource_server_identifier: "https://direct-perm-api.example.com",
+            permission_name: "read:users",
+          },
+          organization.id,
+        );
+
+        await env.data.tenants.update("tenantId", {
+          flags: {
+            inherit_global_permissions_in_organizations: true,
+          },
+        });
+
+        // Membership is bypassed via the direct global permission.
+        const result = await calculateScopesAndPermissions(ctx, {
+          tenantId: "tenantId",
+          clientId: "test-client-id",
+          userId: "directAdminUserId",
+          audience: "https://direct-perm-api.example.com",
+          requestedScopes: ["read:users"],
+          organizationId: organization.id,
+        });
+
+        expect(result.permissions).toContain("read:users");
+
+        // Clean up
+        await env.data.resourceServers.remove("tenantId", resourceServer.id!);
+        await env.data.organizations.remove("tenantId", organization.id);
+        await env.data.tenants.update("tenantId", {
+          flags: {
+            inherit_global_permissions_in_organizations: false,
+          },
+        });
+      });
+
       it("should only grant permissions the user actually has at the global level", async () => {
         const { env } = await getTestServer();
         const ctx = {

--- a/packages/authhero/test/helpers/scopes-permissions.spec.ts
+++ b/packages/authhero/test/helpers/scopes-permissions.spec.ts
@@ -1522,6 +1522,106 @@ describe("scopes-permissions helper", () => {
       });
     });
 
+    describe("role scope isolation (#1198)", () => {
+      it("does not leak an org-scoped role's permissions into a no-org token", async () => {
+        // A user who holds a management permission only via an ORG-scoped role
+        // must not have it applied at the tenant level. Before #1198 the
+        // Drizzle adapter's list(..., "") returned roles across every scope, so
+        // an org-scoped admin's permissions leaked into their global (no-org)
+        // token — letting them e.g. list every organization/vendor without any
+        // global grant. Kysely always scoped correctly; this locks the contract
+        // at the token-building layer.
+        const { env } = await getTestServer();
+        const ctx = {
+          env,
+          var: {},
+        } as Context<{
+          Bindings: Bindings;
+          Variables: Variables;
+        }>;
+
+        const resourceServer = await env.data.resourceServers.create(
+          "tenantId",
+          {
+            name: "Scope Isolation API",
+            identifier: "https://scope-isolation-api.example.com",
+            scopes: [{ value: "read:organizations", description: "Read orgs" }],
+            options: {
+              enforce_policies: true,
+              token_dialect: "access_token_authz",
+            },
+          },
+        );
+
+        const organization = await env.data.organizations.create("tenantId", {
+          name: "Scope Isolation Org",
+          display_name: "Scope Isolation Org",
+        });
+
+        await env.data.users.create("tenantId", {
+          user_id: "email|org-scoped-user",
+          email: "org-scoped@example.com",
+          provider: "email",
+          connection: "email",
+          email_verified: true,
+          is_social: false,
+          name: "Org Scoped User",
+        });
+
+        // read:organizations granted ONLY via an org-scoped role.
+        const orgRole = await env.data.roles.create("tenantId", {
+          name: "Org-scoped Reader",
+          description: "Reads orgs within one org scope",
+        });
+        await env.data.rolePermissions.assign("tenantId", orgRole.id, [
+          {
+            role_id: orgRole.id,
+            resource_server_identifier:
+              "https://scope-isolation-api.example.com",
+            permission_name: "read:organizations",
+          },
+        ]);
+        await env.data.userRoles.create(
+          "tenantId",
+          "email|org-scoped-user",
+          orgRole.id,
+          organization.id, // org-scoped, NOT global
+        );
+        // Member of that org (so the in-org sanity check passes the membership
+        // gate); still holds no global grant.
+        await env.data.userOrganizations.create("tenantId", {
+          user_id: "email|org-scoped-user",
+          organization_id: organization.id,
+        });
+
+        // No-org token: the org-scoped permission must NOT appear.
+        const noOrg = await calculateScopesAndPermissions(ctx, {
+          tenantId: "tenantId",
+          clientId: "test-client-id",
+          userId: "email|org-scoped-user",
+          audience: "https://scope-isolation-api.example.com",
+          requestedScopes: ["read:organizations"],
+        });
+        expect(noOrg.permissions).not.toContain("read:organizations");
+
+        // Sanity: within its own org scope the permission IS granted.
+        const inOrg = await calculateScopesAndPermissions(ctx, {
+          tenantId: "tenantId",
+          clientId: "test-client-id",
+          userId: "email|org-scoped-user",
+          audience: "https://scope-isolation-api.example.com",
+          requestedScopes: ["read:organizations"],
+          organizationId: organization.id,
+        });
+        expect(inOrg.permissions).toContain("read:organizations");
+
+        // Clean up
+        await env.data.resourceServers.remove("tenantId", resourceServer.id!);
+        await env.data.organizations.remove("tenantId", organization.id);
+        await env.data.roles.remove("tenantId", orgRole.id);
+      });
+    });
+
     describe("client_credentials grant", () => {
       it("should throw 403 when requesting unauthorized scopes", async () => {
         const { env } = await getTestServer();

--- a/packages/drizzle/src/adapters/userRoles.ts
+++ b/packages/drizzle/src/adapters/userRoles.ts
@@ -55,7 +55,14 @@ export function createUserRolesAdapter(db: DrizzleDb) {
         eq(userRoles.user_id, user_id),
       ];
 
-      if (organization_id) {
+      // organization_id semantics (must match the Kysely adapter):
+      //   undefined -> roles across every organization scope (no filter)
+      //   ""        -> global / tenant-level roles only
+      //   "<id>"    -> that organization's roles only
+      // Guarding on truthiness instead of `!== undefined` would make ""
+      // (global) fall through to "all scopes", leaking org-scoped roles into
+      // global lookups (see #1198).
+      if (organization_id !== undefined) {
         conditions.push(eq(userRoles.organization_id, organization_id));
       }
 

--- a/packages/drizzle/test/adapters/user-roles-list-scope.test.ts
+++ b/packages/drizzle/test/adapters/user-roles-list-scope.test.ts
@@ -64,4 +64,23 @@ describe("userRoles.list organization scope semantics", () => {
     expect(ids).toContain(globalRoleId);
     expect(ids).toContain(orgRoleId);
   });
+
+  it('does not leak an org-only user\'s roles into the "" global bucket', async () => {
+    // The privilege-escalation shape behind #1198: consumers read a user's
+    // GLOBAL roles via list(..., "") and treat their permissions as tenant-wide
+    // (e.g. the "globalRoles" source in calculateScopesAndPermissions, and the
+    // admin:organizations bypass). A user who only holds org-scoped roles must
+    // yield an EMPTY global bucket, otherwise an org-scoped admin's permissions
+    // would be applied at the tenant level and leak into a no-org token.
+    const orgOnlyUser = "user-org-only";
+    await data.userRoles.create(tenantId, orgOnlyUser, orgRoleId, "org-a");
+
+    const globalRoles = await data.userRoles.list(
+      tenantId,
+      orgOnlyUser,
+      undefined,
+      "",
+    );
+    expect(globalRoles).toHaveLength(0);
+  });
 });

--- a/packages/drizzle/test/adapters/user-roles-list-scope.test.ts
+++ b/packages/drizzle/test/adapters/user-roles-list-scope.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestServer } from "../helpers/test-server";
+
+// Regression for #1198: userRoles.list must honor the organization scope
+// exactly like the Kysely adapter.
+//   undefined -> roles across every organization scope
+//   ""        -> global / tenant-level roles only
+//   "<id>"    -> that organization's roles only
+// Guarding on truthiness instead of `!== undefined` used to make "" (global)
+// fall through to "all scopes", leaking org-scoped roles into global lookups.
+describe("userRoles.list organization scope semantics", () => {
+  let data: ReturnType<typeof getTestServer>["data"];
+  const tenantId = "t1";
+  const userId = "user-1";
+  let globalRoleId: string;
+  let orgRoleId: string;
+
+  beforeEach(async () => {
+    const server = getTestServer();
+    data = server.data;
+
+    await data.tenants.create({ id: tenantId, name: "Tenant 1" });
+
+    const globalRole = await data.roles.create(tenantId, {
+      name: "global-role",
+      description: "Assigned globally",
+    });
+    globalRoleId = globalRole.id;
+
+    const orgRole = await data.roles.create(tenantId, {
+      name: "org-role",
+      description: "Assigned in org-a",
+    });
+    orgRoleId = orgRole.id;
+
+    // Global assignment (organization_id = "").
+    await data.userRoles.create(tenantId, userId, globalRoleId, "");
+    // Org-scoped assignment.
+    await data.userRoles.create(tenantId, userId, orgRoleId, "org-a");
+  });
+
+  it('returns only global roles for organization_id ""', async () => {
+    const roles = await data.userRoles.list(tenantId, userId, undefined, "");
+    const ids = roles.map((r) => r.id);
+    expect(ids).toContain(globalRoleId);
+    expect(ids).not.toContain(orgRoleId);
+  });
+
+  it("returns only that organization's roles for a concrete id", async () => {
+    const roles = await data.userRoles.list(
+      tenantId,
+      userId,
+      undefined,
+      "org-a",
+    );
+    const ids = roles.map((r) => r.id);
+    expect(ids).toContain(orgRoleId);
+    expect(ids).not.toContain(globalRoleId);
+  });
+
+  it("returns roles across every scope for undefined organization_id", async () => {
+    const roles = await data.userRoles.list(tenantId, userId);
+    const ids = roles.map((r) => r.id);
+    expect(ids).toContain(globalRoleId);
+    expect(ids).toContain(orgRoleId);
+  });
+});

--- a/packages/multi-tenancy/src/hooks/provisioning.ts
+++ b/packages/multi-tenancy/src/hooks/provisioning.ts
@@ -276,8 +276,14 @@ async function userHasGlobalOrgAdminPermission(
       { per_page: 1000 },
     );
 
+    // admin:organizations is a management-plane permission, so it only counts
+    // when granted on the Management API audience — otherwise an identically
+    // named permission on an unrelated resource server would masquerade as the
+    // global escape hatch (#1198).
     const hasAdminOrg = rolePermissions.some(
-      (permission) => permission.permission_name === "admin:organizations",
+      (permission) =>
+        permission.permission_name === "admin:organizations" &&
+        permission.resource_server_identifier === MANAGEMENT_API_AUDIENCE,
     );
 
     if (hasAdminOrg) {

--- a/packages/multi-tenancy/test/provisioning.test.ts
+++ b/packages/multi-tenancy/test/provisioning.test.ts
@@ -597,6 +597,7 @@ describe("Tenant Provisioning with admin:organizations permission", () => {
 
   const TEST_ISSUER = "https://auth.example.com/";
   const GLOBAL_ADMIN_USER_ID = "auth0|global-admin";
+  let globalAdminRoleId: string;
 
   beforeEach(async () => {
     db = await createMigratedDb();
@@ -642,6 +643,7 @@ describe("Tenant Provisioning with admin:organizations permission", () => {
       name: "Global Admin",
       description: "Can admin all organizations without membership",
     });
+    globalAdminRoleId = globalAdminRole.id;
 
     // Assign admin:organizations permission to the role
     await adapters.rolePermissions.assign("control_plane", globalAdminRole.id, [
@@ -739,6 +741,61 @@ describe("Tenant Provisioning with admin:organizations permission", () => {
       (uo) => uo.user_id === GLOBAL_ADMIN_USER_ID,
     );
     expect(adminOrgMembership).toBeUndefined();
+  });
+
+  it("does not treat admin:organizations on a non-management audience as the global escape hatch", async () => {
+    // #1198: the bypass is a management-plane permission, so admin:organizations
+    // granted on some OTHER resource server must NOT count. Re-scope the role's
+    // permission to a non-management audience; the user should then be treated
+    // as a normal creator and added to the new org.
+    await adapters.rolePermissions.remove("control_plane", globalAdminRoleId, [
+      {
+        resource_server_identifier: "urn:authhero:management",
+        permission_name: "admin:organizations",
+      },
+    ]);
+    await adapters.rolePermissions.assign("control_plane", globalAdminRoleId, [
+      {
+        role_id: globalAdminRoleId,
+        resource_server_identifier: "https://some-other-api.example.com",
+        permission_name: "admin:organizations",
+      },
+    ]);
+
+    const response = await app.request(
+      "/management/tenants",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          id: "non-mgmt-audience-tenant",
+          friendly_name: "Non Mgmt Audience Tenant",
+          audience: "https://non-mgmt-audience.example.com",
+          sender_email: "support@non-mgmt.com",
+          sender_name: "Non Mgmt",
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(201);
+
+    const orgs = await adapters.organizations.list("control_plane");
+    const newTenantOrg = orgs.organizations.find(
+      (org) => org.name === "non-mgmt-audience-tenant",
+    );
+    expect(newTenantOrg).toBeDefined();
+
+    // No genuine global escape hatch -> creator IS added to the organization.
+    const userOrgs = await adapters.userOrganizations.list("control_plane", {
+      q: `organization_id:${newTenantOrg!.id}`,
+    });
+    const adminOrgMembership = userOrgs.userOrganizations.find(
+      (uo) => uo.user_id === GLOBAL_ADMIN_USER_ID,
+    );
+    expect(adminOrgMembership).toBeDefined();
   });
 
   it("should not assign organization-specific role to user with admin:organizations", async () => {


### PR DESCRIPTION
Fixes #1198.

## Problem

The org-membership bypass keyed on the global `admin:organizations` permission was implemented inconsistently, so a user who is effectively a global org admin could still get a **403** on `grant_type=refresh_token` with an `organization` param. Two distinct gaps:

1. **Gate parity.** `calculateScopesAndPermissions` (the second gate, hit when an `audience` is present) only checked *role-derived* global permissions, whereas the refresh-token and token-exchange gates checked **both** direct and role-derived. A user granted `admin:organizations` **directly** (not via a role) therefore passed gate 1 but 403'd at gate 2.
2. **Drizzle scope leak.** `userRoles.list(..., "")` guarded the org filter on truthiness, so the global scope (`""`) fell through to "all scopes" and leaked org-scoped roles into global lookups (the opposite of Kysely).

## Changes

- Extract a single `userHasGlobalOrgAdminPermission(ctx, tenantId, userId)` helper in `scopes-permissions.ts` (checks both directly-assigned and role-derived global `admin:organizations` @ `urn:authhero:management`) and call it from all three org gates: refresh-token grant, token-exchange grant, and `calculateScopesAndPermissions`. Collapses three near-identical copies into one so they can't drift again.
- Fix Drizzle `userRoles.list(..., "")` to filter `organization_id = ""`, matching Kysely, and document the `undefined` / `""` / `"<id>"` scope contract on the `UserRolesAdapter` interface.
- Tests: new Drizzle scope test (global/org/all cases) + a gap-1 direct-permission test in the scopes-permissions spec.
- Changeset (`authhero` + `@authhero/drizzle`, patch).

## Not included (data-side)

This repairs the code paths but does **not** grant anyone new access: a user must still actually hold `admin:organizations` on a global role/permission (with the tenant's `inherit_global_permissions_in_organizations` flag enabled) to bypass membership. A "tenant-admin"-style global role that lacks that specific permission is still rejected by design — repairing drifted control-plane roles that are missing the permission is a separate data task.

## Verification

- Drizzle full suite: 97 passed
- authhero: scopes-permissions (32), token (66), token-exchange + refresh-token-rotation (18) — all pass
- `tsc --noEmit` clean on `authhero` and `@authhero/drizzle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Global organization-admin permissions now work consistently across grants, scopes, token refresh, and organization switching.
  * Users with the required global permission can bypass organization membership checks where appropriate.
  * Organization-scoped role lookups now correctly distinguish global, specific-organization, and all-scope results.

* **Documentation**
  * Clarified how organization scope affects role listings.

* **Tests**
  * Added coverage for direct global permissions and organization role filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->